### PR TITLE
feat: daily leaderboard page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { LandingRoute } from './pages/landing';
 import { ConfigRoute } from './pages/config';
 import { GameRoute } from './pages/game';
 import { ResultsRoute, DailyResultsRoute } from './pages/results';
+import { LeaderboardRoute } from './pages/leaderboard';
 import './tailwind.css';
 
 function App() {
@@ -99,6 +100,7 @@ function App() {
         <Route path="/daily/results" element={<DailyResultsRoute />} />
         <Route path="/game" element={<GameRoute />} />
         <Route path="/results" element={<ResultsRoute />} />
+        <Route path="/leaderboard" element={<LeaderboardRoute />} />
       </Routes>
     </div>
   );

--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -25,7 +25,7 @@ export function LandingRoute() {
   const handleDailyResults = async () => {
     const info = await fetchDaily();
     setDailyInfo(info);
-    navigate('/daily/results');
+    navigate('/leaderboard');
   };
 
   if (!cachedDaily || !dailyResultLoaded) {

--- a/client/src/pages/leaderboard/LeaderboardPage.tsx
+++ b/client/src/pages/leaderboard/LeaderboardPage.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { DailyNav, type DailyNavEntry } from './components/DailyNav';
+import { PlayerCard, type PlayerCardProps } from './components/PlayerCard';
+import { RankingSelector, type RankingType } from './components/RankingSelector';
+import { TopThree, type TopThreeEntry } from './components/TopThree';
+import { Rankings, type RankingEntry } from './components/Rankings';
+import { MyResultsCard } from './components/MyResultsCard';
+
+interface LeaderboardPageProps {
+  title: string;
+  dailyEntries: DailyNavEntry[];
+  selectedDate: string;
+  onSelectDate: (date: string) => void;
+  onPrev: () => void;
+  onNext: () => void;
+  hasNext: boolean;
+  playerCard: PlayerCardProps;
+  rankingType: RankingType;
+  onRankingTypeChange: (type: RankingType) => void;
+  topThree: TopThreeEntry[];
+  rankings: RankingEntry[];
+  onMyResults: () => void;
+  onBack: () => void;
+}
+
+export function LeaderboardPage({
+  title,
+  dailyEntries,
+  selectedDate,
+  onSelectDate,
+  onPrev,
+  onNext,
+  hasNext,
+  playerCard,
+  rankingType,
+  onRankingTypeChange,
+  topThree,
+  rankings,
+  onMyResults,
+  onBack,
+}: LeaderboardPageProps) {
+  return (
+    <div
+      className="flex flex-col w-full"
+      style={{
+        maxWidth: '400px',
+        margin: '0 auto',
+        height: '100%',
+        gap: '10px',
+        fontFamily: 'var(--font-body)',
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-center relative">
+        <button
+          onClick={onBack}
+          className="absolute left-0 border-none bg-transparent cursor-pointer flex items-center justify-center"
+          style={{
+            fontSize: '1.25rem',
+            color: 'var(--text)',
+            padding: '4px',
+          }}
+        >
+          ←
+        </button>
+        <h1
+          className="m-0"
+          style={{
+            fontSize: '1.35rem',
+            fontFamily: 'var(--font-heading)',
+            fontWeight: 'var(--font-heading-weight)' as any,
+            color: 'var(--text)',
+            letterSpacing: '-0.025em',
+          }}
+        >
+          {title}
+        </h1>
+      </div>
+
+      {/* Daily navigation */}
+      <DailyNav
+        entries={dailyEntries}
+        selectedDate={selectedDate}
+        onSelectDate={onSelectDate}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasNext={hasNext}
+      />
+
+      {/* Player score card */}
+      <PlayerCard {...playerCard} />
+
+      {/* Ranking type selector */}
+      <RankingSelector value={rankingType} onChange={onRankingTypeChange} />
+
+      {/* Top 3 */}
+      <TopThree entries={topThree} />
+
+      {/* Rankings list — fills remaining space */}
+      <div className="flex-1" style={{ minHeight: 0 }}>
+        <Rankings entries={rankings} />
+      </div>
+
+      {/* My results button */}
+      <MyResultsCard onClick={onMyResults} />
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -1,0 +1,128 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGame } from '../../GameContext';
+import {
+  fetchLeaderboard,
+  fetchDailyHistory,
+  type LeaderboardResponse,
+  type DailyHistoryEntry,
+} from '../../shared/api/gameApi';
+import { LeaderboardPage } from './LeaderboardPage';
+import type { RankingType } from './components/RankingSelector';
+import type { DailyNavEntry } from './components/DailyNav';
+
+function getTodayPST(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+}
+
+export function LeaderboardRoute() {
+  const navigate = useNavigate();
+  const { dailyInfo } = useGame();
+
+  const [selectedDate, setSelectedDate] = useState<string>(dailyInfo?.date ?? getTodayPST());
+  const [rankingType, setRankingType] = useState<RankingType>('points');
+  const [leaderboard, setLeaderboard] = useState<LeaderboardResponse | null>(null);
+  const [history, setHistory] = useState<DailyHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch user's history for the nav dropdown
+  useEffect(() => {
+    fetchDailyHistory().then(({ entries }) => setHistory(entries));
+  }, []);
+
+  // Fetch leaderboard when date changes
+  useEffect(() => {
+    setLoading(true);
+    fetchLeaderboard(selectedDate).then((data) => {
+      setLeaderboard(data);
+      setLoading(false);
+    });
+  }, [selectedDate]);
+
+  // Map history to DailyNav entries, injecting rank from current leaderboard
+  const dailyEntries: DailyNavEntry[] = useMemo(() => {
+    const currentUserRank = leaderboard?.rankings.points.find((r) => r.isCurrentUser)?.rank ?? 0;
+    return history.map((e) => ({
+      date: e.date,
+      puzzleNumber: e.puzzleNumber,
+      points: e.points,
+      wordsFound: e.wordsFound,
+      rank: e.date === selectedDate ? currentUserRank : 0,
+      isToday: e.isToday,
+    }));
+  }, [history, leaderboard, selectedDate]);
+
+  const rankings = useMemo(
+    () => leaderboard?.rankings[rankingType] ?? [],
+    [leaderboard, rankingType],
+  );
+
+  const topThree = useMemo(
+    () => rankings.slice(0, 3).map((r) => ({
+      rank: r.rank as 1 | 2 | 3,
+      displayName: r.displayName,
+      value: r.value,
+    })),
+    [rankings],
+  );
+
+  // The rank on the player card should update based on the active ranking type
+  const currentUserRank = useMemo(
+    () => rankings.find((r) => r.isCurrentUser)?.rank ?? 0,
+    [rankings],
+  );
+
+  const playerCard = useMemo(() => {
+    if (!leaderboard?.currentPlayer) {
+      return {
+        points: 0,
+        wordsFound: 0,
+        longestWord: '',
+        rank: 0,
+        totalPlayers: leaderboard?.totalPlayers ?? 0,
+        topPercent: null,
+        accolade: "Play today's daily to see your stats!",
+      };
+    }
+    return {
+      ...leaderboard.currentPlayer,
+      rank: currentUserRank || leaderboard.currentPlayer.rank,
+    };
+  }, [leaderboard, currentUserRank]);
+
+  const handlePrev = useCallback(() => {
+    const idx = dailyEntries.findIndex((e) => e.date === selectedDate);
+    if (idx < dailyEntries.length - 1) setSelectedDate(dailyEntries[idx + 1].date);
+  }, [dailyEntries, selectedDate]);
+
+  const handleNext = useCallback(() => {
+    const idx = dailyEntries.findIndex((e) => e.date === selectedDate);
+    if (idx > 0) setSelectedDate(dailyEntries[idx - 1].date);
+  }, [dailyEntries, selectedDate]);
+
+  const hasNext = useMemo(() => {
+    const idx = dailyEntries.findIndex((e) => e.date === selectedDate);
+    return idx > 0;
+  }, [dailyEntries, selectedDate]);
+
+  if (loading && !leaderboard) return null;
+
+  return (
+    <LeaderboardPage
+      title={`Daily #${leaderboard?.puzzleNumber ?? ''}`}
+      dailyEntries={dailyEntries}
+      selectedDate={selectedDate}
+      onSelectDate={setSelectedDate}
+      onPrev={handlePrev}
+      onNext={handleNext}
+      hasNext={hasNext}
+      playerCard={playerCard}
+      rankingType={rankingType}
+      onRankingTypeChange={setRankingType}
+      topThree={topThree}
+      rankings={rankings}
+      onMyResults={() => navigate('/daily/results')}
+      onBack={() => navigate('/')}
+    />
+  );
+}

--- a/client/src/pages/leaderboard/components/DailyNav.tsx
+++ b/client/src/pages/leaderboard/components/DailyNav.tsx
@@ -1,0 +1,219 @@
+import { useState, useRef, useEffect } from 'react';
+
+export interface DailyNavEntry {
+  date: string;
+  puzzleNumber: number;
+  points: number;
+  wordsFound: number;
+  rank: number;
+  isToday: boolean;
+}
+
+interface DailyNavProps {
+  entries: DailyNavEntry[];
+  selectedDate: string;
+  onSelectDate: (date: string) => void;
+  onPrev: () => void;
+  onNext: () => void;
+  hasNext: boolean;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function formatShortDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function DailyNav({
+  entries,
+  selectedDate,
+  onSelectDate,
+  onPrev,
+  onNext,
+  hasNext,
+}: DailyNavProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selected = entries.find((e) => e.date === selectedDate);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  return (
+    <div className="relative flex items-center justify-center" style={{ gap: '12px' }}>
+      {/* Prev arrow */}
+      <button
+        onClick={onPrev}
+        className="border-none bg-transparent cursor-pointer flex items-center justify-center"
+        style={{
+          fontSize: '1rem',
+          color: 'var(--text-muted)',
+          padding: '4px',
+        }}
+      >
+        ‹
+      </button>
+
+      {/* Date label — toggles dropdown */}
+      <div ref={dropdownRef} className="relative">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="border-none bg-transparent cursor-pointer flex items-center"
+          style={{
+            gap: '6px',
+            fontSize: '0.85rem',
+            fontFamily: 'var(--font-body)',
+            fontWeight: 600,
+            color: 'var(--text)',
+            padding: '4px 8px',
+          }}
+        >
+          <span>{formatDate(selectedDate)}</span>
+          {selected?.isToday && (
+            <span
+              className="rounded"
+              style={{
+                fontSize: '0.55rem',
+                fontFamily: 'var(--font-label)',
+                fontWeight: 'var(--font-label-weight)' as any,
+                padding: '2px 8px',
+                backgroundColor: 'var(--accent)',
+                color: '#fff',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+              }}
+            >
+              Today
+            </span>
+          )}
+          <span
+            style={{
+              fontSize: '0.6rem',
+              color: 'var(--text-muted)',
+              transition: 'transform 0.2s ease',
+              transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+              display: 'inline-block',
+            }}
+          >
+            ▾
+          </span>
+        </button>
+
+        {/* Dropdown overlay */}
+        {isOpen && (
+          <div
+            className="absolute left-1/2 rounded-xl overflow-hidden"
+            style={{
+              top: 'calc(100% + 8px)',
+              transform: 'translateX(-50%)',
+              width: '300px',
+              maxHeight: '280px',
+              overflowY: 'auto',
+              backgroundColor: 'var(--card)',
+              boxShadow: '0 8px 40px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.06)',
+              zIndex: 50,
+            }}
+          >
+            {entries.map((entry, i) => {
+              const isSelected = entry.date === selectedDate;
+              return (
+                <button
+                  key={entry.date}
+                  onClick={() => {
+                    onSelectDate(entry.date);
+                    setIsOpen(false);
+                  }}
+                  className="w-full border-none bg-transparent cursor-pointer text-left flex items-center justify-between"
+                  style={{
+                    padding: '12px 16px',
+                    borderTop: i > 0 ? '1px solid var(--track)' : 'none',
+                    backgroundColor: isSelected ? 'var(--track)' : 'transparent',
+                  }}
+                >
+                  <div>
+                    <div className="flex items-center" style={{ gap: '8px' }}>
+                      <span
+                        style={{
+                          fontSize: '0.85rem',
+                          fontFamily: 'var(--font-body)',
+                          fontWeight: 700,
+                          color: isSelected ? 'var(--accent)' : 'var(--text)',
+                        }}
+                      >
+                        #{entry.puzzleNumber} · {entry.isToday ? 'Today' : formatShortDate(entry.date)}
+                      </span>
+                      {entry.isToday && (
+                        <span
+                          className="rounded"
+                          style={{
+                            fontSize: '0.5rem',
+                            fontFamily: 'var(--font-label)',
+                            fontWeight: 'var(--font-label-weight)' as any,
+                            padding: '2px 6px',
+                            backgroundColor: 'var(--accent)',
+                            color: '#fff',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.04em',
+                          }}
+                        >
+                          Today
+                        </span>
+                      )}
+                    </div>
+                    <span
+                      style={{
+                        fontSize: '0.7rem',
+                        fontFamily: 'var(--font-body)',
+                        fontWeight: 500,
+                        color: 'var(--text-muted)',
+                      }}
+                    >
+                      {entry.points} pts · {entry.wordsFound} words
+                    </span>
+                  </div>
+                  <span
+                    style={{
+                      fontSize: '1rem',
+                      fontFamily: 'var(--font-body)',
+                      fontWeight: 700,
+                      color: isSelected ? 'var(--accent)' : 'var(--text-mid)',
+                    }}
+                  >
+                    #{entry.rank}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Next arrow */}
+      <button
+        onClick={onNext}
+        disabled={!hasNext}
+        className="border-none bg-transparent cursor-pointer flex items-center justify-center"
+        style={{
+          fontSize: '1rem',
+          color: hasNext ? 'var(--text-muted)' : 'var(--track)',
+          padding: '4px',
+        }}
+      >
+        ›
+      </button>
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/components/MyResultsCard.tsx
+++ b/client/src/pages/leaderboard/components/MyResultsCard.tsx
@@ -1,0 +1,36 @@
+interface MyResultsCardProps {
+  onClick: () => void;
+}
+
+const shadow = '0 0 0 1px rgba(0,0,0,0.04), 0 4px 24px rgba(0,0,0,0.06)';
+const hoverShadow = '0 0 0 1px rgba(0,0,0,0.06), 0 8px 32px rgba(0,0,0,0.08)';
+
+export function MyResultsCard({ onClick }: MyResultsCardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="group rounded-2xl cursor-pointer select-none flex items-center justify-between transition-all duration-200 active:scale-[0.985] active:duration-[60ms]"
+      style={{
+        padding: '1rem',
+        WebkitTapHighlightColor: 'transparent',
+        backgroundColor: 'var(--card)',
+        boxShadow: shadow,
+        color: 'var(--text)',
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLElement).style.boxShadow = hoverShadow;
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.boxShadow = shadow;
+      }}
+    >
+      <div className="text-[0.95rem]" style={{ fontFamily: 'var(--font-label)', fontWeight: 'var(--font-label-weight)' as any }}>My Results</div>
+      <span
+        className="text-[0.85rem] transition-all duration-200 group-hover:translate-x-[3px]"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        →
+      </span>
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/components/PlayerCard.tsx
+++ b/client/src/pages/leaderboard/components/PlayerCard.tsx
@@ -1,0 +1,188 @@
+export interface PlayerCardProps {
+  points: number;
+  wordsFound: number;
+  longestWord: string;
+  rank: number;
+  totalPlayers: number;
+  topPercent: number | null;
+  accolade: string;
+}
+
+export function PlayerCard({
+  points,
+  wordsFound,
+  longestWord,
+  rank,
+  totalPlayers,
+  topPercent,
+  accolade,
+}: PlayerCardProps) {
+  return (
+    <div
+      className="rounded-2xl overflow-hidden"
+      style={{
+        backgroundColor: 'var(--accent)',
+        color: '#fff',
+        boxShadow: '0 4px 24px rgba(107,155,125,0.30)',
+      }}
+    >
+      {/* Main content: stats left, rank right */}
+      <div
+        className="flex"
+        style={{ padding: '1rem 1.25rem 0.75rem' }}
+      >
+        {/* Left — personal stats */}
+        <div className="flex-1">
+          {/* Points hero */}
+          <div className="flex items-baseline" style={{ gap: '6px' }}>
+            <span
+              style={{
+                fontSize: '2.2rem',
+                fontFamily: 'var(--font-body)',
+                fontWeight: 700,
+                lineHeight: 1,
+              }}
+            >
+              {points}
+            </span>
+            <span
+              style={{
+                fontSize: '0.75rem',
+                fontFamily: 'var(--font-body)',
+                fontWeight: 500,
+                opacity: 0.7,
+              }}
+            >
+              pts
+            </span>
+          </div>
+
+          {/* Words + Longest */}
+          <div
+            style={{
+              marginTop: '8px',
+              display: 'grid',
+              gridTemplateColumns: 'auto 1fr',
+              gap: '2px 8px',
+              alignItems: 'baseline',
+            }}
+          >
+            <span
+              style={{
+                fontSize: '0.7rem',
+                fontFamily: 'var(--font-body)',
+                fontWeight: 500,
+                opacity: 0.7,
+              }}
+            >
+              Words
+            </span>
+            <span
+              style={{
+                fontSize: '0.85rem',
+                fontFamily: 'var(--font-body)',
+                fontWeight: 700,
+              }}
+            >
+              {wordsFound}
+            </span>
+            <span
+              style={{
+                fontSize: '0.7rem',
+                fontFamily: 'var(--font-body)',
+                fontWeight: 500,
+                opacity: 0.7,
+              }}
+            >
+              Longest
+            </span>
+            <span
+              style={{
+                fontSize: '0.85rem',
+                fontFamily: 'var(--font-body)',
+                fontWeight: 700,
+                textTransform: 'uppercase',
+              }}
+            >
+              {longestWord}
+            </span>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div
+          style={{
+            width: '1px',
+            alignSelf: 'stretch',
+            backgroundColor: 'rgba(255,255,255,0.2)',
+            margin: '0 1rem',
+          }}
+        />
+
+        {/* Right — rank context */}
+        <div
+          className="flex flex-col items-center justify-center"
+          style={{ minWidth: '80px' }}
+        >
+          <span
+            style={{
+              fontSize: '1.75rem',
+              fontFamily: 'var(--font-heading)',
+              fontWeight: 'var(--font-heading-weight)' as any,
+              lineHeight: 1,
+            }}
+          >
+            #{rank}
+          </span>
+          <span
+            style={{
+              fontSize: '0.65rem',
+              fontFamily: 'var(--font-body)',
+              fontWeight: 500,
+              opacity: 0.65,
+              marginTop: '4px',
+            }}
+          >
+            {totalPlayers} played
+          </span>
+          {topPercent !== null && (
+            <span
+              className="rounded-full"
+              style={{
+                marginTop: '6px',
+                fontSize: '0.6rem',
+                fontFamily: 'var(--font-label)',
+                fontWeight: 'var(--font-label-weight)' as any,
+                padding: '3px 10px',
+                backgroundColor: 'rgba(255,255,255,0.15)',
+              }}
+            >
+              Top {topPercent}%
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Accolade bar */}
+      <div
+        style={{
+          borderTop: '1px solid rgba(255,255,255,0.15)',
+          padding: '0.5rem 1.25rem',
+        }}
+      >
+        <div className="flex items-center" style={{ gap: '6px' }}>
+          <span style={{ fontSize: '0.8rem' }}>⭐</span>
+          <span
+            style={{
+              fontSize: '0.7rem',
+              fontFamily: 'var(--font-body)',
+              fontWeight: 500,
+              opacity: 0.85,
+            }}
+            dangerouslySetInnerHTML={{ __html: accolade }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/components/RankingSelector.tsx
+++ b/client/src/pages/leaderboard/components/RankingSelector.tsx
@@ -1,0 +1,100 @@
+import { useState, useRef, useEffect } from 'react';
+
+export type RankingType = 'points' | 'words' | 'rarity';
+
+interface RankingSelectorProps {
+  value: RankingType;
+  onChange: (type: RankingType) => void;
+}
+
+const OPTIONS: { value: RankingType; label: string }[] = [
+  { value: 'points', label: 'Points' },
+  { value: 'words', label: 'Words' },
+  { value: 'rarity', label: 'Rarity' },
+];
+
+export function RankingSelector({ value, onChange }: RankingSelectorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pillStyle, setPillStyle] = useState<{ left: number; width: number }>({ left: 0, width: 0 });
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const index = OPTIONS.findIndex((o) => o.value === value);
+    const buttons = container.querySelectorAll<HTMLButtonElement>('button');
+    const btn = buttons[index];
+    if (btn) {
+      setPillStyle({ left: btn.offsetLeft, width: btn.offsetWidth });
+    }
+  }, [value]);
+
+  return (
+    <div>
+    <div
+      ref={containerRef}
+      className="relative flex rounded-xl"
+      style={{
+        backgroundColor: 'var(--track)',
+        padding: '4px',
+      }}
+    >
+      {/* Sliding pill */}
+      <div
+        className="absolute rounded-lg"
+        style={{
+          top: '4px',
+          bottom: '4px',
+          left: `${pillStyle.left}px`,
+          width: `${pillStyle.width}px`,
+          backgroundColor: 'var(--card)',
+          boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+          transition: 'left 0.3s cubic-bezier(0.4, 0, 0.2, 1), width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        }}
+      />
+
+      {OPTIONS.map((option) => {
+        const isActive = value === option.value;
+        return (
+          <button
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            className="relative z-10 flex-1 border-none cursor-pointer rounded-lg bg-transparent"
+            style={{
+              padding: '6px 0',
+              fontSize: '0.75rem',
+              fontFamily: 'var(--font-label)',
+              fontWeight: 'var(--font-label-weight)' as any,
+              color: isActive ? 'var(--text)' : 'var(--text-muted)',
+              transition: 'color 0.2s ease',
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+    <div
+      style={{
+        overflow: 'hidden',
+        maxHeight: value === 'rarity' ? '24px' : '0px',
+        opacity: value === 'rarity' ? 1 : 0,
+        transition: 'max-height 0.25s ease, opacity 0.2s ease',
+      }}
+    >
+      <p
+        className="text-center"
+        style={{
+          margin: '6px 0 0',
+          fontSize: '0.6rem',
+          fontFamily: 'var(--font-body)',
+          fontWeight: 500,
+          color: 'var(--text-muted)',
+        }}
+      >
+        Words fewer players found score higher.
+      </p>
+    </div>
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/components/Rankings.tsx
+++ b/client/src/pages/leaderboard/components/Rankings.tsx
@@ -1,0 +1,136 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+
+export interface RankingEntry {
+  rank: number;
+  displayName: string;
+  value: number;
+  isCurrentUser: boolean;
+}
+
+interface RankingsProps {
+  entries: RankingEntry[];
+}
+
+export function Rankings({ entries }: RankingsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const userRowRef = useRef<HTMLDivElement>(null);
+  const [pillPosition, setPillPosition] = useState<'above' | 'below' | null>(null);
+
+  const currentUser = entries.find((e) => e.isCurrentUser);
+
+  const scrollToUser = useCallback(() => {
+    userRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, []);
+
+  useEffect(() => {
+    // Auto-scroll to user row on mount
+    if (userRowRef.current) {
+      userRowRef.current.scrollIntoView({ block: 'center' });
+    }
+  }, [entries]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || !userRowRef.current) {
+      setPillPosition(null);
+      return;
+    }
+
+    const checkVisibility = () => {
+      const containerRect = container.getBoundingClientRect();
+      const rowRect = userRowRef.current!.getBoundingClientRect();
+
+      if (rowRect.bottom < containerRect.top) {
+        setPillPosition('above');
+      } else if (rowRect.top > containerRect.bottom) {
+        setPillPosition('below');
+      } else {
+        setPillPosition(null);
+      }
+    };
+
+    checkVisibility();
+    container.addEventListener('scroll', checkVisibility);
+    return () => container.removeEventListener('scroll', checkVisibility);
+  }, [entries]);
+
+  return (
+    <div className="relative flex flex-col" style={{ minHeight: 0, height: '100%' }}>
+      {/* Section label */}
+      <div
+        className="text-[0.65rem] tracking-[0.1em] uppercase mb-2"
+        style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-label)', fontWeight: 'var(--font-label-weight)' as any }}
+      >
+        Rankings
+      </div>
+
+      {/* Scrollable list */}
+      <div
+        ref={scrollRef}
+        className="relative overflow-y-auto flex-1"
+        style={{
+          maskImage:
+            'linear-gradient(to bottom, transparent, black 24px, black calc(100% - 24px), transparent)',
+          WebkitMaskImage:
+            'linear-gradient(to bottom, transparent, black 24px, black calc(100% - 24px), transparent)',
+        }}
+      >
+        {entries.map((entry) => {
+          const isUser = entry.isCurrentUser;
+          return (
+            <div
+              key={entry.rank}
+              ref={isUser ? userRowRef : undefined}
+              className="flex items-center justify-between py-2.5 px-3 rounded-xl transition-colors duration-150"
+              style={{
+                backgroundColor: isUser ? 'var(--accent-row-bg, rgba(107,155,125,0.12))' : 'transparent',
+                border: isUser ? '1px solid var(--accent-row-border, rgba(107,155,125,0.2))' : '1px solid transparent',
+              }}
+            >
+              <div className="flex items-center gap-3">
+                <span
+                  className="text-[0.8rem] w-6 text-center"
+                  style={{ color: isUser ? 'var(--accent)' : 'var(--text-muted)', fontFamily: 'var(--font-body)', fontWeight: 600 }}
+                >
+                  {entry.rank}
+                </span>
+                <span
+                  className="text-[0.85rem]"
+                  style={{ color: isUser ? 'var(--accent)' : 'var(--text)', fontFamily: 'var(--font-body)', fontWeight: 700 }}
+                >
+                  {isUser ? 'You' : entry.displayName}
+                </span>
+              </div>
+              <span
+                className="text-[0.85rem]"
+                style={{ color: isUser ? 'var(--accent)' : 'var(--text)', fontFamily: 'var(--font-body)', fontWeight: 700 }}
+              >
+                {entry.value}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Floating pill when user row is out of view */}
+      {pillPosition && currentUser && (
+        <button
+          onClick={scrollToUser}
+          className="absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full cursor-pointer border-none transition-all duration-200 hover:scale-105"
+          style={{
+            ...(pillPosition === 'above' ? { top: '28px' } : { bottom: '0px' }),
+            backgroundColor: 'var(--accent)',
+            color: '#fff',
+            fontFamily: 'var(--font-body)',
+            fontSize: '0.72rem',
+            fontWeight: 700,
+            boxShadow: '0 2px 12px rgba(107,155,125,0.4)',
+          }}
+        >
+          <span>{pillPosition === 'above' ? '↑' : '↓'}</span>
+          <span>You · #{currentUser.rank} · {currentUser.value}</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/components/TopThree.tsx
+++ b/client/src/pages/leaderboard/components/TopThree.tsx
@@ -1,0 +1,87 @@
+export interface TopThreeEntry {
+  rank: 1 | 2 | 3;
+  displayName: string;
+  value: number;
+}
+
+interface TopThreeProps {
+  entries: TopThreeEntry[];
+}
+
+const MEDAL_COLORS: Record<1 | 2 | 3, { bg: string; text: string }> = {
+  1: { bg: '#C4900A', text: '#fff' },
+  2: { bg: '#8E8E93', text: '#fff' },
+  3: { bg: '#A0714F', text: '#fff' },
+};
+
+const MEDAL_LABELS: Record<1 | 2 | 3, string> = {
+  1: '1ST',
+  2: '2ND',
+  3: '3RD',
+};
+
+export function TopThree({ entries }: TopThreeProps) {
+  return (
+    <div>
+      <div
+        className="text-[0.65rem] tracking-[0.1em] uppercase mb-2"
+        style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-label)', fontWeight: 'var(--font-label-weight)' as any }}
+      >
+        Top 3
+      </div>
+      <div className="flex" style={{ gap: '0.5rem', paddingTop: '0.75rem' }}>
+      {entries.map((entry) => {
+        const medal = MEDAL_COLORS[entry.rank];
+        return (
+          <div
+            key={entry.rank}
+            className="relative flex-1 flex flex-col items-center rounded-xl"
+            style={{
+              padding: '1.25rem 0.75rem 1rem',
+              gap: '2px',
+              backgroundColor: 'var(--card)',
+              boxShadow: '0 0 0 1px rgba(0,0,0,0.04), 0 4px 24px rgba(0,0,0,0.06)',
+            }}
+          >
+            {/* Medal badge — overlaps top edge */}
+            <span
+              style={{
+                position: 'absolute',
+                top: '-10px',
+                left: '50%',
+                transform: 'translateX(-50%)',
+                fontSize: '0.7rem',
+                letterSpacing: '0.05em',
+                borderRadius: '9999px',
+                padding: '4px 10px',
+                fontFamily: 'var(--font-label)',
+                fontWeight: 'var(--font-label-weight)' as any,
+                backgroundColor: medal.bg,
+                color: medal.text,
+              }}
+            >
+              {MEDAL_LABELS[entry.rank]}
+            </span>
+
+            {/* Value */}
+            <span
+              className="text-[1.25rem]"
+              style={{ fontFamily: 'var(--font-body)', fontWeight: 'var(--font-label-weight)', color: 'var(--text)' }}
+            >
+              {entry.value}
+            </span>
+
+            {/* Name */}
+            <span
+              className="text-[0.65rem]"
+              style={{ fontFamily: 'var(--font-body)', fontWeight: 500, color: 'var(--text-muted)' }}
+            >
+              {entry.displayName}
+            </span>
+          </div>
+        );
+      })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/leaderboard/index.ts
+++ b/client/src/pages/leaderboard/index.ts
@@ -1,0 +1,2 @@
+export { LeaderboardRoute } from './LeaderboardRoute';
+export { LeaderboardPage } from './LeaderboardPage';

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -140,6 +140,57 @@ export const fetchDailyResult = async (date: string): Promise<{ found_words: str
   return data.result ?? null;
 };
 
+export interface LeaderboardRankingEntry {
+  rank: number;
+  displayName: string;
+  value: number;
+  subLabel: string;
+  isCurrentUser: boolean;
+}
+
+export interface LeaderboardPlayerCard {
+  points: number;
+  wordsFound: number;
+  longestWord: string;
+  rank: number;
+  totalPlayers: number;
+  topPercent: number | null;
+  accolade: string;
+}
+
+export interface LeaderboardResponse {
+  puzzleNumber: number;
+  totalPlayers: number;
+  rankings: {
+    points: LeaderboardRankingEntry[];
+    words: LeaderboardRankingEntry[];
+    rarity: LeaderboardRankingEntry[];
+  };
+  currentPlayer: LeaderboardPlayerCard | null;
+}
+
+export const fetchLeaderboard = async (date: string): Promise<LeaderboardResponse> => {
+  const response = await fetch(`${API_URL}/daily/leaderboard/${date}`, {
+    headers: await sessionHeaders(),
+  });
+  return response.json();
+};
+
+export interface DailyHistoryEntry {
+  date: string;
+  puzzleNumber: number;
+  points: number;
+  wordsFound: number;
+  isToday: boolean;
+}
+
+export const fetchDailyHistory = async (): Promise<{ entries: DailyHistoryEntry[] }> => {
+  const response = await fetch(`${API_URL}/daily/history`, {
+    headers: await sessionHeaders(),
+  });
+  return response.json();
+};
+
 export const fetchProfile = async (): Promise<{ display_name: string }> => {
   const response = await fetch(`${API_URL}/user/profile`, {
     headers: await sessionHeaders(),

--- a/client/src/stories/DailyNav.stories.tsx
+++ b/client/src/stories/DailyNav.stories.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DailyNav, type DailyNavEntry } from '../pages/leaderboard/components/DailyNav';
+
+const sampleEntries: DailyNavEntry[] = [
+  { date: '2026-04-08', puzzleNumber: 10, points: 98, wordsFound: 23, rank: 8, isToday: true },
+  { date: '2026-04-07', puzzleNumber: 9, points: 112, wordsFound: 29, rank: 5, isToday: false },
+  { date: '2026-04-06', puzzleNumber: 8, points: 61, wordsFound: 14, rank: 12, isToday: false },
+  { date: '2026-04-05', puzzleNumber: 7, points: 72, wordsFound: 18, rank: 8, isToday: false },
+];
+
+const meta: Meta<typeof DailyNav> = {
+  title: 'Leaderboard/DailyNav',
+  component: DailyNav,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DailyNav>;
+
+const Interactive = ({ theme }: { theme: string }) => {
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const selectedDate = sampleEntries[selectedIdx].date;
+
+  return (
+    <div data-theme={theme} style={{ width: '340px', paddingTop: '20px', paddingBottom: '200px', backgroundColor: theme === 'dark' ? 'var(--page-bg)' : undefined, borderRadius: '16px', padding: theme === 'dark' ? '24px 24px 200px' : '20px 0 200px' }}>
+      <DailyNav
+        entries={sampleEntries}
+        selectedDate={selectedDate}
+        onSelectDate={(date) => {
+          const idx = sampleEntries.findIndex((e) => e.date === date);
+          if (idx >= 0) setSelectedIdx(idx);
+        }}
+        onPrev={() => setSelectedIdx((i) => Math.min(i + 1, sampleEntries.length - 1))}
+        onNext={() => setSelectedIdx((i) => Math.max(i - 1, 0))}
+        hasNext={selectedIdx > 0}
+      />
+    </div>
+  );
+};
+
+export const Light: Story = {
+  render: () => <Interactive theme="light" />,
+};
+
+export const Dark: Story = {
+  render: () => <Interactive theme="dark" />,
+};

--- a/client/src/stories/LeaderboardPage.stories.tsx
+++ b/client/src/stories/LeaderboardPage.stories.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { LeaderboardPage } from '../pages/leaderboard/LeaderboardPage';
+import type { RankingType } from '../pages/leaderboard/components/RankingSelector';
+import type { DailyNavEntry } from '../pages/leaderboard/components/DailyNav';
+import type { RankingEntry } from '../pages/leaderboard/components/Rankings';
+import type { TopThreeEntry } from '../pages/leaderboard/components/TopThree';
+
+const dailyEntries: DailyNavEntry[] = [
+  { date: '2026-04-08', puzzleNumber: 10, points: 98, wordsFound: 23, rank: 8, isToday: true },
+  { date: '2026-04-07', puzzleNumber: 9, points: 112, wordsFound: 29, rank: 5, isToday: false },
+  { date: '2026-04-06', puzzleNumber: 8, points: 61, wordsFound: 14, rank: 12, isToday: false },
+  { date: '2026-04-05', puzzleNumber: 7, points: 72, wordsFound: 18, rank: 8, isToday: false },
+];
+
+const fullRankings: RankingEntry[] = [
+  { rank: 1, displayName: 'sarah_j', value: 186, isCurrentUser: false },
+  { rank: 2, displayName: 'mike_k', value: 164, isCurrentUser: false },
+  { rank: 3, displayName: 'alex_l', value: 151, isCurrentUser: false },
+  { rank: 4, displayName: 'chris_n', value: 142, isCurrentUser: false },
+  { rank: 5, displayName: 'taylor_p', value: 127, isCurrentUser: false },
+  { rank: 6, displayName: 'jordan_w', value: 115, isCurrentUser: false },
+  { rank: 7, displayName: 'casey_m', value: 109, isCurrentUser: false },
+  { rank: 8, displayName: 'You', value: 98, isCurrentUser: true },
+  { rank: 9, displayName: 'dana_r', value: 91, isCurrentUser: false },
+  { rank: 10, displayName: 'pat_h', value: 84, isCurrentUser: false },
+  { rank: 11, displayName: 'sam_t', value: 78, isCurrentUser: false },
+  { rank: 12, displayName: 'riley_b', value: 72, isCurrentUser: false },
+  { rank: 13, displayName: 'morgan_c', value: 65, isCurrentUser: false },
+  { rank: 14, displayName: 'quinn_d', value: 58, isCurrentUser: false },
+  { rank: 15, displayName: 'avery_f', value: 51, isCurrentUser: false },
+];
+
+const fullTopThree: TopThreeEntry[] = [
+  { rank: 1, displayName: 'sarah_j', value: 186 },
+  { rank: 2, displayName: 'mike_k', value: 164 },
+  { rank: 3, displayName: 'alex_l', value: 151 },
+];
+
+const meta: Meta<typeof LeaderboardPage> = {
+  title: 'Leaderboard/LeaderboardPage',
+  component: LeaderboardPage,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof LeaderboardPage>;
+
+const Interactive = ({
+  theme,
+  rankings,
+  topThree,
+  totalPlayers,
+  rank,
+}: {
+  theme: string;
+  rankings: RankingEntry[];
+  topThree: TopThreeEntry[];
+  totalPlayers: number;
+  rank: number;
+}) => {
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [rankingType, setRankingType] = useState<RankingType>('points');
+  const entry = dailyEntries[selectedIdx];
+
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width: '375px',
+        height: '667px',
+        backgroundColor: 'var(--page-bg)',
+        padding: '16px 20px',
+        borderRadius: '16px',
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+      }}
+    >
+      <LeaderboardPage
+        title={`Daily #${entry.puzzleNumber}`}
+        dailyEntries={dailyEntries}
+        selectedDate={entry.date}
+        onSelectDate={(date) => {
+          const idx = dailyEntries.findIndex((e) => e.date === date);
+          if (idx >= 0) setSelectedIdx(idx);
+        }}
+        onPrev={() => setSelectedIdx((i) => Math.min(i + 1, dailyEntries.length - 1))}
+        onNext={() => setSelectedIdx((i) => Math.max(i - 1, 0))}
+        hasNext={selectedIdx > 0}
+        playerCard={{
+          points: entry.points,
+          wordsFound: entry.wordsFound,
+          longestWord: 'SNOB',
+          rank,
+          totalPlayers,
+          topPercent: rank <= Math.ceil(totalPlayers * 0.3) ? Math.round((rank / totalPlayers) * 100) : null,
+          accolade: 'Only <b>6%</b> of players found <b>SNOB</b>',
+        }}
+        rankingType={rankingType}
+        onRankingTypeChange={setRankingType}
+        topThree={topThree}
+        rankings={rankings}
+        onMyResults={() => {}}
+        onBack={() => {}}
+      />
+    </div>
+  );
+};
+
+export const Light: Story = {
+  render: () => (
+    <Interactive
+      theme="light"
+      rankings={fullRankings}
+      topThree={fullTopThree}
+      totalPlayers={32}
+      rank={8}
+    />
+  ),
+};
+
+export const Dark: Story = {
+  render: () => (
+    <Interactive
+      theme="dark"
+      rankings={fullRankings}
+      topThree={fullTopThree}
+      totalPlayers={32}
+      rank={8}
+    />
+  ),
+};
+
+export const OnePlayer: Story = {
+  render: () => (
+    <Interactive
+      theme="light"
+      rankings={[
+        { rank: 1, displayName: 'You', value: 98, isCurrentUser: true },
+      ]}
+      topThree={[
+        { rank: 1, displayName: 'You', value: 98 },
+      ]}
+      totalPlayers={1}
+      rank={1}
+    />
+  ),
+};
+
+export const TwoPlayers: Story = {
+  render: () => (
+    <Interactive
+      theme="light"
+      rankings={[
+        { rank: 1, displayName: 'sarah_j', value: 186, isCurrentUser: false },
+        { rank: 2, displayName: 'You', value: 98, isCurrentUser: true },
+      ]}
+      topThree={[
+        { rank: 1, displayName: 'sarah_j', value: 186 },
+        { rank: 2, displayName: 'You', value: 98 },
+      ]}
+      totalPlayers={2}
+      rank={2}
+    />
+  ),
+};

--- a/client/src/stories/MyResultsCard.stories.tsx
+++ b/client/src/stories/MyResultsCard.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { MyResultsCard } from '../pages/leaderboard/components/MyResultsCard';
+
+const meta: Meta<typeof MyResultsCard> = {
+  title: 'Leaderboard/MyResultsCard',
+  component: MyResultsCard,
+  parameters: { layout: 'centered' },
+  args: { onClick: fn() },
+};
+
+export default meta;
+type Story = StoryObj<typeof MyResultsCard>;
+
+export const Light: Story = {
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '24px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/PlayerCard.stories.tsx
+++ b/client/src/stories/PlayerCard.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PlayerCard } from '../pages/leaderboard/components/PlayerCard';
+
+const meta: Meta<typeof PlayerCard> = {
+  title: 'Leaderboard/PlayerCard',
+  component: PlayerCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlayerCard>;
+
+const sampleProps = {
+  points: 98,
+  wordsFound: 23,
+  longestWord: 'SNOB',
+  rank: 8,
+  totalPlayers: 32,
+  topPercent: 26,
+  accolade: 'Only <b>6%</b> of players found <b>SNOB</b>',
+};
+
+export const Light: Story = {
+  args: sampleProps,
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: sampleProps,
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '24px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NoTopPercent: Story = {
+  args: { ...sampleProps, topPercent: null, rank: 22 },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/RankingSelector.stories.tsx
+++ b/client/src/stories/RankingSelector.stories.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { RankingSelector, type RankingType } from '../pages/leaderboard/components/RankingSelector';
+
+const meta: Meta<typeof RankingSelector> = {
+  title: 'Leaderboard/RankingSelector',
+  component: RankingSelector,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof RankingSelector>;
+
+const Interactive = ({ theme }: { theme: string }) => {
+  const [value, setValue] = useState<RankingType>('points');
+  return (
+    <div data-theme={theme} className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '24px', borderRadius: '16px' }}>
+      <RankingSelector value={value} onChange={setValue} />
+    </div>
+  );
+};
+
+export const Light: Story = {
+  render: () => <Interactive theme="light" />,
+};
+
+export const Dark: Story = {
+  render: () => <Interactive theme="dark" />,
+};

--- a/client/src/stories/Rankings.stories.tsx
+++ b/client/src/stories/Rankings.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Rankings, type RankingEntry } from '../pages/leaderboard/components/Rankings';
+
+const sampleEntries: RankingEntry[] = [
+  { rank: 1, displayName: 'sarah_j', value: 186, isCurrentUser: false },
+  { rank: 2, displayName: 'mike_k', value: 164, isCurrentUser: false },
+  { rank: 3, displayName: 'alex_l', value: 151, isCurrentUser: false },
+  { rank: 4, displayName: 'chris_n', value: 142, isCurrentUser: false },
+  { rank: 5, displayName: 'taylor_p', value: 127, isCurrentUser: false },
+  { rank: 6, displayName: 'jordan_w', value: 115, isCurrentUser: false },
+  { rank: 7, displayName: 'casey_m', value: 109, isCurrentUser: false },
+  { rank: 8, displayName: 'You', value: 98, isCurrentUser: true },
+  { rank: 9, displayName: 'dana_r', value: 91, isCurrentUser: false },
+  { rank: 10, displayName: 'pat_h', value: 84, isCurrentUser: false },
+  { rank: 11, displayName: 'sam_t', value: 78, isCurrentUser: false },
+  { rank: 12, displayName: 'riley_b', value: 72, isCurrentUser: false },
+  { rank: 13, displayName: 'morgan_c', value: 65, isCurrentUser: false },
+  { rank: 14, displayName: 'quinn_d', value: 58, isCurrentUser: false },
+  { rank: 15, displayName: 'avery_f', value: 51, isCurrentUser: false },
+  { rank: 16, displayName: 'sam_t', value: 78, isCurrentUser: false },
+  { rank: 17, displayName: 'riley_b', value: 72, isCurrentUser: false },
+  { rank: 18, displayName: 'morgan_c', value: 65, isCurrentUser: false },
+  { rank: 19, displayName: 'quinn_d', value: 58, isCurrentUser: false },
+  { rank: 20, displayName: 'avery_f', value: 51, isCurrentUser: false },
+];
+
+const meta: Meta<typeof Rankings> = {
+  title: 'Leaderboard/Rankings',
+  component: Rankings,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Rankings>;
+
+export const Light: Story = {
+  args: { entries: sampleEntries },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: { entries: sampleEntries },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '24px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/TopThree.stories.tsx
+++ b/client/src/stories/TopThree.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TopThree, type TopThreeEntry } from '../pages/leaderboard/components/TopThree';
+
+const sampleEntries: TopThreeEntry[] = [
+  { rank: 1, displayName: 'sarah_j', value: 186 },
+  { rank: 2, displayName: 'mike_k', value: 164 },
+  { rank: 3, displayName: 'alex_l', value: 151 },
+];
+
+const meta: Meta<typeof TopThree> = {
+  title: 'Leaderboard/TopThree',
+  component: TopThree,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof TopThree>;
+
+export const Light: Story = {
+  args: { entries: sampleEntries },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: { entries: sampleEntries },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '24px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import { GameController } from './GameController.js';
 import { getDailySeed } from 'models/seedCode';
 import { generateSeededBoard } from 'engine/board.js';
+import { scoreWord } from 'engine/scoring.js';
 import { authMiddleware, requireAuth } from './middleware/auth.js';
 import { getDb } from './db/index.js';
 import { getSupabaseAdmin } from './supabaseAdmin.js';
@@ -303,6 +304,204 @@ app.get('/api/daily/results/:date', requireAuth, async (req, res) => {
   } catch (err) {
     console.error('Failed to fetch daily result:', err);
     res.status(500).json({ error: 'Failed to fetch result' });
+  }
+});
+
+// Get leaderboard for a specific date
+// Returns fully computed rankings and player stats ready for display
+app.get('/api/daily/leaderboard/:date', async (req, res) => {
+  const { date } = req.params;
+  const requestingUserId = req.userId; // may be undefined if not authenticated
+
+  try {
+    const db = getDb();
+    const admin = getSupabaseAdmin();
+
+    const results = await db
+      .selectFrom('daily_results')
+      .selectAll()
+      .where('date', '=', date)
+      .execute();
+
+    const totalPlayers = results.length;
+
+    if (totalPlayers === 0) {
+      return res.json({
+        puzzleNumber: getDailyNumber(date),
+        totalPlayers: 0,
+        rankings: { points: [], words: [], rarity: [] },
+        currentPlayer: null,
+      });
+    }
+
+    // Fetch display names
+    const userMap = new Map<string, string>();
+    for (const r of results) {
+      try {
+        const { data } = await admin.auth.admin.getUserById(r.user_id);
+        userMap.set(r.user_id, data.user?.user_metadata?.display_name || 'Anonymous');
+      } catch {
+        userMap.set(r.user_id, 'Anonymous');
+      }
+    }
+
+    // Build word frequency map across all players
+    const wordCounts = new Map<string, number>();
+    const parsedResults = results.map((r) => {
+      const words: string[] = typeof r.found_words === 'string'
+        ? JSON.parse(r.found_words)
+        : r.found_words;
+      for (const w of words) {
+        wordCounts.set(w, (wordCounts.get(w) || 0) + 1);
+      }
+      return { ...r, words };
+    });
+
+    // Score each player
+    const scored = parsedResults.map((r) => {
+      const points = r.words.reduce((sum, w) => sum + scoreWord(w), 0);
+      const wordCount = r.words.length;
+      const rarityScore = Math.round(
+        r.words.reduce((sum, w) => {
+          const base = scoreWord(w);
+          const freq = wordCounts.get(w) || 1;
+          return sum + base * (2 - freq / totalPlayers);
+        }, 0) * 10,
+      ) / 10;
+      const longest = r.words.reduce((a, b) => (b.length > a.length ? b : a), '');
+
+      return {
+        userId: r.user_id,
+        displayName: userMap.get(r.user_id) || 'Anonymous',
+        words: r.words,
+        points,
+        wordCount,
+        rarityScore,
+        longestWord: longest.toUpperCase(),
+        wordFrequencies: Object.fromEntries(
+          r.words.map((w) => [w, wordCounts.get(w) || 0]),
+        ),
+      };
+    });
+
+    // Build rankings for each type
+    function buildRankings(
+      sortKey: 'points' | 'wordCount' | 'rarityScore',
+      subLabelKey: 'wordCount' | 'points',
+      subLabelSuffix: string,
+    ) {
+      const sorted = [...scored].sort((a, b) => b[sortKey] - a[sortKey]);
+      return sorted.map((p, i) => ({
+        rank: i + 1,
+        displayName: p.displayName,
+        value: Math.round(p[sortKey]),
+        subLabel: `${p[subLabelKey]} ${subLabelSuffix}`,
+        isCurrentUser: p.userId === requestingUserId,
+      }));
+    }
+
+    const rankings = {
+      points: buildRankings('points', 'wordCount', 'words'),
+      words: buildRankings('wordCount', 'points', 'pts'),
+      rarity: buildRankings('rarityScore', 'wordCount', 'words'),
+    };
+
+    // Build current player card data
+    let currentPlayer = null;
+    if (requestingUserId) {
+      const me = scored.find((p) => p.userId === requestingUserId);
+      if (me) {
+        const pointsRank = rankings.points.find((r) => r.isCurrentUser)!.rank;
+
+        // Pick accolade
+        const wordsByRarity = [...me.words].sort(
+          (a, b) => (me.wordFrequencies[a] || totalPlayers) - (me.wordFrequencies[b] || totalPlayers),
+        );
+
+        let accolade = '';
+        if (wordsByRarity.length > 0) {
+          const rarestWord = wordsByRarity[0];
+          const freq = me.wordFrequencies[rarestWord] || totalPlayers;
+          const pct = Math.round((freq / totalPlayers) * 100);
+
+          if (pct <= 10) {
+            accolade = `Only <b>${pct}%</b> of players found <b>${rarestWord.toUpperCase()}</b>`;
+          } else {
+            const rareWords = me.words.filter(
+              (w) => ((me.wordFrequencies[w] || totalPlayers) / totalPlayers) * 100 <= 10,
+            );
+            if (rareWords.length >= 2) {
+              accolade = `You found <b>${rareWords.length} words</b> that less than 10% of players spotted`;
+            }
+          }
+        }
+
+        if (!accolade && me.wordCount > 0) {
+          const avg = (me.points / me.wordCount).toFixed(1);
+          accolade = `Your avg word scored <b>${avg} pts</b>`;
+        }
+
+        if (!accolade) {
+          accolade = 'Keep playing to earn accolades!';
+        }
+
+        const topPercent = Math.round((pointsRank / totalPlayers) * 100);
+
+        currentPlayer = {
+          points: me.points,
+          wordsFound: me.wordCount,
+          longestWord: me.longestWord,
+          rank: pointsRank,
+          totalPlayers,
+          topPercent: topPercent <= 30 ? topPercent : null,
+          accolade,
+        };
+      }
+    }
+
+    res.json({
+      puzzleNumber: getDailyNumber(date),
+      totalPlayers,
+      rankings,
+      currentPlayer,
+    });
+  } catch (err) {
+    console.error('Failed to fetch leaderboard:', err);
+    res.status(500).json({ error: 'Failed to fetch leaderboard' });
+  }
+});
+
+// Get current user's daily result history with pre-computed stats
+app.get('/api/daily/history', requireAuth, async (req, res) => {
+  try {
+    const db = getDb();
+    const results = await db
+      .selectFrom('daily_results')
+      .selectAll()
+      .where('user_id', '=', req.userId!)
+      .orderBy('date', 'desc')
+      .execute();
+
+    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+
+    const entries = results.map((result) => {
+      const words: string[] = typeof result.found_words === 'string'
+        ? JSON.parse(result.found_words)
+        : result.found_words;
+
+      return {
+        date: result.date,
+        puzzleNumber: getDailyNumber(result.date),
+        points: words.reduce((sum, w) => sum + scoreWord(w), 0),
+        wordsFound: words.length,
+        isToday: result.date === today,
+      };
+    });
+
+    res.json({ entries });
+  } catch (err) {
+    console.error('Failed to fetch daily history:', err);
+    res.status(500).json({ error: 'Failed to fetch history' });
   }
 });
 


### PR DESCRIPTION
## Summary

- Adds a leaderboard page (`/leaderboard`) with daily puzzle rankings, player stats, and date navigation
- Server endpoints compute all rankings (points, words, rarity) and player card data — no scoring logic on the client
- Completed daily card on landing page now links to leaderboard; "My results" card on leaderboard links to detailed results
- Components: DailyNav, PlayerCard, RankingSelector (with rarity explainer), TopThree, Rankings (auto-scroll + floating pill), MyResultsCard
- Full Storybook coverage with light/dark mode stories for all components and full page

## Test plan

- [ ] Complete a daily puzzle, tap the completed card — should navigate to leaderboard
- [ ] Verify rankings display correctly across Points, Words, and Rarity tabs
- [ ] Confirm rarity subtitle appears when Rarity tab is selected
- [ ] Navigate between dates using arrows and dropdown
- [ ] Tap "My results" card — should navigate to daily results page
- [ ] Verify dark mode renders correctly across all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)