### PR TITLE
Fix iOS Safari zoom on seed code input

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -205,7 +205,7 @@ h1 {
   flex: 1;
   padding: 10px 14px;
   font-family: 'Roboto Mono', monospace;
-  font-size: 14px;
+  font-size: 16px; /* must be ≥16px to prevent iOS Safari auto-zoom on focus */
   font-weight: 600;
   letter-spacing: 1px;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary

- iOS Safari auto-zooms any input with `font-size < 16px` and doesn't restore the zoom level on blur. The seed code input was set to `14px`, triggering this. Bumped to `16px`.

## Test plan
- [ ] Tap the seed code input on iOS Safari — viewport should not zoom in

🤖 Generated with [Claude Code](https://claude.com/claude-code)