### PR TITLE
Fix Android timer bug - use performance.now() instead of Date.now()

### DIFF
--- a/client/src/components/TimerBar.tsx
+++ b/client/src/components/TimerBar.tsx
@@ -9,7 +9,8 @@ export const TimerBar = ({ game }: TimerBarProps) => {
   const [remainingPercentage, setRemainingPercentage] = useState(100);
   // Record local client time when the bar first mounts for this game, to avoid
   // clock-skew issues on Android browsers where device clocks run ahead of the server.
-  const localStartRef = useRef<number>(Date.now());
+  // Use performance.now() (monotonic) to prevent NTP sync jumps from affecting the bar.
+  const localStartRef = useRef<number>(performance.now());
 
   useEffect(() => {
     if (game.config.durationSeconds <= 0) {
@@ -20,7 +21,7 @@ export const TimerBar = ({ game }: TimerBarProps) => {
     const localStart = localStartRef.current;
 
     const updateTimerBar = () => {
-      const elapsed = Date.now() - localStart;
+      const elapsed = performance.now() - localStart;
       const totalDuration = game.config.durationSeconds * 1000;
       const remaining = Math.max(0, totalDuration - elapsed);
       const percentage = (remaining / totalDuration) * 100;

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -17,18 +17,21 @@ export const useTimer = (game: Game | null, onTimeExpired: () => void) => {
       }
 
       // Record a client-local start time the first time we see this game in progress.
+      // Use performance.now() (monotonic clock) instead of Date.now() to avoid jumps
+      // caused by NTP clock synchronization on Android, which would make elapsed time
+      // spike and the timer display less time remaining than it should.
       if (localStartRef.current === null) {
-        localStartRef.current = Date.now();
+        localStartRef.current = performance.now();
       }
       const localStart = localStartRef.current;
 
       // Set initial value immediately to avoid stale flash
-      const elapsed = Date.now() - localStart;
+      const elapsed = performance.now() - localStart;
       const initialRemaining = Math.max(0, game.config.durationSeconds * 1000 - elapsed);
       setTimeRemaining(Math.ceil(initialRemaining / 1000));
 
       const interval = setInterval(() => {
-        const elapsed = Date.now() - localStart;
+        const elapsed = performance.now() - localStart;
         const remaining = Math.max(0, game.config.durationSeconds * 1000 - elapsed);
         setTimeRemaining(Math.ceil(remaining / 1000));
 


### PR DESCRIPTION
## Problem

On Android browsers, the game timer displayed less time than was actually remaining. This happened because Android devices often have their clocks synced via NTP mid-game, causing `Date.now()` to jump forward suddenly. This made the elapsed time calculation spike, showing an artificially low time remaining.

## Fix

Switch from `Date.now()` to `performance.now()` in `useTimer.ts`. `performance.now()` uses a monotonic clock that is not affected by NTP adjustments or system clock changes, so elapsed time is always measured accurately relative to when the game started on the client.