### PR TITLE
Fix Android timer jumping due to NTP clock sync

### DIFF
--- a/client/src/components/TimerBar.tsx
+++ b/client/src/components/TimerBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Game } from 'models';
 
 interface TimerBarProps {
@@ -7,6 +7,9 @@ interface TimerBarProps {
 
 export const TimerBar = ({ game }: TimerBarProps) => {
   const [remainingPercentage, setRemainingPercentage] = useState(100);
+  // Record local client time when the bar first mounts for this game, to avoid
+  // clock-skew issues on Android browsers where device clocks run ahead of the server.
+  const localStartRef = useRef<number>(Date.now());
 
   useEffect(() => {
     if (game.config.durationSeconds <= 0) {
@@ -14,8 +17,10 @@ export const TimerBar = ({ game }: TimerBarProps) => {
       return;
     }
 
+    const localStart = localStartRef.current;
+
     const updateTimerBar = () => {
-      const elapsed = Date.now() - game.startedAt;
+      const elapsed = Date.now() - localStart;
       const totalDuration = game.config.durationSeconds * 1000;
       const remaining = Math.max(0, totalDuration - elapsed);
       const percentage = (remaining / totalDuration) * 100;
@@ -29,7 +34,7 @@ export const TimerBar = ({ game }: TimerBarProps) => {
     const interval = setInterval(updateTimerBar, 100);
 
     return () => clearInterval(interval);
-  }, [game.startedAt, game.config.durationSeconds]);
+  }, [game.config.durationSeconds]);
 
   const isUnlimited = game.config.durationSeconds <= 0;
 

--- a/client/src/components/TimerBar.tsx
+++ b/client/src/components/TimerBar.tsx
@@ -9,7 +9,8 @@ export const TimerBar = ({ game }: TimerBarProps) => {
   const [remainingPercentage, setRemainingPercentage] = useState(100);
   // Record local client time when the bar first mounts for this game, to avoid
   // clock-skew issues on Android browsers where device clocks run ahead of the server.
-  const localStartRef = useRef<number>(Date.now());
+  // Use performance.now() (monotonic) to prevent NTP sync jumps from affecting the bar.
+  const localStartRef = useRef<number>(performance.now());
 
   useEffect(() => {
     if (game.config.durationSeconds <= 0) {
@@ -20,7 +21,7 @@ export const TimerBar = ({ game }: TimerBarProps) => {
     const localStart = localStartRef.current;
 
     const updateTimerBar = () => {
-      const elapsed = Date.now() - localStart;
+      const elapsed = performance.now() - localStart;
       const totalDuration = game.config.durationSeconds * 1000;
       const remaining = Math.max(0, totalDuration - elapsed);
       const percentage = (remaining / totalDuration) * 100;

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Game, GameState } from 'models';
 
 export const useTimer = (game: Game | null, onTimeExpired: () => void) => {
   const [timeRemaining, setTimeRemaining] = useState(0);
+  // Track the local client timestamp when the game was first seen as InProgress.
+  // Using the server's startedAt directly causes the timer to run fast on devices
+  // (e.g. Android browsers) whose clocks are ahead of the server clock.
+  const localStartRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (game && game.status === GameState.InProgress) {
@@ -12,24 +16,32 @@ export const useTimer = (game: Game | null, onTimeExpired: () => void) => {
         return;
       }
 
+      // Record a client-local start time the first time we see this game in progress.
+      if (localStartRef.current === null) {
+        localStartRef.current = Date.now();
+      }
+      const localStart = localStartRef.current;
+
       // Set initial value immediately to avoid stale flash
-      const elapsed = Date.now() - game.startedAt;
+      const elapsed = Date.now() - localStart;
       const initialRemaining = Math.max(0, game.config.durationSeconds * 1000 - elapsed);
       setTimeRemaining(Math.ceil(initialRemaining / 1000));
 
       const interval = setInterval(() => {
-        const elapsed = Date.now() - game.startedAt;
+        const elapsed = Date.now() - localStart;
         const remaining = Math.max(0, game.config.durationSeconds * 1000 - elapsed);
         setTimeRemaining(Math.ceil(remaining / 1000));
-        
+
         if (remaining === 0) {
           clearInterval(interval);
           onTimeExpired();
         }
       }, 100);
-      
+
       return () => clearInterval(interval);
     } else {
+      // Reset local start when game is not in progress
+      localStartRef.current = null;
       setTimeRemaining(0);
     }
   }, [game, onTimeExpired]);

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -17,18 +17,21 @@ export const useTimer = (game: Game | null, onTimeExpired: () => void) => {
       }
 
       // Record a client-local start time the first time we see this game in progress.
+      // Use performance.now() (monotonic clock) instead of Date.now() to avoid jumps
+      // caused by NTP clock synchronization on Android, which would make elapsed time
+      // spike and the timer display less time remaining than it should.
       if (localStartRef.current === null) {
-        localStartRef.current = Date.now();
+        localStartRef.current = performance.now();
       }
       const localStart = localStartRef.current;
 
       // Set initial value immediately to avoid stale flash
-      const elapsed = Date.now() - localStart;
+      const elapsed = performance.now() - localStart;
       const initialRemaining = Math.max(0, game.config.durationSeconds * 1000 - elapsed);
       setTimeRemaining(Math.ceil(initialRemaining / 1000));
 
       const interval = setInterval(() => {
-        const elapsed = Date.now() - localStart;
+        const elapsed = performance.now() - localStart;
         const remaining = Math.max(0, game.config.durationSeconds * 1000 - elapsed);
         setTimeRemaining(Math.ceil(remaining / 1000));
 


### PR DESCRIPTION
## Summary

- The previous fix switched from `game.startedAt` to a local client timestamp, which addressed server/client clock skew. However, it still used `Date.now()`, a wall-clock value that can **jump** when the Android system clock is adjusted by NTP mid-game.
- A forward NTP correction causes `Date.now()` to spike, making elapsed time appear larger — so the timer shows less remaining time than there actually is.
- Fix: replace `Date.now()` with `performance.now()` in both `useTimer` and `TimerBar`. `performance.now()` is a **monotonic clock** — it advances at a steady rate and is never affected by system clock adjustments.

## Files changed

- `client/src/hooks/useTimer.ts` — use `performance.now()` for elapsed time
- `client/src/components/TimerBar.tsx` — use `performance.now()` for elapsed time

## Test plan

- [ ] Start a game on Android Chrome and verify the timer counts down at the correct rate
- [ ] Verify timer bar and time display stay in sync
- [ ] Verify unlimited games (durationSeconds <= 0) still work correctly
- [ ] Verify timer ends the game at the right time

🤖 Generated with [Claude Code](https://claude.com/claude-code)