### PR TITLE
Fix Qu share bug and path bounds crash

### DIFF
--- a/client/src/utils/boardCode.ts
+++ b/client/src/utils/boardCode.ts
@@ -26,11 +26,12 @@ export function encodeBoard(data: SharedBoard): string {
   const configVal = sizeIdx * 9 + timeIdx * 3 + lenIdx;
   const configChar = configVal.toString(36).toUpperCase();
 
-  // Each letter A-Z maps to A-Z (already base26, represent as A-Z directly)
+  // Each letter A-Z maps to itself; 'Qu' maps to '2'
+  const cellToChar = (cell: string) => cell.toUpperCase() === 'QU' ? '2' : cell[0].toUpperCase();
   const letters: string[] = [];
   for (let r = 0; r < data.boardSize; r++) {
     for (let c = 0; c < data.boardSize; c++) {
-      letters.push(data.board[r][c].toUpperCase());
+      letters.push(cellToChar(data.board[r][c]));
     }
   }
 
@@ -57,15 +58,16 @@ export function decodeBoard(code: string): SharedBoard | null {
 
     if (letterStr.length !== totalCells) return null;
 
-    // Validate all A-Z
-    if (!/^[A-Z]+$/.test(letterStr)) return null;
+    // Validate: A-Z or '2' (Qu)
+    if (!/^[A-Z2]+$/.test(letterStr)) return null;
 
+    const charToCell = (ch: string) => ch === '2' ? 'Qu' : ch;
     const board: string[][] = [];
     let idx = 0;
     for (let r = 0; r < boardSize; r++) {
       const row: string[] = [];
       for (let c = 0; c < boardSize; c++) {
-        row.push(letterStr[idx++]);
+        row.push(charToCell(letterStr[idx++]));
       }
       board.push(row);
     }
@@ -97,10 +99,11 @@ export function parseCode(formatted: string): string {
 
 // Board-only encoding: just letters, size implied by count (16=4x4, 25=5x5, 36=6x6)
 export function encodeBoardOnly(board: string[][], boardSize: number): string {
+  const cellToChar = (cell: string) => cell.toUpperCase() === 'QU' ? '2' : cell[0].toUpperCase();
   const letters: string[] = [];
   for (let r = 0; r < boardSize; r++) {
     for (let c = 0; c < boardSize; c++) {
-      letters.push(board[r][c].toUpperCase());
+      letters.push(cellToChar(board[r][c]));
     }
   }
   return letters.join('');
@@ -109,18 +112,19 @@ export function encodeBoardOnly(board: string[][], boardSize: number): string {
 export function decodeBoardOnly(code: string): SharedBoardOnly | null {
   try {
     const letterStr = code.toUpperCase();
-    if (!/^[A-Z]+$/.test(letterStr)) return null;
+    if (!/^[A-Z2]+$/.test(letterStr)) return null;
 
     const totalCells = letterStr.length;
     const boardSize = BOARD_SIZES.find(s => s * s === totalCells);
     if (!boardSize) return null;
 
+    const charToCell = (ch: string) => ch === '2' ? 'Qu' : ch;
     const board: string[][] = [];
     let idx = 0;
     for (let r = 0; r < boardSize; r++) {
       const row: string[] = [];
       for (let c = 0; c < boardSize; c++) {
-        row.push(letterStr[idx++]);
+        row.push(charToCell(letterStr[idx++]));
       }
       board.push(row);
     }

--- a/server/GameController.ts
+++ b/server/GameController.ts
@@ -119,13 +119,14 @@ export class GameController {
       return { valid: false, reason: 'invalid' };
     }
 
+    // Validate path structure and bounds before accessing board cells
+    const size = this.game.board.length;
+    if (!isValidPath(path) || path.some(p => p.row < 0 || p.row >= size || p.col < 0 || p.col >= size)) {
+      return { valid: false, reason: 'invalid' };
+    }
+
     // Derive word from path
     const word = path.map(pos => this.game!.board[pos.row][pos.col]).join('').toUpperCase();
-
-    // Validate path structure
-    if (!isValidPath(path)) {
-      return { valid: false, word, reason: 'invalid' };
-    }
 
     // Validate word length meets minimum requirement
     const minLength = this.game.config.minWordLength;


### PR DESCRIPTION
## Summary

- **Qu share links silently broken** — `boardCode.ts` called `.toUpperCase()` on each cell, turning `'Qu'` into `'QU'` (2 chars). The decoder's length check then failed, the shared board was silently ignored, and the user got a new random board instead of the one that was shared. Affects ~1 in 96 games (1 Qu die, 1/6 chance of rolling it). Fixed by encoding `'Qu'` as `'2'` and decoding `'2'` back to `'Qu'`.
- **Server crash on crafted path** — `GameController.submitWord` accessed `board[pos.row][pos.col]` with no bounds check, which could throw a `TypeError` on an out-of-bounds position. Added bounds validation before the board access.

## Test plan
- [ ] Share a game/board that contains a Qu tile — link should work correctly on the receiving end
- [ ] Verify normal A-Z tiles still encode/decode correctly
- [ ] Confirm server handles malformed word submission paths without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)