### PR TITLE
feat(daily): backend for Daily Puzzle stats page

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,11 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_PROD }}
 
+      - name: Backfill daily result aggregates
+        run: npm run backfill:daily
+        env:
+          DATABASE_URL: postgres://postgres:${{ secrets.SUPABASE_DB_PASSWORD_PROD }}@db.${{ secrets.SUPABASE_PROJECT_REF_PROD }}.supabase.co:5432/postgres
+
       - name: Install Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,6 +36,11 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_STAGING }}
 
+      - name: Backfill daily result aggregates
+        run: npm run backfill:daily
+        env:
+          DATABASE_URL: postgres://postgres:${{ secrets.SUPABASE_DB_PASSWORD_STAGING }}@db.${{ secrets.SUPABASE_PROJECT_REF_STAGING }}.supabase.co:5432/postgres
+
       - name: Install Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "concurrently 'npm run dev:server' 'npm run dev:client'",
     "dev:server": "npm run dev --workspace=server",
-    "dev:client": "npm run dev --workspace=client"
+    "dev:client": "npm run dev --workspace=client",
+    "backfill:daily": "tsx scripts/backfillDailyAggregates.ts"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.27",

--- a/scripts/backfillDailyAggregates.ts
+++ b/scripts/backfillDailyAggregates.ts
@@ -1,0 +1,79 @@
+// Backfills points/word_count/longest_word on daily_results rows written
+// before Phase 2 (which started persisting these columns on submission).
+//
+// Safe to run repeatedly: only selects rows where points = 0 AND
+// word_count = 0. Any real play produces points > 0 so completed rows
+// are never re-swept.
+//
+// Usage:
+//   DATABASE_URL=postgres://... npx tsx scripts/backfillDailyAggregates.ts
+//
+// Runs automatically in the deploy workflows after migrations apply.
+// Remove this script and the CI step once all historical rows have
+// been backfilled on every environment.
+
+import { Kysely, PostgresDialect, sql } from 'kysely';
+import { Pool } from 'pg';
+import { scoreResult } from '../server/services/DailyService.js';
+import type { Database } from '../server/db/types.js';
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is not set');
+  }
+
+  const db = new Kysely<Database>({
+    dialect: new PostgresDialect({
+      pool: new Pool({
+        connectionString,
+        ssl: connectionString.includes('localhost') || connectionString.includes('127.0.0.1')
+          ? false
+          : { rejectUnauthorized: false },
+      }),
+    }),
+  });
+
+  const rows = await db
+    .selectFrom('daily_results')
+    .select(['id', 'found_words'])
+    .where('points', '=', 0)
+    .where('word_count', '=', 0)
+    .execute();
+
+  console.log(`Found ${rows.length} row(s) to backfill.`);
+
+  let updated = 0;
+  for (const row of rows) {
+    const foundWords: string[] = typeof row.found_words === 'string'
+      ? JSON.parse(row.found_words)
+      : (row.found_words as unknown as string[]);
+
+    const { points, wordCount, longestWord } = scoreResult(foundWords);
+
+    // Skip rows that legitimately have zero points (e.g. user opened
+    // the puzzle without finding any words). Re-running wouldn't hurt,
+    // but skipping keeps the "rows to backfill" count honest.
+    if (points === 0 && wordCount === 0) continue;
+
+    await db
+      .updateTable('daily_results')
+      .set({
+        points,
+        word_count: wordCount,
+        longest_word: longestWord,
+      })
+      .where('id', '=', row.id)
+      .execute();
+
+    updated++;
+  }
+
+  console.log(`Backfilled ${updated} row(s).`);
+  await db.destroy();
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -7,6 +7,9 @@ export interface DailyResultsTable {
   found_words: string; // JSON string
   board: string; // JSON string
   completed_at: Generated<Date>;
+  points: Generated<number>;
+  word_count: Generated<number>;
+  longest_word: Generated<string>;
 }
 
 export interface Database {

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,7 +10,7 @@ import { scoreWord } from 'engine/scoring.js';
 import { authMiddleware, requireAuth } from './middleware/auth.js';
 import { getDb } from './db/index.js';
 import { getSupabaseAdmin } from './supabaseAdmin.js';
-import { scoreResult } from './services/DailyService.js';
+import { scoreResult, getDailyStats } from './services/DailyService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -510,6 +510,24 @@ app.get('/api/daily/history', requireAuth, async (req, res) => {
   } catch (err) {
     console.error('Failed to fetch daily history:', err);
     res.status(500).json({ error: 'Failed to fetch history' });
+  }
+});
+
+// Get daily stats page payload — history, streak, averages, rankings.
+// Single endpoint per the "endpoint-per-page" pattern; the client renders
+// directly from this shape.
+app.get('/api/daily/stats', requireAuth, async (req, res) => {
+  try {
+    const db = getDb();
+    const stats = await getDailyStats(db, req.userId!, {
+      launchDate: DAILY_LAUNCH_DATE,
+      today: getDailyDatePST(),
+      getPuzzleNumber: getDailyNumber,
+    });
+    res.json(stats);
+  } catch (err) {
+    console.error('Failed to fetch daily stats:', err);
+    res.status(500).json({ error: 'Failed to fetch stats' });
   }
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -155,7 +155,7 @@ app.get('/api/game/results', (req, res) => {
 });
 
 // Daily puzzle configuration
-const DAILY_LAUNCH_DATE = '2026-03-30';
+const DAILY_LAUNCH_DATE = '2026-04-10';
 const DAILY_BOARD_SIZE = 5;
 const DAILY_TIME_LIMIT = 120;
 const DAILY_MIN_WORD_LENGTH = 4;

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { scoreWord } from 'engine/scoring.js';
 import { authMiddleware, requireAuth } from './middleware/auth.js';
 import { getDb } from './db/index.js';
 import { getSupabaseAdmin } from './supabaseAdmin.js';
+import { scoreResult } from './services/DailyService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -252,6 +253,7 @@ app.post('/api/daily/results', requireAuth, async (req, res) => {
   }
 
   try {
+    const { points, wordCount, longestWord } = scoreResult(found_words);
     const db = getDb();
     await db
       .insertInto('daily_results')
@@ -260,6 +262,9 @@ app.post('/api/daily/results', requireAuth, async (req, res) => {
         date,
         found_words: JSON.stringify(found_words),
         board: JSON.stringify(board),
+        points,
+        word_count: wordCount,
+        longest_word: longestWord,
       })
       .onConflict((oc) => oc
         .columns(['user_id', 'date'])
@@ -267,6 +272,9 @@ app.post('/api/daily/results', requireAuth, async (req, res) => {
           found_words: JSON.stringify(found_words),
           board: JSON.stringify(board),
           completed_at: new Date(),
+          points,
+          word_count: wordCount,
+          longest_word: longestWord,
         })
       )
       .execute();

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -1,4 +1,6 @@
+import { sql, type Kysely } from 'kysely';
 import { scoreWord } from 'engine/scoring.js';
+import type { Database } from '../db/types.js';
 
 export interface ScoredResult {
   points: number;
@@ -23,4 +25,142 @@ export function scoreResult(foundWords: string[]): ScoredResult {
     }
   }
   return { points, wordCount: foundWords.length, longestWord };
+}
+
+export interface DailyStatsDay {
+  date: string;
+  puzzleNumber: number;
+  played: boolean;
+  result: {
+    points: number;
+    wordsFound: number;
+    longestWord: string;
+    rank: number;
+    totalPlayers: number;
+    placedTop3: boolean;
+    placedTop30Percent: boolean;
+  } | null;
+}
+
+export interface DailyStatsResponse {
+  streak: number;
+  sevenDayAvg: { points: number; wordsFound: number };
+  windowStart: string;
+  windowEnd: string;
+  days: DailyStatsDay[];
+}
+
+export interface DailyStatsConfig {
+  launchDate: string;
+  today: string;
+  getPuzzleNumber: (date: string) => number;
+  windowDays?: number;
+}
+
+// Pure PST calendar arithmetic on YYYY-MM-DD strings. Noon UTC avoids
+// any DST edge cases when adding days.
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00Z');
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function maxDate(a: string, b: string): string {
+  return a >= b ? a : b;
+}
+
+export async function getDailyStats(
+  db: Kysely<Database>,
+  userId: string,
+  config: DailyStatsConfig
+): Promise<DailyStatsResponse> {
+  const { launchDate, today, getPuzzleNumber, windowDays = 30 } = config;
+
+  const windowStart = maxDate(addDays(today, -(windowDays - 1)), launchDate);
+  const windowEnd = today;
+
+  // Single query: per-day rank + total_players, filtered to this user's rows.
+  // Tiebreak order matches what "placed top 3" promises to users:
+  // points DESC, word_count DESC, earliest completion wins.
+  // Window functions go through sql fragments since Kysely has no first-class
+  // window-function builder, but the CTE and column wiring stay type-safe.
+  const rankedRows = await db
+    .with('ranked', (qb) =>
+      qb
+        .selectFrom('daily_results')
+        .select((eb) => [
+          'user_id',
+          'date',
+          'points',
+          'word_count',
+          'longest_word',
+          sql<number>`rank() over (partition by ${eb.ref('date')} order by ${eb.ref('points')} desc, ${eb.ref('word_count')} desc, ${eb.ref('completed_at')} asc)`.as('rank'),
+          sql<number>`count(*) over (partition by ${eb.ref('date')})`.as('total_players'),
+        ])
+        .where('date', '>=', windowStart)
+        .where('date', '<=', windowEnd)
+    )
+    .selectFrom('ranked')
+    .select(['date', 'points', 'word_count', 'longest_word', 'rank', 'total_players'])
+    .where('user_id', '=', userId)
+    .execute();
+
+  const byDate = new Map<string, typeof rankedRows[number]>();
+  for (const row of rankedRows) byDate.set(row.date, row);
+
+  const days: DailyStatsDay[] = [];
+  for (let d = windowStart; d <= windowEnd; d = addDays(d, 1)) {
+    const row = byDate.get(d);
+    if (!row) {
+      days.push({
+        date: d,
+        puzzleNumber: getPuzzleNumber(d),
+        played: false,
+        result: null,
+      });
+      continue;
+    }
+
+    // Postgres returns bigint for count(); rank() is int but Kysely types it
+    // loosely. Coerce both defensively in case the driver hands back strings.
+    const rank = Number(row.rank);
+    const totalPlayers = Number(row.total_players);
+    days.push({
+      date: d,
+      puzzleNumber: getPuzzleNumber(d),
+      played: true,
+      result: {
+        points: row.points,
+        wordsFound: row.word_count,
+        longestWord: row.longest_word,
+        rank,
+        totalPlayers,
+        placedTop3: rank <= 3,
+        // Ceiling so the single-player case (1 of 1) still counts as top 30%.
+        placedTop30Percent: rank <= Math.ceil(totalPlayers * 0.3),
+      },
+    });
+  }
+
+  // Streak: walk backwards from today; today missing is not a break yet.
+  // Starting point is today if played, else yesterday.
+  let streak = 0;
+  for (let i = days.length - 1; i >= 0; i--) {
+    const day = days[i];
+    if (i === days.length - 1 && !day.played) continue; // today unplayed: OK
+    if (!day.played) break;
+    streak++;
+  }
+
+  // 7-day avg: last 7 PLAYED days (any time in window).
+  const playedDays = days.filter((d) => d.played);
+  const recentPlayed = playedDays.slice(-7);
+  const sevenDayAvg = recentPlayed.length === 0
+    ? { points: 0, wordsFound: 0 }
+    : {
+        points: recentPlayed.reduce((s, d) => s + (d.result?.points ?? 0), 0) / recentPlayed.length,
+        wordsFound: recentPlayed.reduce((s, d) => s + (d.result?.wordsFound ?? 0), 0) / recentPlayed.length,
+      };
+
+  return { streak, sevenDayAvg, windowStart, windowEnd, days };
 }

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -1,0 +1,26 @@
+import { scoreWord } from 'engine/scoring.js';
+
+export interface ScoredResult {
+  points: number;
+  wordCount: number;
+  longestWord: string;
+}
+
+// Computes the aggregates that get persisted alongside a daily_results row.
+// Kept pure and trivially testable so the Phase 3 backfill script can reuse it.
+// Longest-word tiebreak is alphabetical ascending so the stored value is stable
+// regardless of the order words were found in.
+export function scoreResult(foundWords: string[]): ScoredResult {
+  let points = 0;
+  let longestWord = '';
+  for (const word of foundWords) {
+    points += scoreWord(word);
+    if (
+      word.length > longestWord.length ||
+      (word.length === longestWord.length && word < longestWord)
+    ) {
+      longestWord = word;
+    }
+  }
+  return { points, wordCount: foundWords.length, longestWord };
+}

--- a/supabase/migrations/20260415000000_daily_stats_schema.sql
+++ b/supabase/migrations/20260415000000_daily_stats_schema.sql
@@ -1,0 +1,21 @@
+-- Phase 1: Schema changes for Daily Puzzle stats page
+--
+-- Adds stored aggregates to daily_results so the stats endpoint and
+-- leaderboards can rank in SQL without re-scoring every row in JS.
+--
+-- Defaults are safe: existing rows get points=0, word_count=0, longest_word=''.
+-- A backfill script (Phase 3) populates real values. The new write path
+-- (Phase 2) writes correct values for all new submissions.
+--
+-- Puzzle-date enumeration for missed-day / streak queries is synthesized
+-- via generate_series(launch, today) at query time — no separate puzzle
+-- table is needed while "one puzzle per PST calendar day" holds.
+
+alter table public.daily_results
+  add column points int not null default 0,
+  add column word_count int not null default 0,
+  add column longest_word text not null default '';
+
+-- Optimizes rank queries: ORDER BY date, points DESC
+create index idx_daily_results_date_points
+  on public.daily_results(date, points desc);


### PR DESCRIPTION
## Summary

Adds the backend for the Daily Puzzle stats page: a single endpoint (\`GET /api/daily/stats\`) returning history, streak, 7-day averages, and per-day rankings. Also persists score aggregates on submission so ranking no longer re-scores in JS on every read.

- **Schema**: adds \`points\`, \`word_count\`, \`longest_word\` to \`daily_results\` with safe defaults. Deferred a separate \`daily_puzzles\` table — date-range queries use \`generate_series\`-style window math in JS since the product rigidly defines "one puzzle per PST calendar day." If that assumption ever loosens (skipped days, themed puzzles), the table can be reintroduced.
- **Write path**: \`DailyService.scoreResult\` helper; \`POST /api/daily/results\` now persists aggregates on insert and conflict-update. Longest-word tiebreak is alphabetical asc for deterministic storage.
- **Backfill**: idempotent script (\`scripts/backfillDailyAggregates.ts\`) fills historical rows. Wired into staging + prod workflows between migration apply and Fly deploy. \`DATABASE_URL\` constructed inline from existing \`SUPABASE_*\` secrets — no new secrets required. Locally verified: 14 rows backfilled, second run reports 0 (idempotent).
- **Read path**: \`GET /api/daily/stats\` returns a 30-day window clamped to \`DAILY_LAUNCH_DATE\` (moved to 2026-04-10 — the first day with real submissions). Rank + totalPlayers computed via SQL window functions in a single CTE query; \`placedTop30Percent\` uses \`ceil(total * 0.3)\` so the single-player edge case still flags true.
- **Streak**: consecutive PST days ending at today or yesterday; today unplayed does not break the streak until the PST day rolls over.
- **Timezone**: PST remains canonical. Date strings are treated as opaque labels, never as timezone-aware datetimes, so there's no tz math on reads.

FE changes are intentionally excluded — they'll reconcile against this endpoint's real shape in a follow-up PR off \`feat/daily-page\`.

## Test plan

- [x] Local: migration applies cleanly
- [x] Local: backfill fills 14 rows; second run is a no-op
- [x] Local: \`getDailyStats\` smoke test for a played user returns correct rank, aggregates, streak, avg
- [x] Local: \`getDailyStats\` smoke test for a user with no in-window results returns all \`played: false\`, streak 0
- [x] Server typechecks clean
- [ ] Staging: merge triggers deploy workflow; migration + backfill succeed
- [ ] Staging: hit \`/api/daily/stats\` with a real JWT, spot-check against staging data
- [ ] Prod: manual workflow_dispatch after staging verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)