### PR TITLE
feat(daily): wire Daily Puzzle page to stats endpoint

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { ConfigRoute } from './pages/config';
 import { GameRoute } from './pages/game';
 import { ResultsRoute, DailyResultsRoute } from './pages/results';
 import { LeaderboardRoute } from './pages/leaderboard';
+import { DailyPuzzleRoute } from './pages/daily';
 import './tailwind.css';
 
 function App() {
@@ -96,7 +97,7 @@ function App() {
       <Routes>
         <Route path="/" element={<LandingRoute />} />
         <Route path="/play" element={<ConfigRoute mode="freeplay" />} />
-        <Route path="/daily" element={<ConfigRoute mode="daily" />} />
+        <Route path="/daily" element={<DailyPuzzleRoute />} />
         <Route path="/daily/results" element={<DailyResultsRoute />} />
         <Route path="/game" element={<GameRoute />} />
         <Route path="/results" element={<ResultsRoute />} />

--- a/client/src/pages/config/GameConfigPage.tsx
+++ b/client/src/pages/config/GameConfigPage.tsx
@@ -64,16 +64,15 @@ export function GameConfigPage({ title, subtitle, card = true, disabled = false,
               type="button"
               onClick={onBack}
               className="
-                absolute left-0 top-0.5
-                flex items-center justify-center
-                bg-transparent border-none cursor-pointer
-                text-[0.85rem] text-[var(--text-muted)] hover:text-[var(--text)]
-                transition-all duration-200 select-none
+                absolute left-0 top-1/2 -translate-y-1/2
+                bg-transparent border-none cursor-pointer leading-none flex
+                text-lg text-[var(--text-muted)] hover:text-[var(--text)]
+                transition-colors duration-200 select-none
               "
               style={{ WebkitTapHighlightColor: "transparent" }}
               aria-label="Back"
             >
-              ←
+              &#8249;
             </button>
           )}
           <div className="text-center">

--- a/client/src/pages/daily/DailyPage.tsx
+++ b/client/src/pages/daily/DailyPage.tsx
@@ -15,7 +15,7 @@ export interface DailyPageProps {
   onStartPuzzle: () => void;
   onViewResults: (puzzleNumber: number) => void;
   onViewLeaderboard: (puzzleNumber: number) => void;
-  onShare: (puzzleNumber: number) => void;
+  getShareText: (puzzleNumber: number) => Promise<string>;
   onBack: () => void;
 }
 
@@ -28,7 +28,7 @@ export function DailyPage({
   onStartPuzzle,
   onViewResults,
   onViewLeaderboard,
-  onShare,
+  getShareText,
   onBack,
 }: DailyPageProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -66,16 +66,16 @@ export function DailyPage({
 
   return (
     <div
-      className="relative rounded-2xl pt-5.5 pb-4 overflow-hidden min-h-[580px]"
+      // className="relative rounded-2xl pt-5.5 pb-4 overflow-hidden min-h-[580px]"
       style={{ background: "var(--page-bg)" }}
     >
       <BlurOverlay visible={showOverlay} onClick={handleOverlayClick} />
 
       {/* Header */}
-      <div className="text-center mb-4.5 relative px-[18px]">
+      <div className="text-center mb-4.5 relative">
         <button
           type="button"
-          className="absolute left-[18px] top-1/2 -translate-y-1/2 text-lg cursor-pointer leading-none flex bg-transparent border-none"
+          className="absolute top-1/2 -translate-y-1/2 text-lg cursor-pointer leading-none flex bg-transparent border-none"
           style={{ color: "var(--text-muted)" }}
           onClick={onBack}
         >
@@ -111,14 +111,14 @@ export function DailyPage({
         onStartPuzzle={onStartPuzzle}
         onViewResults={onViewResults}
         onViewLeaderboard={onViewLeaderboard}
-        onShare={onShare}
+        getShareText={getShareText}
         onDefinitionExpand={handleDefinitionExpand}
         disabled={pickerOpen}
       />
 
       {/* Divider */}
       <div
-        className="mx-[18px] mt-3 mb-3"
+        className="mt-3 mb-3"
         style={{ borderTop: "0.5px solid var(--dot)" }}
       />
 

--- a/client/src/pages/daily/DailyPage.tsx
+++ b/client/src/pages/daily/DailyPage.tsx
@@ -1,0 +1,143 @@
+import { useState, useCallback } from "react";
+import type { DailyEntry, DailyStats } from "./types";
+import { BlurOverlay } from "./components/BlurOverlay";
+import { DateSelector } from "./components/DateSelector";
+import { CardCarousel } from "./components/CardCarousel";
+import { StreakCard } from "./components/StreakCard";
+import { StatsCard } from "./components/StatsCard";
+
+export interface DailyPageProps {
+  entries: DailyEntry[];
+  stats: DailyStats;
+  currentIndex: number;
+  nextPuzzleCountdown: string;
+  onChangeIndex: (index: number) => void;
+  onStartPuzzle: () => void;
+  onViewResults: (puzzleNumber: number) => void;
+  onViewLeaderboard: (puzzleNumber: number) => void;
+  onShare: (puzzleNumber: number) => void;
+  onBack: () => void;
+}
+
+export function DailyPage({
+  entries,
+  stats,
+  currentIndex,
+  nextPuzzleCountdown,
+  onChangeIndex,
+  onStartPuzzle,
+  onViewResults,
+  onViewLeaderboard,
+  onShare,
+  onBack,
+}: DailyPageProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [defExpanded, setDefExpanded] = useState(false);
+
+  const currentEntry = entries[currentIndex];
+  const showOverlay = pickerOpen || defExpanded;
+
+  function handleOverlayClick() {
+    if (pickerOpen) setPickerOpen(false);
+    if (defExpanded) setDefExpanded(false);
+  }
+
+  function handlePickerToggle() {
+    if (defExpanded) setDefExpanded(false);
+    setPickerOpen((prev) => !prev);
+  }
+
+  function handlePickerSelect(index: number) {
+    onChangeIndex(index);
+    setPickerOpen(false);
+  }
+
+  function handleIndexChange(index: number) {
+    setDefExpanded(false);
+    setPickerOpen(false);
+    onChangeIndex(index);
+  }
+
+  const handleDefinitionExpand = useCallback((expanded: boolean) => {
+    setDefExpanded(expanded);
+  }, []);
+
+  if (!currentEntry) return null;
+
+  return (
+    <div
+      className="relative rounded-2xl pt-5.5 pb-4 overflow-hidden min-h-[580px]"
+      style={{ background: "var(--page-bg)" }}
+    >
+      <BlurOverlay visible={showOverlay} onClick={handleOverlayClick} />
+
+      {/* Header */}
+      <div className="text-center mb-4.5 relative px-[18px]">
+        <button
+          type="button"
+          className="absolute left-[18px] top-1/2 -translate-y-1/2 text-lg cursor-pointer leading-none flex bg-transparent border-none"
+          style={{ color: "var(--text-muted)" }}
+          onClick={onBack}
+        >
+          &#8249;
+        </button>
+        <h2
+          className="text-[22px]"
+          style={{
+            color: "var(--text)",
+            fontFamily: "var(--font-heading)",
+            fontWeight: "var(--font-heading-weight)",
+          }}
+        >
+          Daily #{currentEntry.puzzleNumber}
+        </h2>
+      </div>
+
+      {/* Date selector + picker dropdown */}
+      <DateSelector
+        entries={entries}
+        currentIndex={currentIndex}
+        isOpen={pickerOpen}
+        onToggle={handlePickerToggle}
+        onSelect={handlePickerSelect}
+      />
+
+      {/* Card carousel */}
+      <CardCarousel
+        entries={entries}
+        currentIndex={currentIndex}
+        defExpanded={defExpanded}
+        onChangeIndex={handleIndexChange}
+        onStartPuzzle={onStartPuzzle}
+        onViewResults={onViewResults}
+        onViewLeaderboard={onViewLeaderboard}
+        onShare={onShare}
+        onDefinitionExpand={handleDefinitionExpand}
+        disabled={pickerOpen}
+      />
+
+      {/* Divider */}
+      <div
+        className="mx-[18px] mt-3 mb-3"
+        style={{ borderTop: "0.5px solid var(--dot)" }}
+      />
+
+      {/* Streak */}
+      <StreakCard stats={stats} />
+
+      {/* 7 day average */}
+      <StatsCard stats={stats} />
+
+      {/* Footer */}
+      <div
+        className="text-center text-[11px] mt-2.5"
+        style={{
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-sans)",
+        }}
+      >
+        Next puzzle in {nextPuzzleCountdown}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/DailyRoute.tsx
+++ b/client/src/pages/daily/DailyRoute.tsx
@@ -1,0 +1,118 @@
+import { useState, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useGame } from "../../GameContext";
+import { DailyPage } from "./DailyPage";
+import type { DailyEntry, DailyStats } from "./types";
+
+export function DailyPuzzleRoute() {
+  const navigate = useNavigate();
+  const game = useGame();
+
+  // ── Data mapping ─────────────────────────────────────────────
+  // TODO: Replace stubs with actual data from useGame().
+  //
+  // Build the entries array from your daily history. Each entry
+  // maps a DailyInfo + the player's result for that day into the
+  // shape the page component expects.
+  //
+  // Example:
+  //
+  // const entries: DailyEntry[] = useMemo(() => {
+  //   return game.dailyHistory.map((daily) => ({
+  //     puzzleNumber: daily.number,
+  //     date: new Date(daily.date),
+  //     state: daily.completed
+  //       ? "completed"
+  //       : daily.isToday
+  //         ? "unplayed"
+  //         : "missed",
+  //     points: daily.score,
+  //     wordsFound: daily.wordsFound,
+  //     longestWord: daily.longestWord,
+  //     longestWordDefinition: daily.longestWordDefinition,
+  //     stampTier: daily.stampTier ?? null,
+  //     playersCount: daily.playersCount,
+  //     config: daily.config,
+  //   }));
+  // }, [game.dailyHistory]);
+
+  const entries: DailyEntry[] = useMemo(() => [], []);
+
+  const stats: DailyStats = useMemo(
+    () => ({
+      currentStreak: 0,
+      streakDays: [false, false, false, false, false, false, false],
+      avgPoints: 0,
+      avgWords: 0,
+    }),
+    [],
+  );
+
+  // ── Index state ──────────────────────────────────────────────
+  // Start on the most recent entry (today)
+  const [currentIndex, setCurrentIndex] = useState(
+    Math.max(entries.length - 1, 0),
+  );
+
+  // ── Countdown ────────────────────────────────────────────────
+  const nextPuzzleCountdown = useMemo(() => {
+    const now = new Date();
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(0, 0, 0, 0);
+    const diff = tomorrow.getTime() - now.getTime();
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor(
+      (diff % (1000 * 60 * 60)) / (1000 * 60),
+    );
+    return `${hours}h ${minutes}m`;
+  }, []);
+
+  // ── Handlers ─────────────────────────────────────────────────
+  const handleChangeIndex = useCallback((index: number) => {
+    setCurrentIndex(index);
+  }, []);
+
+  const handleStartPuzzle = useCallback(() => {
+    // TODO: Adjust route to match your router config
+    navigate("/daily/play");
+  }, [navigate]);
+
+  const handleViewResults = useCallback(
+    (puzzleNumber: number) => {
+      navigate(`/daily/${puzzleNumber}/results`);
+    },
+    [navigate],
+  );
+
+  const handleViewLeaderboard = useCallback(
+    (puzzleNumber: number) => {
+      navigate(`/daily/${puzzleNumber}/leaderboard`);
+    },
+    [navigate],
+  );
+
+  const handleShare = useCallback((_puzzleNumber: number) => {
+    // TODO: Implement share (Web Share API, clipboard fallback, etc.)
+  }, []);
+
+  const handleBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  // ── Render ───────────────────────────────────────────────────
+  return (
+    <DailyPage
+      entries={entries}
+      stats={stats}
+      currentIndex={currentIndex}
+      nextPuzzleCountdown={nextPuzzleCountdown}
+      onChangeIndex={handleChangeIndex}
+      onStartPuzzle={handleStartPuzzle}
+      onViewResults={handleViewResults}
+      onViewLeaderboard={handleViewLeaderboard}
+      onShare={handleShare}
+      onBack={handleBack}
+    />
+  );
+}

--- a/client/src/pages/daily/DailyRoute.tsx
+++ b/client/src/pages/daily/DailyRoute.tsx
@@ -1,106 +1,188 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useGame } from "../../GameContext";
 import { DailyPage } from "./DailyPage";
 import type { DailyEntry, DailyStats } from "./types";
+import {
+  fetchDailyStats,
+  fetchDailyResult,
+  type DailyInfo,
+  type DailyStatsResponse,
+  type DailyStatsDay,
+} from "../../shared/api/gameApi";
+import { scoreWord } from "engine/scoring";
+import { generateShareText } from "../results/utils/shareResults";
+
+function adaptDay(day: DailyStatsDay, config: DailyInfo["config"]): DailyEntry {
+  return {
+    puzzleNumber: day.puzzleNumber,
+    date: new Date(day.date + "T12:00:00"),
+    state: day.state,
+    points: day.points ?? undefined,
+    wordsFound: day.wordsFound ?? undefined,
+    longestWord: day.longestWord ?? undefined,
+    longestWordDefinition: day.longestWordDefinition,
+    stampTier: day.stampTier,
+    playersCount: day.playersCount,
+    config,
+  };
+}
+
+// Countdown to next PST midnight, rendered in the user's local clock.
+function useCountdownToNextPuzzle(): string {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return useMemo(() => {
+    const pstNowStr = new Date(now).toLocaleString("en-US", {
+      timeZone: "America/Los_Angeles",
+    });
+    const pstNow = new Date(pstNowStr);
+    const pstMidnight = new Date(pstNow);
+    pstMidnight.setHours(24, 0, 0, 0);
+    const diffMs = pstMidnight.getTime() - pstNow.getTime();
+    const hours = Math.max(0, Math.floor(diffMs / (1000 * 60 * 60)));
+    const minutes = Math.max(
+      0,
+      Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60)),
+    );
+    return `${hours}h ${minutes}m`;
+  }, [now]);
+}
 
 export function DailyPuzzleRoute() {
   const navigate = useNavigate();
-  const game = useGame();
+  const {
+    dailyInfo,
+    setDailyInfo,
+    refreshDaily,
+    createGame,
+    startGame,
+    game,
+  } = useGame();
 
-  // ── Data mapping ─────────────────────────────────────────────
-  // TODO: Replace stubs with actual data from useGame().
-  //
-  // Build the entries array from your daily history. Each entry
-  // maps a DailyInfo + the player's result for that day into the
-  // shape the page component expects.
-  //
-  // Example:
-  //
-  // const entries: DailyEntry[] = useMemo(() => {
-  //   return game.dailyHistory.map((daily) => ({
-  //     puzzleNumber: daily.number,
-  //     date: new Date(daily.date),
-  //     state: daily.completed
-  //       ? "completed"
-  //       : daily.isToday
-  //         ? "unplayed"
-  //         : "missed",
-  //     points: daily.score,
-  //     wordsFound: daily.wordsFound,
-  //     longestWord: daily.longestWord,
-  //     longestWordDefinition: daily.longestWordDefinition,
-  //     stampTier: daily.stampTier ?? null,
-  //     playersCount: daily.playersCount,
-  //     config: daily.config,
-  //   }));
-  // }, [game.dailyHistory]);
+  const [statsResponse, setStatsResponse] = useState<DailyStatsResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
-  const entries: DailyEntry[] = useMemo(() => [], []);
+  // Fetch stats + daily info in parallel. dailyInfo may already be in context
+  // from an earlier visit; refresh so puzzle number and board are current.
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchDailyStats(), refreshDaily()])
+      .then(([stats, info]) => {
+        if (cancelled) return;
+        setStatsResponse(stats);
+        setDailyInfo(info);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setLoadError(err.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // refreshDaily and setDailyInfo are stable context fns
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const entries: DailyEntry[] = useMemo(() => {
+    if (!statsResponse || !dailyInfo) return [];
+    return statsResponse.days.map((d) => adaptDay(d, dailyInfo.config));
+  }, [statsResponse, dailyInfo]);
 
   const stats: DailyStats = useMemo(
     () => ({
-      currentStreak: 0,
-      streakDays: [false, false, false, false, false, false, false],
-      avgPoints: 0,
-      avgWords: 0,
+      currentStreak: statsResponse?.currentStreak ?? 0,
+      streakDays: statsResponse?.streakDays ?? Array(7).fill(false),
+      avgPoints: statsResponse?.avgPoints ?? 0,
+      avgWords: statsResponse?.avgWords ?? 0,
     }),
-    [],
+    [statsResponse],
   );
 
-  // ── Index state ──────────────────────────────────────────────
-  // Start on the most recent entry (today)
-  const [currentIndex, setCurrentIndex] = useState(
-    Math.max(entries.length - 1, 0),
-  );
+  const [currentIndex, setCurrentIndex] = useState(0);
+  useEffect(() => {
+    if (entries.length > 0) setCurrentIndex(entries.length - 1);
+  }, [entries.length]);
 
-  // ── Countdown ────────────────────────────────────────────────
-  const nextPuzzleCountdown = useMemo(() => {
-    const now = new Date();
-    const tomorrow = new Date(now);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 0, 0, 0);
-    const diff = tomorrow.getTime() - now.getTime();
-    const hours = Math.floor(diff / (1000 * 60 * 60));
-    const minutes = Math.floor(
-      (diff % (1000 * 60 * 60)) / (1000 * 60),
-    );
-    return `${hours}h ${minutes}m`;
-  }, []);
+  const nextPuzzleCountdown = useCountdownToNextPuzzle();
 
-  // ── Handlers ─────────────────────────────────────────────────
   const handleChangeIndex = useCallback((index: number) => {
     setCurrentIndex(index);
   }, []);
 
-  const handleStartPuzzle = useCallback(() => {
-    // TODO: Adjust route to match your router config
-    navigate("/daily/play");
-  }, [navigate]);
+  // Start today's daily puzzle directly — no config step.
+  const handleStartPuzzle = useCallback(async () => {
+    if (!dailyInfo) return;
+    if (!game) await createGame();
+    await startGame(
+      dailyInfo.config.timeLimit,
+      dailyInfo.config.boardSize,
+      dailyInfo.config.minWordLength,
+      undefined,
+      dailyInfo.seed,
+    );
+    navigate("/game");
+  }, [dailyInfo, game, createGame, startGame, navigate]);
 
   const handleViewResults = useCallback(
-    (puzzleNumber: number) => {
-      navigate(`/daily/${puzzleNumber}/results`);
+    (_puzzleNumber: number) => {
+      navigate(`/daily/results`);
     },
     [navigate],
   );
 
   const handleViewLeaderboard = useCallback(
-    (puzzleNumber: number) => {
-      navigate(`/daily/${puzzleNumber}/leaderboard`);
+    (_puzzleNumber: number) => {
+      navigate(`/leaderboard`);
     },
     [navigate],
   );
 
-  const handleShare = useCallback((_puzzleNumber: number) => {
-    // TODO: Implement share (Web Share API, clipboard fallback, etc.)
-  }, []);
+  // Given a puzzle number in the current window, build the share text the
+  // same way the results page does: fetch the submission, score each word
+  // client-side, then generate the emoji histogram + link block.
+  const getShareText = useCallback(
+    async (puzzleNumber: number): Promise<string> => {
+      const entry = entries.find((e) => e.puzzleNumber === puzzleNumber);
+      if (!entry) return "";
+      const dateStr = entry.date.toISOString().slice(0, 10);
+      const result = await fetchDailyResult(dateStr);
+      if (!result) return "";
+      const scoredWords = result.found_words.map((word) => ({
+        word,
+        path: [],
+        score: scoreWord(word),
+      }));
+      return generateShareText(scoredWords, { daily: { number: puzzleNumber } });
+    },
+    [entries],
+  );
 
   const handleBack = useCallback(() => {
-    navigate(-1);
+    navigate("/");
   }, [navigate]);
 
-  // ── Render ───────────────────────────────────────────────────
+  if (loadError) {
+    return (
+      <div className="p-8 text-center" style={{ color: "var(--text-muted)" }}>
+        Couldn't load daily stats: {loadError}
+      </div>
+    );
+  }
+
+  if (!statsResponse || !dailyInfo) {
+    return (
+      <div className="p-8 text-center" style={{ color: "var(--text-muted)" }}>
+        Loading…
+      </div>
+    );
+  }
+
   return (
     <DailyPage
       entries={entries}
@@ -111,7 +193,7 @@ export function DailyPuzzleRoute() {
       onStartPuzzle={handleStartPuzzle}
       onViewResults={handleViewResults}
       onViewLeaderboard={handleViewLeaderboard}
-      onShare={handleShare}
+      getShareText={getShareText}
       onBack={handleBack}
     />
   );

--- a/client/src/pages/daily/components/BlurOverlay.tsx
+++ b/client/src/pages/daily/components/BlurOverlay.tsx
@@ -1,0 +1,16 @@
+interface BlurOverlayProps {
+  visible: boolean;
+  onClick: () => void;
+}
+
+export function BlurOverlay({ visible, onClick }: BlurOverlayProps) {
+  if (!visible) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-5 rounded-2xl backdrop-blur-sm"
+      style={{ background: "var(--page-bg)", opacity: 0.7 }}
+      onClick={onClick}
+    />
+  );
+}

--- a/client/src/pages/daily/components/BlurOverlay.tsx
+++ b/client/src/pages/daily/components/BlurOverlay.tsx
@@ -8,8 +8,10 @@ export function BlurOverlay({ visible, onClick }: BlurOverlayProps) {
 
   return (
     <div
-      className="absolute inset-0 z-5 rounded-2xl backdrop-blur-sm"
-      style={{ background: "var(--page-bg)", opacity: 0.7 }}
+      className="absolute inset-0 z-5 rounded-2xl backdrop-blur-xs"
+      style={{
+        background: "color-mix(in srgb, var(--page-bg) 40%, transparent)",
+      }}
       onClick={onClick}
     />
   );

--- a/client/src/pages/daily/components/BlurOverlay.tsx
+++ b/client/src/pages/daily/components/BlurOverlay.tsx
@@ -6,9 +6,13 @@ interface BlurOverlayProps {
 export function BlurOverlay({ visible, onClick }: BlurOverlayProps) {
   if (!visible) return null;
 
+  // Fixed + inset:0 so the blur covers the entire viewport. Using the
+  // page's container bounds would leave the App-level 20px padding
+  // unblurred (visible as an edge strip), which breaks the illusion
+  // that the whole UI is de-emphasized.
   return (
     <div
-      className="absolute inset-0 z-5 rounded-2xl backdrop-blur-xs"
+      className="fixed inset-0 z-10 backdrop-blur-xs"
       style={{
         background: "color-mix(in srgb, var(--page-bg) 40%, transparent)",
       }}

--- a/client/src/pages/daily/components/CardActions.tsx
+++ b/client/src/pages/daily/components/CardActions.tsx
@@ -1,35 +1,120 @@
+import { useState, useRef, useEffect } from "react";
 import { Button } from "../../../shared/components/Button";
 
 interface CardActionsProps {
   isCompleted: boolean;
   onResults: () => void;
   onLeaderboard: () => void;
-  onShare: () => void;
+  getShareText: () => Promise<string>;
 }
 
 export function CardActions({
   isCompleted,
   onResults,
   onLeaderboard,
-  onShare,
+  getShareText,
 }: CardActionsProps) {
+  const [shareOpen, setShareOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const shareRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!shareOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (shareRef.current && !shareRef.current.contains(e.target as Node)) {
+        setShareOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [shareOpen]);
+
+  const canNativeShare = typeof navigator !== "undefined" && !!navigator.share;
+
+  const handleNativeShare = async () => {
+    try {
+      const text = await getShareText();
+      await navigator.share({ text });
+    } catch {
+      // User cancelled or share failed — nothing more to do.
+    }
+    setShareOpen(false);
+  };
+
+  const handleCopy = async () => {
+    try {
+      const text = await getShareText();
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      // Revert the label after a moment; leave the popover open — the user
+      // dismisses it themselves (matches ResultsPage). Auto-closing here
+      // used to race with a quick reopen and flash the popover shut.
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setShareOpen(false);
+    }
+  };
+
   return (
     <div className="flex gap-1.5 mt-2">
-      <ActionButton
-        label="Results"
-        disabled={!isCompleted}
-        onClick={onResults}
-      />
-      <ActionButton
-        label="Leaderboard"
-        disabled={false}
-        onClick={onLeaderboard}
-      />
-      <ActionButton
-        label="Share"
-        disabled={!isCompleted}
-        onClick={onShare}
-      />
+      <div className="flex-1">
+        <ActionButton label="Results" disabled={!isCompleted} onClick={onResults} />
+      </div>
+      <div className="flex-1">
+        <ActionButton label="Leaderboard" disabled={false} onClick={onLeaderboard} />
+      </div>
+
+      <div className="flex-1 relative" ref={shareRef}>
+        <ActionButton
+          label="Share"
+          disabled={!isCompleted}
+          onClick={() => setShareOpen((v) => !v)}
+        />
+        {shareOpen && (
+          <div className="absolute bottom-[calc(100%+6px)] right-0 bg-white border border-[#e0e0e0] rounded-[10px] shadow-[0_4px_16px_rgba(0,0,0,0.1),0_1px_4px_rgba(0,0,0,0.06)] overflow-hidden min-w-[170px] z-30">
+            {canNativeShare && (
+              <button
+                type="button"
+                className="flex items-center gap-2 w-full py-2.5 px-3.5 bg-transparent border-none text-[13px] font-semibold text-[#555] cursor-pointer transition-colors duration-100 text-left whitespace-nowrap hover:bg-[#f5f5f5] active:bg-[#eee]"
+                style={{ WebkitTapHighlightColor: "transparent" }}
+                onClick={handleNativeShare}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="18" cy="5" r="3" />
+                  <circle cx="6" cy="12" r="3" />
+                  <circle cx="18" cy="19" r="3" />
+                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                </svg>
+                Share to...
+              </button>
+            )}
+            <button
+              type="button"
+              className={`flex items-center gap-2 w-full py-2.5 px-3.5 bg-transparent border-none text-[13px] font-semibold text-[#555] cursor-pointer transition-colors duration-100 text-left whitespace-nowrap hover:bg-[#f5f5f5] active:bg-[#eee] ${canNativeShare ? "border-t border-t-[#f0f0f0]" : ""}`}
+              style={{ WebkitTapHighlightColor: "transparent" }}
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                  Copy to clipboard
+                </>
+              )}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -45,7 +130,7 @@ function ActionButton({ label, disabled, onClick }: ActionButtonProps) {
     <Button
       type="button"
       size="sm"
-      className="flex-1 rounded-[10px] py-2.5 px-1 text-center text-xs cursor-pointer"
+      className="w-full rounded-[10px] py-2.5 px-1 text-center text-xs cursor-pointer"
       style={{
         background: "var(--track)",
         color: "var(--text)",

--- a/client/src/pages/daily/components/CardActions.tsx
+++ b/client/src/pages/daily/components/CardActions.tsx
@@ -1,0 +1,64 @@
+import { Button } from "../../../shared/components/Button";
+
+interface CardActionsProps {
+  isCompleted: boolean;
+  onResults: () => void;
+  onLeaderboard: () => void;
+  onShare: () => void;
+}
+
+export function CardActions({
+  isCompleted,
+  onResults,
+  onLeaderboard,
+  onShare,
+}: CardActionsProps) {
+  return (
+    <div className="flex gap-1.5 mt-2">
+      <ActionButton
+        label="Results"
+        disabled={!isCompleted}
+        onClick={onResults}
+      />
+      <ActionButton
+        label="Leaderboard"
+        disabled={false}
+        onClick={onLeaderboard}
+      />
+      <ActionButton
+        label="Share"
+        disabled={!isCompleted}
+        onClick={onShare}
+      />
+    </div>
+  );
+}
+
+interface ActionButtonProps {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function ActionButton({ label, disabled, onClick }: ActionButtonProps) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      className="flex-1 rounded-[10px] py-2.5 px-1 text-center text-xs cursor-pointer"
+      style={{
+        background: "var(--track)",
+        color: "var(--text)",
+        fontFamily: "var(--font-sans)",
+        fontWeight: 600,
+        opacity: disabled ? 0.3 : 1,
+        cursor: disabled ? "default" : "pointer",
+        pointerEvents: disabled ? "none" : "auto",
+      }}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/client/src/pages/daily/components/CardCarousel.tsx
+++ b/client/src/pages/daily/components/CardCarousel.tsx
@@ -223,69 +223,79 @@ export function CardCarousel({
   }, [handleDragMove, handleDragEnd]);
 
   // ── Render ───────────────────────────────────────────────────
+  const currentEntry = entries[currentIndex];
+
   return (
-    <div
-      ref={carouselRef}
-      className={`relative mb-3.5 ${defExpanded ? "z-12" : "z-1"}`}
-      style={{
-        height: carouselHeight > 0 ? carouselHeight : "auto",
-        overflowX: "clip",
-        overflowY: defExpanded ? "visible" : "hidden",
-      }}
-    >
+    <>
       <div
-        ref={trackRef}
-        className="flex will-change-transform select-none"
-        style={{ gap: `${GAP}px` }}
-        onMouseDown={onMouseDown}
-        onTouchStart={onTouchStart}
+        ref={carouselRef}
+        className={`relative ${defExpanded ? "z-12" : "z-1"}`}
+        style={{
+          height: carouselHeight > 0 ? carouselHeight : "auto",
+          overflowX: "clip",
+          overflowY: defExpanded ? "visible" : "hidden",
+        }}
       >
-        {entries.map((entry, index) => {
-          let card: ReactNode;
+        <div
+          ref={trackRef}
+          className="flex will-change-transform select-none"
+          style={{ gap: `${GAP}px` }}
+          onMouseDown={onMouseDown}
+          onTouchStart={onTouchStart}
+        >
+          {entries.map((entry, index) => {
+            let card: ReactNode;
 
-          if (entry.state === "unplayed") {
-            card = (
-              <UnplayedCard
-                config={entry.config}
-                onStart={onStartPuzzle}
-              />
-            );
-          } else if (entry.state === "missed") {
-            card = (
-              <MissedCard
-                puzzleNumber={entry.puzzleNumber}
-                playersCount={entry.playersCount}
-              />
-            );
-          } else {
-            card = (
-              <CompletedCard
-                entry={entry}
-                expanded={defExpanded && index === currentIndex}
-                onExpandChange={onDefinitionExpand}
-              />
-            );
-          }
-
-          return (
-            <div
-              key={entry.puzzleNumber}
-              data-card-slot
-              className="shrink-0 flex flex-col"
-            >
-              <div className="flex-1 flex flex-col">
-                {card}
-                <CardActions
-                  isCompleted={entry.state === "completed"}
-                  onResults={() => onViewResults(entry.puzzleNumber)}
-                  onLeaderboard={() => onViewLeaderboard(entry.puzzleNumber)}
-                  onShare={() => onShare(entry.puzzleNumber)}
+            if (entry.state === "unplayed") {
+              card = (
+                <UnplayedCard
+                  config={entry.config}
+                  onStart={onStartPuzzle}
                 />
+              );
+            } else if (entry.state === "missed") {
+              card = (
+                <MissedCard
+                  puzzleNumber={entry.puzzleNumber}
+                  playersCount={entry.playersCount}
+                />
+              );
+            } else {
+              card = (
+                <CompletedCard
+                  entry={entry}
+                  expanded={defExpanded && index === currentIndex}
+                  onExpandChange={onDefinitionExpand}
+                />
+              );
+            }
+
+            return (
+              <div
+                key={entry.puzzleNumber}
+                data-card-slot
+                className="shrink-0 flex flex-col"
+              >
+                {card}
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      {/* Card actions — rendered outside the carousel so they stay fixed in
+          place (and get covered by the blur overlay) when the current card's
+          definition is expanded. */}
+      {currentEntry && (
+        <div className="mx-[18px] mt-2 mb-3.5">
+          <CardActions
+            isCompleted={currentEntry.state === "completed"}
+            onResults={() => onViewResults(currentEntry.puzzleNumber)}
+            onLeaderboard={() => onViewLeaderboard(currentEntry.puzzleNumber)}
+            onShare={() => onShare(currentEntry.puzzleNumber)}
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/client/src/pages/daily/components/CardCarousel.tsx
+++ b/client/src/pages/daily/components/CardCarousel.tsx
@@ -19,7 +19,7 @@ interface CardCarouselProps {
   onStartPuzzle: () => void;
   onViewResults: (puzzleNumber: number) => void;
   onViewLeaderboard: (puzzleNumber: number) => void;
-  onShare: (puzzleNumber: number) => void;
+  getShareText: (puzzleNumber: number) => Promise<string>;
   onDefinitionExpand: (expanded: boolean) => void;
   /** When true, swipe gestures are ignored (e.g. picker is open) */
   disabled?: boolean;
@@ -49,7 +49,7 @@ export function CardCarousel({
   onStartPuzzle,
   onViewResults,
   onViewLeaderboard,
-  onShare,
+  getShareText,
   onDefinitionExpand,
   disabled = false,
 }: CardCarouselProps) {
@@ -234,6 +234,7 @@ export function CardCarousel({
           height: carouselHeight > 0 ? carouselHeight : "auto",
           overflowX: "clip",
           overflowY: defExpanded ? "visible" : "hidden",
+          marginInline: -20
         }}
       >
         <div
@@ -287,12 +288,12 @@ export function CardCarousel({
           place (and get covered by the blur overlay) when the current card's
           definition is expanded. */}
       {currentEntry && (
-        <div className="mx-[18px] mt-2 mb-3.5">
+        <div className="mt-2 mb-3.5">
           <CardActions
             isCompleted={currentEntry.state === "completed"}
             onResults={() => onViewResults(currentEntry.puzzleNumber)}
             onLeaderboard={() => onViewLeaderboard(currentEntry.puzzleNumber)}
-            onShare={() => onShare(currentEntry.puzzleNumber)}
+            getShareText={() => getShareText(currentEntry.puzzleNumber)}
           />
         </div>
       )}

--- a/client/src/pages/daily/components/CardCarousel.tsx
+++ b/client/src/pages/daily/components/CardCarousel.tsx
@@ -1,0 +1,291 @@
+import {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+import type { DailyEntry } from "../types";
+import { CompletedCard } from "./CompletedCard";
+import { UnplayedCard } from "./UnplayedCard";
+import { MissedCard } from "./MissedCard";
+import { CardActions } from "./CardActions";
+
+interface CardCarouselProps {
+  entries: DailyEntry[];
+  currentIndex: number;
+  defExpanded: boolean;
+  onChangeIndex: (index: number) => void;
+  onStartPuzzle: () => void;
+  onViewResults: (puzzleNumber: number) => void;
+  onViewLeaderboard: (puzzleNumber: number) => void;
+  onShare: (puzzleNumber: number) => void;
+  onDefinitionExpand: (expanded: boolean) => void;
+  /** When true, swipe gestures are ignored (e.g. picker is open) */
+  disabled?: boolean;
+}
+
+/**
+ * Horizontal padding on each side of the carousel.
+ * Cards are sized as (containerWidth - PAD * 2), so adjacent cards
+ * peek by PAD pixels on each side.
+ */
+const PAD = 18;
+
+/** Gap between card slots in px */
+const GAP = 6;
+
+/** Minimum drag distance (px) before it counts as a move rather than a tap */
+const MOVE_THRESHOLD = 5;
+
+/** Fraction of card width you need to drag before it snaps to the next card */
+const SWIPE_THRESHOLD = 0.15;
+
+export function CardCarousel({
+  entries,
+  currentIndex,
+  defExpanded,
+  onChangeIndex,
+  onStartPuzzle,
+  onViewResults,
+  onViewLeaderboard,
+  onShare,
+  onDefinitionExpand,
+  disabled = false,
+}: CardCarouselProps) {
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [cardWidth, setCardWidth] = useState(0);
+  const [carouselHeight, setCarouselHeight] = useState(0);
+
+  // Drag state lives in a ref so event handlers always see current values
+  // without causing re-renders on every pointermove.
+  const drag = useRef({
+    active: false,
+    startX: 0,
+    deltaX: 0,
+    moved: false,
+  });
+
+  const step = cardWidth + GAP;
+
+  /** Pixel offset for the track transform at the current index */
+  const getOffset = useCallback(
+    (idx: number) => -(idx * step) + PAD,
+    [step],
+  );
+
+  // ── Measurement ──────────────────────────────────────────────
+  const measure = useCallback(() => {
+    const carousel = carouselRef.current;
+    const track = trackRef.current;
+    if (!carousel || !track) return;
+
+    const containerW = carousel.offsetWidth;
+    const cW = containerW - PAD * 2;
+    setCardWidth(cW);
+
+    // Size each slot and find the tallest
+    const slots = track.querySelectorAll<HTMLElement>("[data-card-slot]");
+    slots.forEach((s) => {
+      s.style.width = `${cW}px`;
+      s.style.height = "auto";
+    });
+
+    let maxH = 0;
+    slots.forEach((s) => {
+      if (s.scrollHeight > maxH) maxH = s.scrollHeight;
+    });
+
+    setCarouselHeight(maxH);
+    slots.forEach((s) => {
+      s.style.height = `${maxH}px`;
+    });
+  }, []);
+
+  useEffect(() => {
+    // Measure after first paint so slots have their content
+    requestAnimationFrame(measure);
+
+    // Use ResizeObserver on the carousel container so we re-measure
+    // whenever it changes size (e.g. parent layout shift, panel resize),
+    // not only on window resize.
+    const el = carouselRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measure, entries.length]);
+
+  // ── Track transform helpers ──────────────────────────────────
+  function applyTransform(offset: number, animate: boolean) {
+    const track = trackRef.current;
+    if (!track) return;
+    track.style.transition = animate
+      ? "transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1)"
+      : "none";
+    track.style.transform = `translateX(${offset}px)`;
+  }
+
+  // Animate to the current index whenever it changes
+  useEffect(() => {
+    if (cardWidth > 0) {
+      applyTransform(getOffset(currentIndex), true);
+    }
+  }, [currentIndex, cardWidth, getOffset]);
+
+  // ── Drag / swipe handling ────────────────────────────────────
+  function shouldIgnoreTarget(target: EventTarget | null): boolean {
+    if (!target || !(target instanceof HTMLElement)) return false;
+    return !!(
+      target.closest("[data-chevron-btn]") ||
+      target.closest("[data-start-btn]")
+    );
+  }
+
+  function handleDragStart(clientX: number) {
+    if (disabled || defExpanded) return;
+    drag.current = { active: true, startX: clientX, deltaX: 0, moved: false };
+  }
+
+  const handleDragMove = useCallback(
+    (clientX: number) => {
+      if (!drag.current.active) return;
+      const delta = clientX - drag.current.startX;
+      drag.current.deltaX = delta;
+      if (Math.abs(delta) > MOVE_THRESHOLD) drag.current.moved = true;
+      applyTransform(getOffset(currentIndex) + delta, false);
+    },
+    [currentIndex, getOffset],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    if (!drag.current.active) return;
+    drag.current.active = false;
+
+    if (!drag.current.moved) {
+      // It was a tap, not a swipe — snap back without animation flicker
+      applyTransform(getOffset(currentIndex), false);
+      return;
+    }
+
+    const threshold = cardWidth * SWIPE_THRESHOLD;
+    const delta = drag.current.deltaX;
+
+    if (delta > threshold && currentIndex > 0) {
+      onChangeIndex(currentIndex - 1);
+    } else if (delta < -threshold && currentIndex < entries.length - 1) {
+      onChangeIndex(currentIndex + 1);
+    } else {
+      applyTransform(getOffset(currentIndex), true);
+    }
+  }, [cardWidth, currentIndex, entries.length, getOffset, onChangeIndex]);
+
+  // Mouse events on the track element
+  function onMouseDown(e: React.MouseEvent) {
+    if (shouldIgnoreTarget(e.target)) return;
+    handleDragStart(e.clientX);
+  }
+
+  // Touch events on the track element
+  function onTouchStart(e: React.TouchEvent) {
+    if (shouldIgnoreTarget(e.target)) return;
+    handleDragStart(e.touches[0].clientX);
+  }
+
+  // Global move/end listeners so dragging works even if pointer leaves the track
+  useEffect(() => {
+    function onMouseMove(e: MouseEvent) {
+      handleDragMove(e.clientX);
+    }
+    function onMouseUp() {
+      handleDragEnd();
+    }
+    function onTouchMove(e: TouchEvent) {
+      handleDragMove(e.touches[0].clientX);
+    }
+    function onTouchEnd() {
+      handleDragEnd();
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("touchmove", onTouchMove, { passive: true });
+    document.addEventListener("touchend", onTouchEnd);
+
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [handleDragMove, handleDragEnd]);
+
+  // ── Render ───────────────────────────────────────────────────
+  return (
+    <div
+      ref={carouselRef}
+      className={`relative mb-3.5 ${defExpanded ? "z-12" : "z-1"}`}
+      style={{
+        height: carouselHeight > 0 ? carouselHeight : "auto",
+        overflowX: "clip",
+        overflowY: defExpanded ? "visible" : "hidden",
+      }}
+    >
+      <div
+        ref={trackRef}
+        className="flex will-change-transform select-none"
+        style={{ gap: `${GAP}px` }}
+        onMouseDown={onMouseDown}
+        onTouchStart={onTouchStart}
+      >
+        {entries.map((entry, index) => {
+          let card: ReactNode;
+
+          if (entry.state === "unplayed") {
+            card = (
+              <UnplayedCard
+                config={entry.config}
+                onStart={onStartPuzzle}
+              />
+            );
+          } else if (entry.state === "missed") {
+            card = (
+              <MissedCard
+                puzzleNumber={entry.puzzleNumber}
+                playersCount={entry.playersCount}
+              />
+            );
+          } else {
+            card = (
+              <CompletedCard
+                entry={entry}
+                expanded={defExpanded && index === currentIndex}
+                onExpandChange={onDefinitionExpand}
+              />
+            );
+          }
+
+          return (
+            <div
+              key={entry.puzzleNumber}
+              data-card-slot
+              className="shrink-0 flex flex-col"
+            >
+              <div className="flex-1 flex flex-col">
+                {card}
+                <CardActions
+                  isCompleted={entry.state === "completed"}
+                  onResults={() => onViewResults(entry.puzzleNumber)}
+                  onLeaderboard={() => onViewLeaderboard(entry.puzzleNumber)}
+                  onShare={() => onShare(entry.puzzleNumber)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/CompletedCard.tsx
+++ b/client/src/pages/daily/components/CompletedCard.tsx
@@ -1,0 +1,163 @@
+import type { DailyEntry } from "../types";
+import { formatConfig } from "../utils";
+import { PerformanceStamp } from "./PerformanceStamp";
+import { DefinitionArea } from "./DefinitionArea";
+
+interface CompletedCardProps {
+  entry: DailyEntry;
+  expanded: boolean;
+  onExpandChange: (expanded: boolean) => void;
+}
+
+/** Fixed parchment color used for the card background and fade gradient */
+const CARD_BG = "#e6e0d2";
+const CARD_BORDER = "#d4cec0";
+const CARD_TEXT = "#2c2820";
+const CARD_TEXT_MUTED = "#8a8378";
+const TEAR_COLOR = "#cdc5b4";
+
+export function CompletedCard({
+  entry,
+  expanded,
+  onExpandChange,
+}: CompletedCardProps) {
+  const { boardLabel, timerLabel, lettersLabel } = formatConfig(entry.config);
+
+  return (
+    <div
+      className="rounded-[14px] flex-1 flex flex-col overflow-hidden"
+      style={{
+        background: CARD_BG,
+        border: `0.5px solid ${CARD_BORDER}`,
+      }}
+    >
+      {/* Header: puzzle number, player count, stamps */}
+      <div className="px-4 pt-3.5 pb-2.5 min-h-[165px]">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2" style={{fontFamily:"var(--font-sans)"}}>
+            <span
+              className="text-xs"
+              style={{
+                color: CARD_TEXT_MUTED,
+                fontWeight: 600,
+              }}
+            >
+              #{entry.puzzleNumber}
+            </span>
+            <span
+              className="text-[10px] flex items-center gap-[3px]"
+              style={{ color: CARD_TEXT_MUTED }}
+            >
+              <svg
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                className="w-2.5 h-2.5"
+              >
+                <circle cx="8" cy="5" r="3" />
+                <path d="M2 14c0-3 2.5-5 6-5s6 2 6 5" />
+              </svg>
+              {entry.playersCount}
+            </span>
+          </div>
+          <PerformanceStamp tier={entry.stampTier} />
+        </div>
+
+        {/* Word showcase */}
+        <div
+          className="text-[11px] mb-1.5"
+          style={{
+            color: CARD_TEXT_MUTED,
+            fontFamily: "var(--font-sans)",
+          }}
+        >
+          Longest word
+        </div>
+        <div
+          className="text-[26px] mb-1"
+          style={{
+            color: CARD_TEXT,
+            fontFamily: "var(--font-heading)",
+            fontWeight: 700,
+          }}
+        >
+          {entry.longestWord}
+        </div>
+
+        {/* Expandable definition */}
+        <DefinitionArea
+          word={entry.longestWord ?? ""}
+          definition={entry.longestWordDefinition ?? ""}
+          expanded={expanded}
+          onExpandChange={onExpandChange}
+          color={CARD_TEXT_MUTED}
+        />
+      </div>
+
+      {/* Tear line */}
+      <div
+        className="mx-3.5"
+        style={{ borderTop: `2px dashed ${TEAR_COLOR}` }}
+      />
+
+      {/* Stats row */}
+      <div
+        className="flex justify-around py-3 px-4 text-center"
+        style={{
+            color: CARD_TEXT,
+            fontFamily: "var(--font-sans)",
+            fontWeight: 600,
+        }}>
+        <div className="flex-1">
+          <div
+            className="text-xl"
+            style={{
+              fontWeight: 600,
+            }}
+          >
+            {entry.points}
+          </div>
+          <div
+            className="text-[10px] mt-0.5"
+            style={{ color: CARD_TEXT_MUTED, fontWeight: 400 }}
+          >
+            points
+          </div>
+        </div>
+        <div className="flex-1">
+          <div
+            className="text-xl"
+            style={{
+              fontWeight: 600,
+            }}
+          >
+            {entry.wordsFound}
+          </div>
+          <div
+            className="text-[10px] mt-0.5"
+            style={{ color: CARD_TEXT_MUTED, fontWeight: 400 }}
+          >
+            words found
+          </div>
+        </div>
+      </div>
+
+      {/* Config footer */}
+      <div
+        className="px-4 py-2 text-[11px] mt-auto flex items-center justify-center gap-[3px]"
+        style={{
+          borderTop: `0.5px solid ${CARD_BORDER}`,
+          color: CARD_TEXT_MUTED,
+          fontFamily: "var(--font-sans)",
+        }}
+      >
+        <span>{boardLabel}</span>
+        <span>&middot;</span>
+        <span>{timerLabel}</span>
+        <span>&middot;</span>
+        <span>{lettersLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/CompletedCard.tsx
+++ b/client/src/pages/daily/components/CompletedCard.tsx
@@ -25,7 +25,7 @@ export function CompletedCard({
 
   return (
     <div
-      className="rounded-[14px] flex-1 flex flex-col overflow-hidden"
+      className="rounded-[14px] flex-1 flex flex-col"
       style={{
         background: CARD_BG,
         border: `0.5px solid ${CARD_BORDER}`,

--- a/client/src/pages/daily/components/CompletedCard.tsx
+++ b/client/src/pages/daily/components/CompletedCard.tsx
@@ -88,7 +88,7 @@ export function CompletedCard({
         {/* Expandable definition */}
         <DefinitionArea
           word={entry.longestWord ?? ""}
-          definition={entry.longestWordDefinition ?? ""}
+          definition={entry.longestWordDefinition ?? null}
           expanded={expanded}
           onExpandChange={onExpandChange}
           color={CARD_TEXT_MUTED}

--- a/client/src/pages/daily/components/DateSelector.tsx
+++ b/client/src/pages/daily/components/DateSelector.tsx
@@ -1,0 +1,165 @@
+import type { DailyEntry } from "../types";
+import { formatFullDate, formatShortDate } from "../utils";
+import { PerformanceStamp } from "./PerformanceStamp";
+
+interface DateSelectorProps {
+  entries: DailyEntry[];
+  currentIndex: number;
+  isOpen: boolean;
+  onToggle: () => void;
+  onSelect: (index: number) => void;
+}
+
+export function DateSelector({
+  entries,
+  currentIndex,
+  isOpen,
+  onToggle,
+  onSelect,
+}: DateSelectorProps) {
+  const currentEntry = entries[currentIndex];
+  const isToday = currentIndex === entries.length - 1;
+
+  return (
+    <>
+      {/* Date trigger */}
+      <div className="flex items-center justify-center px-[18px] mb-2.5 relative">
+        <button
+          type="button"
+          className="text-[15px] cursor-pointer flex items-center gap-1.5 bg-transparent border-none outline-none p-0"
+          style={{
+            color: "var(--text)",
+            fontFamily: "var(--font-sans)",
+            fontWeight: 600,
+          }}
+          onClick={onToggle}
+        >
+          <span>{formatFullDate(currentEntry.date)}</span>
+          {isToday && <TodayBadge />}
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className={`w-3 h-3 transition-transform duration-200 ${
+              isOpen ? "rotate-180" : ""
+            }`}
+          >
+            <path d="M4 6l4 4 4-4" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Dropdown picker */}
+      {isOpen && (
+        <div className="absolute left-0 right-0 top-[80px] z-11 flex justify-center px-[18px] mt-[36px]">
+          <div
+            className="rounded-xl flex flex-col w-full min-w-[360px] p-2"
+            style={{
+              background: "var(--card)",
+              border: "0.5px solid var(--dot)",
+            }}
+          >
+            {[...entries].reverse().map((_entry, reversedIdx) => {
+              const realIdx = entries.length - 1 - reversedIdx;
+              const entry = entries[realIdx];
+              const isActive = realIdx === currentIndex;
+              const entryIsToday = realIdx === entries.length - 1;
+
+              return (
+                <div key={entry.puzzleNumber}>
+                  <button
+                    type="button"
+                    className="flex items-center justify-between w-full px-2 py-2.5 cursor-pointer bg-transparent border-none outline-none text-left rounded-lg"
+                    style={{
+                      background: isActive ? "var(--track)" : "transparent",
+                    }}
+                    onClick={() => onSelect(realIdx)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="text-[15px]"
+                        style={{
+                          color: "var(--text)",
+                          fontFamily: "var(--font-sans)",
+                          fontWeight: 600,
+                        }}
+                      >
+                        {formatShortDate(entry.date)}
+                      </span>
+                      <span
+                        className="text-[13px]"
+                        style={{
+                          color: "var(--text-muted)",
+                          fontFamily: "var(--font-sans)",
+                        }}
+                      >
+                        #{entry.puzzleNumber}
+                      </span>
+                      {entryIsToday && <TodayBadge />}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <PickerEntryStatus entry={entry} />
+                    </div>
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+/** "Today" pill badge used in the date trigger and picker rows */
+function TodayBadge() {
+  return (
+    <span
+      className="text-[11px] px-2 py-0.5 rounded-md"
+      style={{
+        color: "var(--accent)",
+        background: "color-mix(in srgb, var(--accent) 12%, var(--page-bg) 88%)",
+        border: "1px solid color-mix(in srgb, var(--accent) 25%, transparent 75%)",
+        fontFamily: "var(--font-sans)",
+        fontWeight: 600,
+      }}
+    >
+      Today
+    </span>
+  );
+}
+
+/** Right side of each picker row — score + badges or missed/not played label */
+function PickerEntryStatus({ entry }: { entry: DailyEntry }) {
+  if (entry.state === "completed") {
+    return (
+      <>
+        <span
+          className="text-sm"
+          style={{
+            color: "var(--text)",
+            fontFamily: "var(--font-sans)",
+            fontWeight: 600,
+          }}
+        >
+          {entry.points} pts
+        </span>
+        <PerformanceStamp tier={entry.stampTier} size="sm" />
+      </>
+    );
+  }
+
+  return (
+    <span
+      className="text-[13px] italic"
+      style={{
+        color: "var(--text-muted)",
+        fontFamily: "var(--font-sans)",
+      }}
+    >
+      {entry.state === "unplayed" ? "Not played" : "Missed"}
+    </span>
+  );
+}

--- a/client/src/pages/daily/components/DateSelector.tsx
+++ b/client/src/pages/daily/components/DateSelector.tsx
@@ -20,10 +20,16 @@ export function DateSelector({
   const currentEntry = entries[currentIndex];
   const isToday = currentIndex === entries.length - 1;
 
+  // z-20 on the wrapper puts the trigger (and dropdown) above BlurOverlay
+  // (z-10), so the current date stays legible while the rest of the page
+  // blurs behind the dropdown.
   return (
-    <>
+    // pb-2.5 (instead of mb-2.5 on the trigger) so the wrapper's content box
+    // includes the breathing room — which means `top-full` on the dropdown
+    // lands 10px below the trigger text on any host layout.
+    <div className="relative z-20 pb-2.5">
       {/* Date trigger */}
-      <div className="flex items-center justify-center px-[18px] mb-2.5 relative">
+      <div className="flex items-center justify-center px-[18px] min-h-[20px]">
         <button
           type="button"
           className="text-[15px] cursor-pointer flex items-center gap-1.5 bg-transparent border-none outline-none p-0"
@@ -50,14 +56,15 @@ export function DateSelector({
         </button>
       </div>
 
-      {/* Dropdown picker */}
+      {/* Dropdown picker — positioned just below the trigger in any layout. */}
       {isOpen && (
-        <div className="absolute left-0 right-0 top-[80px] z-11 flex justify-center px-[18px] mt-[36px]">
+        <div className="absolute left-0 right-0 top-full flex justify-center px-[18px]">
           <div
-            className="rounded-xl flex flex-col w-full min-w-[360px] p-2"
+            className="rounded-xl flex flex-col w-full p-2 overflow-y-auto"
             style={{
               background: "var(--card)",
               border: "0.5px solid var(--dot)",
+              maxHeight: "60vh",
             }}
           >
             {[...entries].reverse().map((_entry, reversedIdx) => {
@@ -70,7 +77,7 @@ export function DateSelector({
                 <div key={entry.puzzleNumber}>
                   <button
                     type="button"
-                    className="flex items-center justify-between w-full px-2 py-2.5 cursor-pointer bg-transparent border-none outline-none text-left rounded-lg"
+                    className="flex items-center justify-between w-full px-2 py-2.5 cursor-pointer bg-transparent border-none outline-none text-left rounded-lg min-h-[40px]"
                     style={{
                       background: isActive ? "var(--track)" : "transparent",
                     }}
@@ -109,7 +116,7 @@ export function DateSelector({
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/client/src/pages/daily/components/DefinitionArea.tsx
+++ b/client/src/pages/daily/components/DefinitionArea.tsx
@@ -1,0 +1,115 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+
+interface DefinitionAreaProps {
+  word: string;
+  definition: string;
+  expanded: boolean;
+  onExpandChange: (expanded: boolean) => void;
+  /** Override the text & chevron color. Defaults to var(--text-muted). */
+  color?: string;
+}
+
+/** Max height in px before truncation kicks in (~2 lines at 12px/1.5 leading) */
+const TRUNCATION_HEIGHT = 55;
+
+export function DefinitionArea({
+  word,
+  definition,
+  expanded,
+  onExpandChange,
+  color = "var(--text-muted)",
+}: DefinitionAreaProps) {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [needsTruncation, setNeedsTruncation] = useState(false);
+
+  const checkTruncation = useCallback(() => {
+    const el = textRef.current;
+    if (!el) return;
+
+    // scrollHeight reports the full content height even when
+    // overflow is hidden, so no need to temporarily remove constraints.
+    setNeedsTruncation(el.scrollHeight > TRUNCATION_HEIGHT);
+  }, []);
+
+  // Re-check when definition text changes
+  useEffect(() => {
+    checkTruncation();
+  }, [checkTruncation, definition]);
+
+  // Re-check when the container resizes (e.g. carousel sets card width after
+  // initial render). This replaces a window resize listener so it fires any
+  // time the text element's layout width actually changes.
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      checkTruncation();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [checkTruncation]);
+
+  function handleToggle() {
+    onExpandChange(!expanded);
+  }
+
+  const isTruncated = needsTruncation && !expanded;
+
+  return (
+    <div className="min-h-[62px]">
+      {/* Definition text with conditional truncation */}
+      <div className="relative">
+        <div
+          ref={textRef}
+          className="text-xs italic leading-relaxed"
+          style={{
+            fontFamily: "var(--font-serif)",
+            color,
+            maxHeight: isTruncated ? `${TRUNCATION_HEIGHT}px` : "none",
+            overflow: isTruncated ? "hidden" : "visible",
+            ...(isTruncated
+              ? {
+                  maskImage:
+                    "linear-gradient(to bottom, black 40%, transparent 100%)",
+                  WebkitMaskImage:
+                    "linear-gradient(to bottom, black 40%, transparent 100%)",
+                }
+              : {}),
+          }}
+        >
+          {definition}
+        </div>
+      </div>
+
+      {/* Expand/collapse chevron — only rendered when definition overflows */}
+      {needsTruncation && (
+        <button
+          type="button"
+          data-chevron-btn
+          className="flex justify-center w-full pt-1 cursor-pointer relative z-20 bg-transparent border-none outline-none p-0"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleToggle();
+          }}
+        >
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke={color}
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-4 h-4"
+          >
+            {expanded ? (
+              <path d="M4 10l4-4 4 4" />
+            ) : (
+              <path d="M4 6l4 4 4-4" />
+            )}
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/DefinitionArea.tsx
+++ b/client/src/pages/daily/components/DefinitionArea.tsx
@@ -1,8 +1,9 @@
 import { useRef, useState, useEffect, useCallback } from "react";
+import type { WordDefinition } from "../../results/hooks/useDefinition";
 
 interface DefinitionAreaProps {
   word: string;
-  definition: string;
+  definition: WordDefinition | null;
   expanded: boolean;
   onExpandChange: (expanded: boolean) => void;
   /** Override the text & chevron color. Defaults to var(--text-muted). */
@@ -25,24 +26,16 @@ export function DefinitionArea({
   const checkTruncation = useCallback(() => {
     const el = textRef.current;
     if (!el) return;
-
-    // scrollHeight reports the full content height even when
-    // overflow is hidden, so no need to temporarily remove constraints.
     setNeedsTruncation(el.scrollHeight > TRUNCATION_HEIGHT);
   }, []);
 
-  // Re-check when definition text changes
   useEffect(() => {
     checkTruncation();
   }, [checkTruncation, definition]);
 
-  // Re-check when the container resizes (e.g. carousel sets card width after
-  // initial render). This replaces a window resize listener so it fires any
-  // time the text element's layout width actually changes.
   useEffect(() => {
     const el = textRef.current;
     if (!el) return;
-
     const observer = new ResizeObserver(() => {
       checkTruncation();
     });
@@ -58,7 +51,6 @@ export function DefinitionArea({
 
   return (
     <div className="min-h-[62px]">
-      {/* Definition text with conditional truncation */}
       <div className="relative">
         <div
           ref={textRef}
@@ -78,11 +70,39 @@ export function DefinitionArea({
               : {}),
           }}
         >
-          {definition}
+          {definition ? (
+            <>
+              {definition.phonetic && (
+                <div className="not-italic text-[11px] mb-1" style={{ opacity: 0.7 }}>
+                  {definition.phonetic}
+                </div>
+              )}
+              {definition.meanings.map((meaning, i) => (
+                <div key={i} className="mb-1.5">
+                  <span className="not-italic text-[11px]" style={{ opacity: 0.7 }}>
+                    {meaning.partOfSpeech}
+                  </span>
+                  <ol className="mt-0.5 pl-[18px] not-italic">
+                    {meaning.definitions.map((def, j) => (
+                      <li key={j} className="mb-0.5 italic">
+                        {def.definition}
+                        {def.example && (
+                          <span className="block not-italic text-[11px] mt-px" style={{ opacity: 0.6 }}>
+                            "{def.example}"
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              ))}
+            </>
+          ) : (
+            <span style={{ opacity: 0.6 }}>No definition available for "{word}".</span>
+          )}
         </div>
       </div>
 
-      {/* Expand/collapse chevron — only rendered when definition overflows */}
       {needsTruncation && (
         <button
           type="button"

--- a/client/src/pages/daily/components/MissedCard.tsx
+++ b/client/src/pages/daily/components/MissedCard.tsx
@@ -1,0 +1,55 @@
+interface MissedCardProps {
+  puzzleNumber: number;
+  playersCount: number;
+}
+
+export function MissedCard({ puzzleNumber, playersCount }: MissedCardProps) {
+  return (
+    <div
+      className="rounded-[14px] flex-1 flex flex-col items-center justify-center px-4 py-6"
+      style={{
+        background: "color-mix(in srgb, var(--page-bg) 90%, var(--text) 5%)",
+        border: "1px dashed var(--dot)",
+        fontFamily: "var(--font-sans)"
+      }}
+    >
+      <div
+        className="text-xs mb-2"
+        style={{
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-sans)",
+          fontWeight: 600,
+        }}
+      >
+        #{puzzleNumber}
+      </div>
+      <div
+        className="w-8 h-8 rounded-full flex items-center justify-center mx-auto mb-2"
+        style={{ background: "var(--dot)" }}
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="var(--text-muted)"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className="w-4 h-4"
+        >
+          <path d="M4 4l8 8m0-8l-8 8" />
+        </svg>
+      </div>
+      <div
+        className="text-sm mb-0.5"
+        style={{ color: "var(--text-mid)" }}
+      >
+        You didn&apos;t play this one
+      </div>
+      <div
+        className="text-xs"
+        style={{ color: "var(--text-muted)" }}
+      >
+        {playersCount} played
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/PerformanceStamp.tsx
+++ b/client/src/pages/daily/components/PerformanceStamp.tsx
@@ -44,7 +44,7 @@ const SIZE_CONFIG = {
     badgeText: "text-[9px]",
     badgeBorder: 1.5,
     badgeRotate: "-rotate-[4deg]",
-    checkSize: "w-[22px] h-[22px]",
+    checkSize: "w-[25px] h-[25px]",
     checkIcon: "w-3 h-3",
     checkStroke: 2,
   },
@@ -82,7 +82,7 @@ export function PerformanceStamp({ tier, size = "md" }: PerformanceStampProps) {
         </div>
       )}
       <div
-        className={`${s.checkSize} rounded-full flex items-center justify-center bg-[#c5dac5] w-[25px] h-[25px]`}
+        className={`${s.checkSize} rounded-full flex items-center justify-center bg-[#c5dac5]`}
       >
         <svg
           viewBox="0 0 16 16"

--- a/client/src/pages/daily/components/PerformanceStamp.tsx
+++ b/client/src/pages/daily/components/PerformanceStamp.tsx
@@ -1,0 +1,101 @@
+import type { StampTier } from "../types";
+
+interface PerformanceStampProps {
+  tier: StampTier;
+  /** "md" (default) for the completed card, "sm" for inline use like the date picker */
+  size?: "md" | "sm";
+}
+
+const TIER_CONFIG: Record<
+  Exclude<StampTier, null>,
+  { label: string; borderColor: string; textColor: string; bg: string }
+> = {
+  first: {
+    label: "1ST",
+    borderColor: "#c4a44a",
+    textColor: "#a08a30",
+    bg: "rgba(196, 164, 74, 0.40)",
+  },
+  second: {
+    label: "2ND",
+    borderColor: "#9a9a9a",
+    textColor: "#7a7a7a",
+    bg: "rgba(154, 154, 154, 0.40)",
+  },
+  third: {
+    label: "3RD",
+    borderColor: "#b87a4a",
+    textColor: "#9a6a3a",
+    bg: "rgba(184, 122, 74, 0.40)",
+  },
+  top30: {
+    label: "TOP 30%",
+    borderColor: "rgb(133, 183, 235)",
+    textColor: "rgb(42, 125, 214)",
+    bg: "rgba(24, 95, 165, 0.30)",
+  },
+};
+
+const SIZE_CONFIG = {
+  md: {
+    gap: "gap-1.5",
+    badgeHeight: "h-[22px]",
+    badgePx: "px-2",
+    badgeText: "text-[9px]",
+    badgeBorder: 1.5,
+    badgeRotate: "-rotate-[4deg]",
+    checkSize: "w-[22px] h-[22px]",
+    checkIcon: "w-3 h-3",
+    checkStroke: 2,
+  },
+  sm: {
+    gap: "gap-1.5",
+    badgeHeight: "h-4",
+    badgePx: "px-2",
+    badgeText: "text-[8px]",
+    badgeBorder: 1,
+    badgeRotate: "",
+    checkSize: "w-4 h-4",
+    checkIcon: "w-2.5 h-2.5",
+    checkStroke: 2.5,
+  },
+} as const;
+
+export function PerformanceStamp({ tier, size = "md" }: PerformanceStampProps) {
+  const tierConfig = tier ? TIER_CONFIG[tier] : null;
+  const s = SIZE_CONFIG[size];
+
+  return (
+    <div className={`flex items-center ${s.gap}`}>
+      {tierConfig && (
+        <div
+          className={`${s.badgeHeight} rounded-full ${s.badgePx} flex items-center ${s.badgeText} tracking-wide ${s.badgeRotate}`}
+          style={{
+            fontWeight: 600,
+            fontFamily: "var(--font-sans)",
+            border: `${s.badgeBorder}px solid ${tierConfig.borderColor}`,
+            color: tierConfig.textColor,
+            background: tierConfig.bg,
+          }}
+        >
+          {tierConfig.label}
+        </div>
+      )}
+      <div
+        className={`${s.checkSize} rounded-full flex items-center justify-center bg-[#c5dac5] w-[25px] h-[25px]`}
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="#3a6a3e"
+          strokeWidth={s.checkStroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={s.checkIcon}
+        >
+          <path d="M3.5 8.5l3 3 6-7" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/StatsCard.tsx
+++ b/client/src/pages/daily/components/StatsCard.tsx
@@ -7,7 +7,7 @@ interface StatsCardProps {
 export function StatsCard({ stats }: StatsCardProps) {
   return (
     <div
-      className="flex items-center gap-2 rounded-[10px] py-2.5 px-3.5 mx-[18px] mb-2"
+      className="flex items-center gap-2 rounded-[10px] py-2.5 px-3.5 mb-2 min-h-[30px]"
       style={{ background: "var(--track)" }}
     >
       {/* Chart icon */}

--- a/client/src/pages/daily/components/StatsCard.tsx
+++ b/client/src/pages/daily/components/StatsCard.tsx
@@ -1,0 +1,65 @@
+import type { DailyStats } from "../types";
+
+interface StatsCardProps {
+  stats: DailyStats;
+}
+
+export function StatsCard({ stats }: StatsCardProps) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-[10px] py-2.5 px-3.5 mx-[18px] mb-2"
+      style={{ background: "var(--track)" }}
+    >
+      {/* Chart icon */}
+      <div
+        className="w-5 h-5 rounded-md flex items-center justify-center shrink-0"
+        style={{
+          background: "color-mix(in srgb, var(--accent) 15%, var(--page-bg) 85%)",
+        }}
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="1.5"
+          className="w-3 h-3"
+        >
+          <path d="M3 12l3-4 2.5 2L12 4" />
+        </svg>
+      </div>
+
+      {/* Label */}
+      <span
+        className="text-sm flex-1"
+        style={{
+          color: "var(--text)",
+          fontFamily: "var(--font-sans)",
+        }}
+      >
+        7 day avg
+      </span>
+
+      {/* Values */}
+      <span
+        className="text-sm"
+        style={{
+          color: "var(--text)",
+          fontFamily: "var(--font-sans)",
+          fontWeight: 600,
+        }}
+      >
+        {Math.round(stats.avgPoints)} pts
+      </span>
+      <span
+        className="text-sm"
+        style={{
+          color: "var(--text)",
+          fontFamily: "var(--font-sans)",
+          fontWeight: 600,
+        }}
+      >
+        {Math.round(stats.avgWords)} words
+      </span>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/StreakCard.tsx
+++ b/client/src/pages/daily/components/StreakCard.tsx
@@ -1,0 +1,69 @@
+import type { DailyStats } from "../types";
+
+interface StreakCardProps {
+  stats: DailyStats;
+}
+
+export function StreakCard({ stats }: StreakCardProps) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-[10px] py-2.5 px-3.5 mx-[18px] mb-2"
+      style={{ background: "var(--track)" }}
+    >
+      {/* Fire icon */}
+      <div
+        className="w-5 h-5 rounded-md flex items-center justify-center shrink-0"
+        style={{
+          background: "color-mix(in srgb, #d4713a 15%, var(--page-bg) 85%)",
+        }}
+      >
+        <svg viewBox="0 0 16 16" fill="none" className="w-3 h-3">
+          <path
+            d="M8 1.5c0 0-1.5 2-2.5 3.5C4.5 6.5 4 7.5 4 9a4 4 0 008 0c0-1.5-.5-2.5-1.5-4C9.5 3.5 8 1.5 8 1.5z"
+            fill="#d4713a"
+          />
+          <path
+            d="M8 5c0 0-1 1.2-1.5 2.2C6 8.2 5.8 9 6 10a2.2 2.2 0 004 0c.2-1-.2-1.8-.7-2.8C8.8 6.2 8 5 8 5z"
+            fill="#e8943a"
+          />
+        </svg>
+      </div>
+
+      {/* Label */}
+      <span
+        className="text-sm flex-1"
+        style={{
+          color: "var(--text)",
+          fontFamily: "var(--font-sans)",
+        }}
+      >
+        Streak
+      </span>
+
+      {/* Value + dots */}
+      <div className="flex flex-col items-end gap-1">
+        <span
+          className="text-sm"
+          style={{
+            color: "var(--text)",
+            fontFamily: "var(--font-sans)",
+            fontWeight: 600,
+          }}
+        >
+          {stats.currentStreak} days
+        </span>
+        <div className="flex gap-[3px]">
+          {stats.streakDays.map((active, i) => (
+            <div
+              key={i}
+              className="w-1.5 h-1.5 rounded-full"
+              style={{
+                background: active ? "var(--accent)" : "var(--dot)",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/StreakCard.tsx
+++ b/client/src/pages/daily/components/StreakCard.tsx
@@ -7,7 +7,7 @@ interface StreakCardProps {
 export function StreakCard({ stats }: StreakCardProps) {
   return (
     <div
-      className="flex items-center gap-2 rounded-[10px] py-2.5 px-3.5 mx-[18px] mb-2"
+      className="flex items-center gap-2 rounded-[10px] py-2.5 px-3.5 mb-2"
       style={{ background: "var(--track)" }}
     >
       {/* Fire icon */}

--- a/client/src/pages/daily/components/UnplayedCard.tsx
+++ b/client/src/pages/daily/components/UnplayedCard.tsx
@@ -1,0 +1,44 @@
+import { Button } from "../../../shared/components/Button"
+import { formatConfig } from "../utils";
+
+interface UnplayedCardProps {
+  config: {
+    boardSize: number;
+    timeLimit: number;
+    minWordLength: number;
+  };
+  onStart: () => void;
+}
+
+export function UnplayedCard({ config, onStart }: UnplayedCardProps) {
+  const { boardLabel, timerLabel, lettersLabel } = formatConfig(config);
+
+  return (
+    <div
+      className="rounded-[14px] flex-1 flex flex-col items-center justify-center px-4 py-6"
+      style={{
+        background: "color-mix(in srgb, var(--page-bg) 85%, var(--text) 5%)",
+        border: "1.5px dashed var(--dot)",
+      }}
+    >
+      <div data-start-btn>
+        <Button variant="primary" size="lg" onClick={onStart}>
+          Start puzzle
+        </Button>
+      </div>
+      <div
+        className="text-[11px] mt-3 flex items-center justify-center gap-[3px]"
+        style={{
+          fontFamily: "var(--font-sans)",
+          color: "var(--text-muted)",
+        }}
+      >
+        <span>{boardLabel}</span>
+        <span>&middot;</span>
+        <span>{timerLabel}</span>
+        <span>&middot;</span>
+        <span>{lettersLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/daily/components/index.ts
+++ b/client/src/pages/daily/components/index.ts
@@ -1,0 +1,2 @@
+export { DateSelector } from "./DateSelector";
+export { BlurOverlay } from "./BlurOverlay";

--- a/client/src/pages/daily/index.ts
+++ b/client/src/pages/daily/index.ts
@@ -1,0 +1,1 @@
+export { DailyPuzzleRoute } from "./DailyRoute";

--- a/client/src/pages/daily/types.ts
+++ b/client/src/pages/daily/types.ts
@@ -1,15 +1,9 @@
-/**
- * Performance stamp tiers, ordered by precedence (highest wins).
- * null = completed with no special ranking.
- */
+import type { WordDefinition } from "../results/hooks/useDefinition";
+
 export type StampTier = "first" | "second" | "third" | "top30" | null;
 
 export type DailyState = "completed" | "missed" | "unplayed";
 
-/**
- * A single daily puzzle entry for display in the daily page carousel.
- * Built from DailyInfo + the player's result data for that day.
- */
 export interface DailyEntry {
   puzzleNumber: number;
   date: Date;
@@ -17,7 +11,7 @@ export interface DailyEntry {
   points?: number;
   wordsFound?: number;
   longestWord?: string;
-  longestWordDefinition?: string;
+  longestWordDefinition?: WordDefinition | null;
   stampTier: StampTier;
   playersCount: number;
   config: {
@@ -29,7 +23,6 @@ export interface DailyEntry {
 
 export interface DailyStats {
   currentStreak: number;
-  /** 7 booleans representing the last 7 days, true = played */
   streakDays: boolean[];
   avgPoints: number;
   avgWords: number;

--- a/client/src/pages/daily/types.ts
+++ b/client/src/pages/daily/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Performance stamp tiers, ordered by precedence (highest wins).
+ * null = completed with no special ranking.
+ */
+export type StampTier = "first" | "second" | "third" | "top30" | null;
+
+export type DailyState = "completed" | "missed" | "unplayed";
+
+/**
+ * A single daily puzzle entry for display in the daily page carousel.
+ * Built from DailyInfo + the player's result data for that day.
+ */
+export interface DailyEntry {
+  puzzleNumber: number;
+  date: Date;
+  state: DailyState;
+  points?: number;
+  wordsFound?: number;
+  longestWord?: string;
+  longestWordDefinition?: string;
+  stampTier: StampTier;
+  playersCount: number;
+  config: {
+    boardSize: number;
+    timeLimit: number;
+    minWordLength: number;
+  };
+}
+
+export interface DailyStats {
+  currentStreak: number;
+  /** 7 booleans representing the last 7 days, true = played */
+  streakDays: boolean[];
+  avgPoints: number;
+  avgWords: number;
+}

--- a/client/src/pages/daily/utils.ts
+++ b/client/src/pages/daily/utils.ts
@@ -1,0 +1,48 @@
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const SHORT_MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+function ordinal(day: number): string {
+  const suffixes = ["th", "st", "nd", "rd"];
+  const mod100 = day % 100;
+  return (
+    day + (suffixes[(mod100 - 20) % 10] || suffixes[mod100] || suffixes[0])
+  );
+}
+
+/** "April 12th, 2026" */
+export function formatFullDate(date: Date): string {
+  return `${MONTHS[date.getMonth()]} ${ordinal(date.getDate())}, ${date.getFullYear()}`;
+}
+
+/** "Apr 12" */
+export function formatShortDate(date: Date): string {
+  return `${SHORT_MONTHS[date.getMonth()]} ${date.getDate()}`;
+}
+
+/**
+ * Formats a DailyInfo config into display strings.
+ * e.g. { boardSize: 5, timeLimit: 120, minWordLength: 4 }
+ *   -> { boardLabel: "5x5", timerLabel: "2:00", lettersLabel: "4+ letters" }
+ */
+export function formatConfig(config: {
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+}): { boardLabel: string; timerLabel: string; lettersLabel: string } {
+  const minutes = Math.floor(config.timeLimit / 60);
+  const seconds = config.timeLimit % 60;
+  const timerLabel = `${minutes}:${String(seconds).padStart(2, "0")}`;
+
+  return {
+    boardLabel: `${config.boardSize}x${config.boardSize}`,
+    timerLabel,
+    lettersLabel: `${config.minWordLength}+ letters`,
+  };
+}

--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -18,14 +18,7 @@ export function LandingRoute() {
   const handleDaily = async () => {
     const info = await fetchDaily();
     setDailyInfo(info);
-    await createGame();
     navigate('/daily');
-  };
-
-  const handleDailyResults = async () => {
-    const info = await fetchDaily();
-    setDailyInfo(info);
-    navigate('/leaderboard');
   };
 
   if (!cachedDaily || !dailyResultLoaded) {
@@ -64,7 +57,7 @@ export function LandingRoute() {
           minWordLength: cachedDaily.config.minWordLength,
         }}
         dailyResults={dailyResultsData}
-        onDailyClick={hasPlayed ? handleDailyResults : handleDaily}
+        onDailyClick={handleDaily}
         onFreePlayClick={handleFreePlay}
         displayName={displayName}
         onDisplayNameChange={updateDisplayName}

--- a/client/src/pages/leaderboard/LeaderboardPage.tsx
+++ b/client/src/pages/leaderboard/LeaderboardPage.tsx
@@ -60,15 +60,12 @@ export function LeaderboardPage({
       {/* Header */}
       <div className="flex items-center justify-center relative">
         <button
+          type="button"
+          className="absolute left-[18px] top-1/2 -translate-y-1/2 text-lg cursor-pointer leading-none flex bg-transparent border-none"
+          style={{ color: "var(--text-muted)" }}
           onClick={onBack}
-          className="absolute left-0 border-none bg-transparent cursor-pointer flex items-center justify-center"
-          style={{
-            fontSize: '1.25rem',
-            color: 'var(--text)',
-            padding: '4px',
-          }}
         >
-          ←
+          &#8249;
         </button>
         <h1
           className="m-0"

--- a/client/src/pages/leaderboard/LeaderboardPage.tsx
+++ b/client/src/pages/leaderboard/LeaderboardPage.tsx
@@ -1,9 +1,5 @@
 import { useState } from 'react';
 import {
-  DailyNav,
-  type DailyNavEntry,
-  PlayerCard,
-  type PlayerCardProps,
   RankingSelector,
   type RankingType,
   TopThree,
@@ -12,16 +8,14 @@ import {
   type RankingEntry,
   MyResultsCard,
 } from './components';
+import { DateSelector, BlurOverlay } from '../daily/components';
+import type { DailyEntry } from '../daily/types';
 
 interface LeaderboardPageProps {
   title: string;
-  dailyEntries: DailyNavEntry[];
-  selectedDate: string;
-  onSelectDate: (date: string) => void;
-  onPrev: () => void;
-  onNext: () => void;
-  hasNext: boolean;
-  playerCard: PlayerCardProps;
+  entries: DailyEntry[];
+  currentIndex: number;
+  onChangeIndex: (index: number) => void;
   rankingType: RankingType;
   onRankingTypeChange: (type: RankingType) => void;
   topThree: TopThreeEntry[];
@@ -32,13 +26,9 @@ interface LeaderboardPageProps {
 
 export function LeaderboardPage({
   title,
-  dailyEntries,
-  selectedDate,
-  onSelectDate,
-  onPrev,
-  onNext,
-  hasNext,
-  playerCard,
+  entries,
+  currentIndex,
+  onChangeIndex,
   rankingType,
   onRankingTypeChange,
   topThree,
@@ -46,17 +36,30 @@ export function LeaderboardPage({
   onMyResults,
   onBack,
 }: LeaderboardPageProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  function handlePickerSelect(index: number) {
+    onChangeIndex(index);
+    setPickerOpen(false);
+  }
   return (
     <div
-      className="flex flex-col w-full"
+      className="relative flex-1 flex flex-col"
       style={{
-        maxWidth: '400px',
-        margin: '0 auto',
-        height: '100%',
-        gap: '10px',
         fontFamily: 'var(--font-body)',
       }}
     >
+      <BlurOverlay visible={pickerOpen} onClick={() => setPickerOpen(false)} />
+
+      <div
+        className="flex flex-col w-full"
+        style={{
+          margin: '0 auto',
+          height: '100%',
+          gap: '10px',
+        }}
+      >
+
       {/* Header */}
       <div className="flex items-center justify-center relative">
         <button
@@ -81,18 +84,16 @@ export function LeaderboardPage({
         </h1>
       </div>
 
-      {/* Daily navigation */}
-      <DailyNav
-        entries={dailyEntries}
-        selectedDate={selectedDate}
-        onSelectDate={onSelectDate}
-        onPrev={onPrev}
-        onNext={onNext}
-        hasNext={hasNext}
-      />
-
-      {/* Player score card */}
-      <PlayerCard {...playerCard} />
+      {/* Date selector (matches the daily page) */}
+      {entries.length > 0 && (
+        <DateSelector
+          entries={entries}
+          currentIndex={currentIndex}
+          isOpen={pickerOpen}
+          onToggle={() => setPickerOpen((v) => !v)}
+          onSelect={handlePickerSelect}
+        />
+      )}
 
       {/* Ranking type selector */}
       <RankingSelector value={rankingType} onChange={onRankingTypeChange} />
@@ -107,6 +108,7 @@ export function LeaderboardPage({
 
       {/* My results button */}
       <MyResultsCard onClick={onMyResults} />
+      </div>
     </div>
   );
 }

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -3,15 +3,34 @@ import { useNavigate } from 'react-router-dom';
 import { useGame } from '../../GameContext';
 import {
   fetchLeaderboard,
-  fetchDailyHistory,
+  fetchDailyStats,
+  fetchDaily,
   type LeaderboardResponse,
-  type DailyHistoryEntry,
+  type DailyStatsResponse,
+  type DailyStatsDay,
+  type DailyInfo,
 } from '../../shared/api/gameApi';
 import { LeaderboardPage } from './LeaderboardPage';
-import type { RankingType, DailyNavEntry } from './components';
+import type { RankingType } from './components';
+import type { DailyEntry } from '../daily/types';
 
 function getTodayPST(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+}
+
+function adaptDay(day: DailyStatsDay, config: DailyInfo['config']): DailyEntry {
+  return {
+    puzzleNumber: day.puzzleNumber,
+    date: new Date(day.date + 'T12:00:00'),
+    state: day.state,
+    points: day.points ?? undefined,
+    wordsFound: day.wordsFound ?? undefined,
+    longestWord: day.longestWord ?? undefined,
+    longestWordDefinition: day.longestWordDefinition,
+    stampTier: day.stampTier,
+    playersCount: day.playersCount,
+    config,
+  };
 }
 
 export function LeaderboardRoute() {
@@ -21,15 +40,19 @@ export function LeaderboardRoute() {
   const [selectedDate, setSelectedDate] = useState<string>(dailyInfo?.date ?? getTodayPST());
   const [rankingType, setRankingType] = useState<RankingType>('points');
   const [leaderboard, setLeaderboard] = useState<LeaderboardResponse | null>(null);
-  const [history, setHistory] = useState<DailyHistoryEntry[]>([]);
+  const [stats, setStats] = useState<DailyStatsResponse | null>(null);
+  const [config, setConfig] = useState<DailyInfo['config'] | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Fetch user's history for the nav dropdown
+  // Navigator data comes from the same endpoint that drives the daily page,
+  // so the picker is identical in data and UI across both pages.
   useEffect(() => {
-    fetchDailyHistory().then(({ entries }) => setHistory(entries));
+    Promise.all([fetchDailyStats(), fetchDaily()]).then(([s, info]) => {
+      setStats(s);
+      setConfig(info.config);
+    });
   }, []);
 
-  // Fetch leaderboard when date changes
   useEffect(() => {
     setLoading(true);
     fetchLeaderboard(selectedDate).then((data) => {
@@ -38,18 +61,25 @@ export function LeaderboardRoute() {
     });
   }, [selectedDate]);
 
-  // Map history to DailyNav entries, injecting rank from current leaderboard
-  const dailyEntries: DailyNavEntry[] = useMemo(() => {
-    const currentUserRank = leaderboard?.rankings.points.find((r) => r.isCurrentUser)?.rank ?? 0;
-    return history.map((e) => ({
-      date: e.date,
-      puzzleNumber: e.puzzleNumber,
-      points: e.points,
-      wordsFound: e.wordsFound,
-      rank: e.date === selectedDate ? currentUserRank : 0,
-      isToday: e.isToday,
-    }));
-  }, [history, leaderboard, selectedDate]);
+  const entries: DailyEntry[] = useMemo(() => {
+    if (!stats || !config) return [];
+    return stats.days.map((d) => adaptDay(d, config));
+  }, [stats, config]);
+
+  const currentIndex = useMemo(() => {
+    if (entries.length === 0) return 0;
+    const idx = entries.findIndex((e) => e.date.toISOString().slice(0, 10) === selectedDate);
+    return idx >= 0 ? idx : entries.length - 1;
+  }, [entries, selectedDate]);
+
+  const handleChangeIndex = useCallback(
+    (index: number) => {
+      const entry = entries[index];
+      if (!entry) return;
+      setSelectedDate(entry.date.toISOString().slice(0, 10));
+    },
+    [entries],
+  );
 
   const rankings = useMemo(
     () => leaderboard?.rankings[rankingType] ?? [],
@@ -57,81 +87,39 @@ export function LeaderboardRoute() {
   );
 
   const topThreeUnit = useMemo(() => {
-    switch(rankingType){
+    switch (rankingType) {
       default:
-        return "pts"
-      case "words":
-        return "w"
+        return 'pts';
+      case 'words':
+        return 'w';
     }
-  }, [rankingType])
+  }, [rankingType]);
 
   const topThree = useMemo(
-    () => rankings.slice(0, 3).map((r) => ({
-      rank: r.rank as 1 | 2 | 3,
-      displayName: r.displayName,
-      value: r.value,
-      unit: topThreeUnit,
-    })),
+    () =>
+      rankings.slice(0, 3).map((r) => ({
+        rank: r.rank as 1 | 2 | 3,
+        displayName: r.displayName,
+        value: r.value,
+        unit: topThreeUnit,
+      })),
     [rankings, topThreeUnit],
   );
-
-  // The rank on the player card should update based on the active ranking type
-  const currentUserRank = useMemo(
-    () => rankings.find((r) => r.isCurrentUser)?.rank ?? 0,
-    [rankings],
-  );
-
-  const playerCard = useMemo(() => {
-    if (!leaderboard?.currentPlayer) {
-      return {
-        points: 0,
-        wordsFound: 0,
-        longestWord: '',
-        rank: 0,
-        totalPlayers: leaderboard?.totalPlayers ?? 0,
-        topPercent: null,
-        accolade: "Play today's daily to see your stats!",
-      };
-    }
-    return {
-      ...leaderboard.currentPlayer,
-      rank: currentUserRank || leaderboard.currentPlayer.rank,
-    };
-  }, [leaderboard, currentUserRank]);
-
-  const handlePrev = useCallback(() => {
-    const idx = dailyEntries.findIndex((e) => e.date === selectedDate);
-    if (idx < dailyEntries.length - 1) setSelectedDate(dailyEntries[idx + 1].date);
-  }, [dailyEntries, selectedDate]);
-
-  const handleNext = useCallback(() => {
-    const idx = dailyEntries.findIndex((e) => e.date === selectedDate);
-    if (idx > 0) setSelectedDate(dailyEntries[idx - 1].date);
-  }, [dailyEntries, selectedDate]);
-
-  const hasNext = useMemo(() => {
-    const idx = dailyEntries.findIndex((e) => e.date === selectedDate);
-    return idx > 0;
-  }, [dailyEntries, selectedDate]);
 
   if (loading && !leaderboard) return null;
 
   return (
     <LeaderboardPage
       title={`Daily #${leaderboard?.puzzleNumber ?? ''}`}
-      dailyEntries={dailyEntries}
-      selectedDate={selectedDate}
-      onSelectDate={setSelectedDate}
-      onPrev={handlePrev}
-      onNext={handleNext}
-      hasNext={hasNext}
-      playerCard={playerCard}
+      entries={entries}
+      currentIndex={currentIndex}
+      onChangeIndex={handleChangeIndex}
       rankingType={rankingType}
       onRankingTypeChange={setRankingType}
       topThree={topThree}
       rankings={rankings}
       onMyResults={() => navigate('/daily/results')}
-      onBack={() => navigate('/')}
+      onBack={() => navigate(-1)}
     />
   );
 }

--- a/client/src/pages/leaderboard/components/RankingSelector.tsx
+++ b/client/src/pages/leaderboard/components/RankingSelector.tsx
@@ -59,7 +59,7 @@ export function RankingSelector({ value, onChange }: RankingSelectorProps) {
           <button
             key={option.value}
             onClick={() => onChange(option.value)}
-            className="relative z-10 flex-1 border-none cursor-pointer rounded-lg bg-transparent"
+            className="relative z-4 flex-1 border-none cursor-pointer rounded-lg bg-transparent"
             style={{
               padding: '6px 0',
               fontSize: '0.75rem',

--- a/client/src/pages/results/DailyResultsRoute.tsx
+++ b/client/src/pages/results/DailyResultsRoute.tsx
@@ -43,6 +43,8 @@ export function DailyResultsRoute() {
     navigate('/');
   };
 
+  const handleBack = () => navigate('/daily');
+
   return (
     <ResultsPage
       results={{
@@ -55,6 +57,7 @@ export function DailyResultsRoute() {
         missedWords: [],
       }}
       onPlayAgain={handlePlayAgain}
+      onBack={handleBack}
       game={{
         board: serverResult.board,
         startedAt: 0,

--- a/client/src/pages/results/ResultsPage.tsx
+++ b/client/src/pages/results/ResultsPage.tsx
@@ -19,12 +19,13 @@ const SCORE_SQUARE_STYLES: Record<number, React.CSSProperties> = {
 interface ResultsPageProps {
   results: GameResults | null;
   onPlayAgain: () => void;
+  onBack: () => void;
   game: Game;
   gameSeed?: number | null;
   dailyNumber?: number;
 }
 
-export const ResultsPage = ({ results, onPlayAgain, game, gameSeed, dailyNumber }: ResultsPageProps) => {
+export const ResultsPage = ({ results, onPlayAgain, onBack, game, gameSeed, dailyNumber }: ResultsPageProps) => {
   const [highlightPath, setHighlightPath] = useState<Position[] | null>(null);
   const [highlightedWordInfo, setHighlightedWordInfo] = useState<{ word: string; score: number } | null>(null);
   const [boardMinimized, setBoardMinimized] = useState(true);
@@ -98,7 +99,16 @@ export const ResultsPage = ({ results, onPlayAgain, game, gameSeed, dailyNumber 
   };
 
   return (
-    <div className="py-2.5">
+    <div className="py-2.5 relative">
+      <button
+        type="button"
+        onClick={onBack}
+        aria-label="Back"
+        className="absolute left-0 top-2.5 text-lg cursor-pointer leading-none flex bg-transparent border-none z-10"
+        style={{ color: "var(--text-muted)", WebkitTapHighlightColor: "transparent" }}
+      >
+        &#8249;
+      </button>
       <div className={boardMinimized ? 'flex flex-row gap-4 items-start h-[440px]' : 'flex flex-col gap-4 h-auto'}>
         {/* Board section */}
         <div className={`flex flex-col min-w-0 max-h-full ${boardMinimized ? 'w-1/2 shrink-0' : 'w-full max-w-[500px]'}`}>

--- a/client/src/pages/results/ResultsRoute.tsx
+++ b/client/src/pages/results/ResultsRoute.tsx
@@ -26,5 +26,20 @@ export function ResultsRoute() {
     }
   };
 
-  return <ResultsPage results={results} onPlayAgain={handlePlayAgain} game={game} gameSeed={gameSeed} dailyNumber={dailyInfo?.number} />;
+  // Back skips the game page since navigating back into an in-progress
+  // game doesn't make sense: go to the freeplay config, or to the daily
+  // stats page if this was a daily.
+  const handleBack = async () => {
+    navigatingRef.current = true;
+    if (dailyInfo) {
+      setDailyInfo(null);
+      if (game) await cancelGame();
+      navigate('/daily');
+    } else {
+      if (game) await cancelGame();
+      navigate('/play');
+    }
+  };
+
+  return <ResultsPage results={results} onPlayAgain={handlePlayAgain} onBack={handleBack} game={game} gameSeed={gameSeed} dailyNumber={dailyInfo?.number} />;
 }

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -123,6 +123,42 @@ export const fetchDaily = async (): Promise<DailyInfo> => {
   return response.json();
 };
 
+// Mirrors DailyStatsResponse in server/services/DailyService.ts.
+import type { WordDefinition } from '../../pages/results/hooks/useDefinition';
+
+export type DailyState = 'completed' | 'missed' | 'unplayed';
+export type StampTier = 'first' | 'second' | 'third' | 'top30' | null;
+
+export interface DailyStatsDay {
+  date: string;
+  puzzleNumber: number;
+  state: DailyState;
+  points: number | null;
+  wordsFound: number | null;
+  longestWord: string | null;
+  longestWordDefinition: WordDefinition | null;
+  stampTier: StampTier;
+  playersCount: number;
+}
+
+export interface DailyStatsResponse {
+  currentStreak: number;
+  streakDays: boolean[];
+  avgPoints: number;
+  avgWords: number;
+  windowStart: string;
+  windowEnd: string;
+  days: DailyStatsDay[];
+}
+
+export const fetchDailyStats = async (): Promise<DailyStatsResponse> => {
+  const response = await fetch(`${API_URL}/daily/stats`, {
+    headers: await sessionHeaders(),
+  });
+  if (!response.ok) throw new Error(`fetchDailyStats: ${response.status}`);
+  return response.json();
+};
+
 export const recordDailyResultToServer = async (date: string, foundWords: string[], board: string[][]): Promise<{ success: boolean }> => {
   const response = await fetch(`${API_URL}/daily/results`, {
     method: 'POST',

--- a/client/src/stories/CardActions.stories.tsx
+++ b/client/src/stories/CardActions.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CardActions } from '../pages/daily/components/CardActions';
+
+const meta: Meta<typeof CardActions> = {
+  title: 'Daily/CardActions',
+  component: CardActions,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardActions>;
+
+const callbacks = {
+  onResults: () => {},
+  onLeaderboard: () => {},
+  onShare: () => {},
+};
+
+export const CompletedLight: Story = {
+  args: { isCompleted: true, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const CompletedDark: Story = {
+  args: { isCompleted: true, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NotCompletedLight: Story = {
+  args: { isCompleted: false, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NotCompletedDark: Story = {
+  args: { isCompleted: false, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/CardCarousel.stories.tsx
+++ b/client/src/stories/CardCarousel.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { CardCarousel } from '../pages/daily/components/CardCarousel';
 import type { DailyEntry } from '../pages/daily/types';
+import { mockDefinition } from './mockDefinition';
 
 const meta: Meta<typeof CardCarousel> = {
   title: 'Daily/CardCarousel',
@@ -20,7 +21,7 @@ const entries: DailyEntry[] = [
     points: 44,
     wordsFound: 12,
     longestWord: 'TABLET',
-    longestWordDefinition: 'A flat slab of stone, clay, or wood used for writing.',
+    longestWordDefinition: mockDefinition('TABLET', 'A flat slab of stone, clay, or wood used for writing.'),
     stampTier: null,
     playersCount: 91,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -40,7 +41,7 @@ const entries: DailyEntry[] = [
     points: 58,
     wordsFound: 17,
     longestWord: 'BRIDGE',
-    longestWordDefinition: 'A structure carrying a road, path, or railway across a river, road, or other obstacle.',
+    longestWordDefinition: mockDefinition('BRIDGE', 'A structure carrying a road, path, or railway across a river, road, or other obstacle.'),
     stampTier: 'first',
     playersCount: 102,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -52,7 +53,7 @@ const entries: DailyEntry[] = [
     points: 35,
     wordsFound: 9,
     longestWord: 'CLAMP',
-    longestWordDefinition: 'A device used to hold things tightly together or in place.',
+    longestWordDefinition: mockDefinition('CLAMP', 'A device used to hold things tightly together or in place.'),
     stampTier: null,
     playersCount: 95,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -64,8 +65,10 @@ const entries: DailyEntry[] = [
     points: 42,
     wordsFound: 14,
     longestWord: 'SERENDIPITY',
-    longestWordDefinition:
+    longestWordDefinition: mockDefinition(
+      'SERENDIPITY',
       'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them.',
+    ),
     stampTier: 'top30',
     playersCount: 110,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -84,7 +87,7 @@ const callbacks = {
   onStartPuzzle: () => {},
   onViewResults: () => {},
   onViewLeaderboard: () => {},
-  onShare: () => {},
+  getShareText: async () => 'Froggle #1 0W 0pts',
   onDefinitionExpand: () => {},
 };
 
@@ -111,6 +114,7 @@ function InteractiveCarousel({
       <CardCarousel
         entries={entries}
         currentIndex={currentIndex}
+        defExpanded={false}
         onChangeIndex={setCurrentIndex}
         {...callbacks}
       />

--- a/client/src/stories/CardCarousel.stories.tsx
+++ b/client/src/stories/CardCarousel.stories.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { CardCarousel } from '../pages/daily/components/CardCarousel';
+import type { DailyEntry } from '../pages/daily/types';
+
+const meta: Meta<typeof CardCarousel> = {
+  title: 'Daily/CardCarousel',
+  component: CardCarousel,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardCarousel>;
+
+const entries: DailyEntry[] = [
+  {
+    puzzleNumber: 10,
+    date: new Date('2026-04-08'),
+    state: 'completed',
+    points: 44,
+    wordsFound: 12,
+    longestWord: 'TABLET',
+    longestWordDefinition: 'A flat slab of stone, clay, or wood used for writing.',
+    stampTier: null,
+    playersCount: 91,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 11,
+    date: new Date('2026-04-09'),
+    state: 'missed',
+    stampTier: null,
+    playersCount: 88,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 12,
+    date: new Date('2026-04-10'),
+    state: 'completed',
+    points: 58,
+    wordsFound: 17,
+    longestWord: 'BRIDGE',
+    longestWordDefinition: 'A structure carrying a road, path, or railway across a river, road, or other obstacle.',
+    stampTier: 'first',
+    playersCount: 102,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 13,
+    date: new Date('2026-04-11'),
+    state: 'completed',
+    points: 35,
+    wordsFound: 9,
+    longestWord: 'CLAMP',
+    longestWordDefinition: 'A device used to hold things tightly together or in place.',
+    stampTier: null,
+    playersCount: 95,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 14,
+    date: new Date('2026-04-12'),
+    state: 'completed',
+    points: 42,
+    wordsFound: 14,
+    longestWord: 'SERENDIPITY',
+    longestWordDefinition:
+      'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them.',
+    stampTier: 'top30',
+    playersCount: 110,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 15,
+    date: new Date('2026-04-13'),
+    state: 'unplayed',
+    stampTier: null,
+    playersCount: 45,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+];
+
+const callbacks = {
+  onStartPuzzle: () => {},
+  onViewResults: () => {},
+  onViewLeaderboard: () => {},
+  onShare: () => {},
+  onDefinitionExpand: () => {},
+};
+
+/** Wrapper that manages currentIndex state so swiping works in Storybook */
+function InteractiveCarousel({
+  initialIndex,
+  theme,
+}: {
+  initialIndex: number;
+  theme: 'light' | 'dark';
+}) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+
+  return (
+    <div
+      data-theme={theme}
+      className="w-full max-w-[430px] mx-auto relative"
+      style={{
+        backgroundColor: 'var(--page-bg)',
+        padding: '16px 0',
+        minHeight: '100vh',
+      }}
+    >
+      <CardCarousel
+        entries={entries}
+        currentIndex={currentIndex}
+        onChangeIndex={setCurrentIndex}
+        {...callbacks}
+      />
+    </div>
+  );
+}
+
+export const TodayUnplayedLight: Story = {
+  render: () => <InteractiveCarousel initialIndex={5} theme="light" />,
+};
+
+export const TodayUnplayedDark: Story = {
+  render: () => <InteractiveCarousel initialIndex={5} theme="dark" />,
+};
+
+export const CompletedLight: Story = {
+  render: () => <InteractiveCarousel initialIndex={4} theme="light" />,
+};
+
+export const CompletedDark: Story = {
+  render: () => <InteractiveCarousel initialIndex={4} theme="dark" />,
+};
+
+export const MissedLight: Story = {
+  render: () => <InteractiveCarousel initialIndex={1} theme="light" />,
+};
+
+export const MissedDark: Story = {
+  render: () => <InteractiveCarousel initialIndex={1} theme="dark" />,
+};

--- a/client/src/stories/CompletedCard.stories.tsx
+++ b/client/src/stories/CompletedCard.stories.tsx
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CompletedCard } from '../pages/daily/components/CompletedCard';
+import type { DailyEntry } from '../pages/daily/types';
+
+const meta: Meta<typeof CompletedCard> = {
+  title: 'Daily/CompletedCard',
+  component: CompletedCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CompletedCard>;
+
+const baseEntry: DailyEntry = {
+  puzzleNumber: 42,
+  date: new Date('2026-04-13'),
+  state: 'completed',
+  points: 87,
+  wordsFound: 23,
+  longestWord: 'FROGGLE',
+  longestWordDefinition:
+    'A playful portmanteau combining "frog" and "boggle", referring to a word puzzle game played on a grid of letters.',
+  stampTier: 'first',
+  playersCount: 128,
+  config: {
+    boardSize: 4,
+    timeLimit: 180,
+    minWordLength: 3,
+  },
+};
+
+const longDefinitionEntry: DailyEntry = {
+  ...baseEntry,
+  longestWord: 'SERENDIPITY',
+  longestWordDefinition:
+    'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them. The term was coined by Horace Walpole in 1754 based on the Persian fairy tale "The Three Princes of Serendip" whose heroes were always making discoveries by accident and sagacity.',
+  stampTier: 'top30',
+  points: 54,
+  wordsFound: 14,
+};
+
+export const FirstPlaceLight: Story = {
+  args: { entry: baseEntry, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const FirstPlaceDark: Story = {
+  args: { entry: baseEntry, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SecondPlaceLight: Story = {
+  args: { entry: { ...baseEntry, stampTier: 'second', points: 72, wordsFound: 19 }, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SecondPlaceDark: Story = {
+  args: { entry: { ...baseEntry, stampTier: 'second', points: 72, wordsFound: 19 }, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ThirdPlaceLight: Story = {
+  args: { entry: { ...baseEntry, stampTier: 'third', points: 65, wordsFound: 16 }, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ThirdPlaceDark: Story = {
+  args: { entry: { ...baseEntry, stampTier: 'third', points: 65, wordsFound: 16 }, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Top30Light: Story = {
+  args: { entry: longDefinitionEntry, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Top30Dark: Story = {
+  args: { entry: longDefinitionEntry, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NoStampLight: Story = {
+  args: { entry: { ...baseEntry, stampTier: null, points: 31, wordsFound: 8 }, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NoStampDark: Story = {
+  args: { entry: { ...baseEntry, stampTier: null, points: 31, wordsFound: 8 }, onExpandChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/CompletedCard.stories.tsx
+++ b/client/src/stories/CompletedCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { CompletedCard } from '../pages/daily/components/CompletedCard';
 import type { DailyEntry } from '../pages/daily/types';
+import { mockDefinition } from './mockDefinition';
 
 const meta: Meta<typeof CompletedCard> = {
   title: 'Daily/CompletedCard',
@@ -18,8 +19,10 @@ const baseEntry: DailyEntry = {
   points: 87,
   wordsFound: 23,
   longestWord: 'FROGGLE',
-  longestWordDefinition:
+  longestWordDefinition: mockDefinition(
+    'FROGGLE',
     'A playful portmanteau combining "frog" and "boggle", referring to a word puzzle game played on a grid of letters.',
+  ),
   stampTier: 'first',
   playersCount: 128,
   config: {
@@ -32,8 +35,10 @@ const baseEntry: DailyEntry = {
 const longDefinitionEntry: DailyEntry = {
   ...baseEntry,
   longestWord: 'SERENDIPITY',
-  longestWordDefinition:
+  longestWordDefinition: mockDefinition(
+    'SERENDIPITY',
     'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them. The term was coined by Horace Walpole in 1754 based on the Persian fairy tale "The Three Princes of Serendip" whose heroes were always making discoveries by accident and sagacity.',
+  ),
   stampTier: 'top30',
   points: 54,
   wordsFound: 14,

--- a/client/src/stories/DailyPage.stories.tsx
+++ b/client/src/stories/DailyPage.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { DailyPage } from '../pages/daily/DailyPage';
 import type { DailyEntry, DailyStats } from '../pages/daily/types';
+import { mockDefinition } from './mockDefinition';
 
 const meta: Meta<typeof DailyPage> = {
   title: 'Daily/DailyPage',
@@ -20,7 +21,7 @@ const entries: DailyEntry[] = [
     points: 44,
     wordsFound: 12,
     longestWord: 'TABLET',
-    longestWordDefinition: 'A flat slab of stone, clay, or wood, used especially for an inscription.',
+    longestWordDefinition: mockDefinition('TABLET', 'A flat slab of stone, clay, or wood, used especially for an inscription.'),
     stampTier: null,
     playersCount: 91,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -40,7 +41,7 @@ const entries: DailyEntry[] = [
     points: 58,
     wordsFound: 17,
     longestWord: 'BRIDGE',
-    longestWordDefinition: 'A structure carrying a road, path, or railway across a river, road, or other obstacle.',
+    longestWordDefinition: mockDefinition('BRIDGE', 'A structure carrying a road, path, or railway across a river, road, or other obstacle.'),
     stampTier: 'first',
     playersCount: 102,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -52,7 +53,7 @@ const entries: DailyEntry[] = [
     points: 35,
     wordsFound: 9,
     longestWord: 'CLAMP',
-    longestWordDefinition: 'A device used to hold things tightly together or in place.',
+    longestWordDefinition: mockDefinition('CLAMP', 'A device used to hold things tightly together or in place.'),
     stampTier: null,
     playersCount: 95,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -64,8 +65,10 @@ const entries: DailyEntry[] = [
     points: 42,
     wordsFound: 14,
     longestWord: 'SERENDIPITY',
-    longestWordDefinition:
+    longestWordDefinition: mockDefinition(
+      'SERENDIPITY',
       'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them.',
+    ),
     stampTier: 'top30',
     playersCount: 110,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -91,7 +94,7 @@ const callbacks = {
   onStartPuzzle: () => {},
   onViewResults: () => {},
   onViewLeaderboard: () => {},
-  onShare: () => {},
+  getShareText: async () => 'Froggle #1 0W 0pts',
   onBack: () => {},
 };
 

--- a/client/src/stories/DailyPage.stories.tsx
+++ b/client/src/stories/DailyPage.stories.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DailyPage } from '../pages/daily/DailyPage';
+import type { DailyEntry, DailyStats } from '../pages/daily/types';
+
+const meta: Meta<typeof DailyPage> = {
+  title: 'Daily/DailyPage',
+  component: DailyPage,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DailyPage>;
+
+const entries: DailyEntry[] = [
+  {
+    puzzleNumber: 10,
+    date: new Date('2026-04-08'),
+    state: 'completed',
+    points: 44,
+    wordsFound: 12,
+    longestWord: 'TABLET',
+    longestWordDefinition: 'A flat slab of stone, clay, or wood, used especially for an inscription.',
+    stampTier: null,
+    playersCount: 91,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 11,
+    date: new Date('2026-04-09'),
+    state: 'missed',
+    stampTier: null,
+    playersCount: 88,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 12,
+    date: new Date('2026-04-10'),
+    state: 'completed',
+    points: 58,
+    wordsFound: 17,
+    longestWord: 'BRIDGE',
+    longestWordDefinition: 'A structure carrying a road, path, or railway across a river, road, or other obstacle.',
+    stampTier: 'first',
+    playersCount: 102,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 13,
+    date: new Date('2026-04-11'),
+    state: 'completed',
+    points: 35,
+    wordsFound: 9,
+    longestWord: 'CLAMP',
+    longestWordDefinition: 'A device used to hold things tightly together or in place.',
+    stampTier: null,
+    playersCount: 95,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 14,
+    date: new Date('2026-04-12'),
+    state: 'completed',
+    points: 42,
+    wordsFound: 14,
+    longestWord: 'SERENDIPITY',
+    longestWordDefinition:
+      'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them.',
+    stampTier: 'top30',
+    playersCount: 110,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 15,
+    date: new Date('2026-04-13'),
+    state: 'unplayed',
+    stampTier: null,
+    playersCount: 45,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+];
+
+const stats: DailyStats = {
+  currentStreak: 5,
+  streakDays: [true, true, false, true, true, true, true],
+  avgPoints: 72.4,
+  avgWords: 18.6,
+};
+
+const callbacks = {
+  onStartPuzzle: () => {},
+  onViewResults: () => {},
+  onViewLeaderboard: () => {},
+  onShare: () => {},
+  onBack: () => {},
+};
+
+function InteractiveDailyPage({
+  initialIndex,
+  theme,
+}: {
+  initialIndex: number;
+  theme: 'light' | 'dark';
+}) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+
+  return (
+    <div
+      data-theme={theme}
+      className="w-full max-w-[430px] mx-auto"
+      style={{ backgroundColor: 'var(--page-bg)', minHeight: '100vh' }}
+    >
+      <DailyPage
+        entries={entries}
+        stats={stats}
+        currentIndex={currentIndex}
+        nextPuzzleCountdown="4h 23m"
+        onChangeIndex={setCurrentIndex}
+        {...callbacks}
+      />
+    </div>
+  );
+}
+
+export const TodayLight: Story = {
+  render: () => <InteractiveDailyPage initialIndex={5} theme="light" />,
+};
+
+export const TodayDark: Story = {
+  render: () => <InteractiveDailyPage initialIndex={5} theme="dark" />,
+};
+
+export const CompletedLight: Story = {
+  render: () => <InteractiveDailyPage initialIndex={4} theme="light" />,
+};
+
+export const CompletedDark: Story = {
+  render: () => <InteractiveDailyPage initialIndex={4} theme="dark" />,
+};
+
+export const MissedLight: Story = {
+  render: () => <InteractiveDailyPage initialIndex={1} theme="light" />,
+};
+
+export const MissedDark: Story = {
+  render: () => <InteractiveDailyPage initialIndex={1} theme="dark" />,
+};

--- a/client/src/stories/DateSelector.stories.tsx
+++ b/client/src/stories/DateSelector.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DateSelector } from '../pages/daily/components/DateSelector';
+import type { DailyEntry } from '../pages/daily/types';
+
+const meta: Meta<typeof DateSelector> = {
+  title: 'Daily/DateSelector',
+  component: DateSelector,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DateSelector>;
+
+const entries: DailyEntry[] = [
+  {
+    puzzleNumber: 39,
+    date: new Date('2026-04-10'),
+    state: 'completed',
+    points: 65,
+    wordsFound: 16,
+    longestWord: 'BRIDGE',
+    longestWordDefinition: 'A structure carrying a road over a river.',
+    stampTier: 'second',
+    playersCount: 102,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 40,
+    date: new Date('2026-04-11'),
+    state: 'missed',
+    stampTier: null,
+    playersCount: 88,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 41,
+    date: new Date('2026-04-12'),
+    state: 'completed',
+    points: 87,
+    wordsFound: 23,
+    longestWord: 'FROGGLE',
+    longestWordDefinition: 'A word puzzle game.',
+    stampTier: 'first',
+    playersCount: 128,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+  {
+    puzzleNumber: 42,
+    date: new Date('2026-04-13'),
+    state: 'unplayed',
+    stampTier: null,
+    playersCount: 45,
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  },
+];
+
+const callbacks = {
+  onToggle: () => {},
+  onSelect: () => {},
+};
+
+export const ClosedLight: Story = {
+  args: { entries, currentIndex: 3, isOpen: false, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ClosedDark: Story = {
+  args: { entries, currentIndex: 3, isOpen: false, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const OpenLight: Story = {
+  args: { entries, currentIndex: 3, isOpen: true, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px', minHeight: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const OpenDark: Story = {
+  args: { entries, currentIndex: 3, isOpen: true, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px', minHeight: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const OlderDateSelectedLight: Story = {
+  args: { entries, currentIndex: 0, isOpen: false, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const OlderDateSelectedDark: Story = {
+  args: { entries, currentIndex: 0, isOpen: false, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/DateSelector.stories.tsx
+++ b/client/src/stories/DateSelector.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { DateSelector } from '../pages/daily/components/DateSelector';
 import type { DailyEntry } from '../pages/daily/types';
+import { mockDefinition } from './mockDefinition';
 
 const meta: Meta<typeof DateSelector> = {
   title: 'Daily/DateSelector',
@@ -19,7 +20,7 @@ const entries: DailyEntry[] = [
     points: 65,
     wordsFound: 16,
     longestWord: 'BRIDGE',
-    longestWordDefinition: 'A structure carrying a road over a river.',
+    longestWordDefinition: mockDefinition('BRIDGE', 'A structure carrying a road over a river.'),
     stampTier: 'second',
     playersCount: 102,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -39,7 +40,7 @@ const entries: DailyEntry[] = [
     points: 87,
     wordsFound: 23,
     longestWord: 'FROGGLE',
-    longestWordDefinition: 'A word puzzle game.',
+    longestWordDefinition: mockDefinition('FROGGLE', 'A word puzzle game.'),
     stampTier: 'first',
     playersCount: 128,
     config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
@@ -119,6 +120,63 @@ export const OlderDateSelectedDark: Story = {
   decorators: [
     (Story) => (
       <div data-theme="dark" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+// 30 entries so the dropdown overflows its max-height and scrolls. Mixes
+// completed/missed/unplayed states + all stamp tiers.
+const manyEntries: DailyEntry[] = Array.from({ length: 30 }).map((_, i) => {
+  const dayIndex = i + 1;
+  const date = new Date(2026, 2, dayIndex + 14); // March 15 → April 13, 2026
+  const isLast = i === 29;
+  const state: DailyEntry['state'] =
+    isLast ? 'unplayed' : (i % 5 === 0 ? 'missed' : 'completed');
+
+  if (state !== 'completed') {
+    return {
+      puzzleNumber: dayIndex,
+      date,
+      state,
+      stampTier: null,
+      playersCount: 40 + (i % 20),
+      config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+    };
+  }
+
+  const tierCycle: DailyEntry['stampTier'][] = ['first', 'second', 'third', 'top30', null];
+  return {
+    puzzleNumber: dayIndex,
+    date,
+    state,
+    points: 45 + (i * 3) % 70,
+    wordsFound: 8 + (i * 2) % 18,
+    longestWord: ['BRIDGE', 'TABLET', 'CLAMP', 'SEEKER', 'LAPTOP'][i % 5],
+    longestWordDefinition: null,
+    stampTier: tierCycle[i % tierCycle.length],
+    playersCount: 40 + (i % 20),
+    config: { boardSize: 4, timeLimit: 180, minWordLength: 3 },
+  };
+});
+
+export const ScrollingLight: Story = {
+  args: { entries: manyEntries, currentIndex: manyEntries.length - 1, isOpen: true, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px', height: '500px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ScrollingDark: Story = {
+  args: { entries: manyEntries, currentIndex: manyEntries.length - 1, isOpen: true, ...callbacks },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px] relative" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px', height: '500px' }}>
         <Story />
       </div>
     ),

--- a/client/src/stories/DefinitionArea.stories.tsx
+++ b/client/src/stories/DefinitionArea.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DefinitionArea } from '../pages/daily/components/DefinitionArea';
+
+const meta: Meta<typeof DefinitionArea> = {
+  title: 'Daily/DefinitionArea',
+  component: DefinitionArea,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DefinitionArea>;
+
+const shortDefinition = {
+  word: 'FROG',
+  definition: 'A small tailless amphibian with a short squat body and very long hind legs for leaping.',
+  onExpandChange: () => {},
+};
+
+const longDefinition = {
+  word: 'SERENDIPITY',
+  definition:
+    'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them. The term was coined by Horace Walpole in 1754 based on the Persian fairy tale "The Three Princes of Serendip" whose heroes were always making discoveries by accident and sagacity.',
+  onExpandChange: () => {},
+};
+
+export const ShortLight: Story = {
+  args: shortDefinition,
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ShortDark: Story = {
+  args: shortDefinition,
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const LongTruncatedLight: Story = {
+  args: longDefinition,
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const LongTruncatedDark: Story = {
+  args: longDefinition,
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/DefinitionArea.stories.tsx
+++ b/client/src/stories/DefinitionArea.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { DefinitionArea } from '../pages/daily/components/DefinitionArea';
+import { mockDefinition } from './mockDefinition';
 
 const meta: Meta<typeof DefinitionArea> = {
   title: 'Daily/DefinitionArea',
@@ -12,14 +13,19 @@ type Story = StoryObj<typeof DefinitionArea>;
 
 const shortDefinition = {
   word: 'FROG',
-  definition: 'A small tailless amphibian with a short squat body and very long hind legs for leaping.',
+  definition: mockDefinition(
+    'FROG',
+    'A small tailless amphibian with a short squat body and very long hind legs for leaping.',
+  ),
   onExpandChange: () => {},
 };
 
 const longDefinition = {
   word: 'SERENDIPITY',
-  definition:
+  definition: mockDefinition(
+    'SERENDIPITY',
     'The faculty or phenomenon of finding valuable or agreeable things not sought for. Often associated with happy accidents or pleasant surprises that occur when one is not actively searching for them. The term was coined by Horace Walpole in 1754 based on the Persian fairy tale "The Three Princes of Serendip" whose heroes were always making discoveries by accident and sagacity.',
+  ),
   onExpandChange: () => {},
 };
 

--- a/client/src/stories/LeaderboardPage.stories.tsx
+++ b/client/src/stories/LeaderboardPage.stories.tsx
@@ -2,15 +2,61 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { LeaderboardPage } from '../pages/leaderboard/LeaderboardPage';
 import type { RankingType } from '../pages/leaderboard/components/RankingSelector';
-import type { DailyNavEntry } from '../pages/leaderboard/components/DailyNav';
 import type { RankingEntry } from '../pages/leaderboard/components/Rankings';
 import type { TopThreeEntry } from '../pages/leaderboard/components/TopThree';
+import type { DailyEntry } from '../pages/daily/types';
 
-const dailyEntries: DailyNavEntry[] = [
-  { date: '2026-04-08', puzzleNumber: 10, points: 98, wordsFound: 23, rank: 8, isToday: true },
-  { date: '2026-04-07', puzzleNumber: 9, points: 112, wordsFound: 29, rank: 5, isToday: false },
-  { date: '2026-04-06', puzzleNumber: 8, points: 61, wordsFound: 14, rank: 12, isToday: false },
-  { date: '2026-04-05', puzzleNumber: 7, points: 72, wordsFound: 18, rank: 8, isToday: false },
+const stubConfig = { boardSize: 5, timeLimit: 120, minWordLength: 4 };
+
+const dailyEntries: DailyEntry[] = [
+  {
+    puzzleNumber: 7,
+    date: new Date('2026-04-05T12:00:00'),
+    state: 'completed',
+    points: 72,
+    wordsFound: 18,
+    longestWord: 'BRIDGE',
+    longestWordDefinition: null,
+    stampTier: 'top30',
+    playersCount: 24,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 8,
+    date: new Date('2026-04-06T12:00:00'),
+    state: 'completed',
+    points: 61,
+    wordsFound: 14,
+    longestWord: 'CLAMP',
+    longestWordDefinition: null,
+    stampTier: null,
+    playersCount: 26,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 9,
+    date: new Date('2026-04-07T12:00:00'),
+    state: 'completed',
+    points: 112,
+    wordsFound: 29,
+    longestWord: 'TABLET',
+    longestWordDefinition: null,
+    stampTier: 'top30',
+    playersCount: 30,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 10,
+    date: new Date('2026-04-08T12:00:00'),
+    state: 'completed',
+    points: 98,
+    wordsFound: 23,
+    longestWord: 'FROGGLE',
+    longestWordDefinition: null,
+    stampTier: 'top30',
+    playersCount: 32,
+    config: stubConfig,
+  },
 ];
 
 const fullRankings: RankingEntry[] = [
@@ -59,7 +105,7 @@ const Interactive = ({
   totalPlayers: number;
   rank: number;
 }) => {
-  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [selectedIdx, setSelectedIdx] = useState(dailyEntries.length - 1);
   const [rankingType, setRankingType] = useState<RankingType>('points');
   const entry = dailyEntries[selectedIdx];
 
@@ -78,24 +124,9 @@ const Interactive = ({
     >
       <LeaderboardPage
         title={`Daily #${entry.puzzleNumber}`}
-        dailyEntries={dailyEntries}
-        selectedDate={entry.date}
-        onSelectDate={(date) => {
-          const idx = dailyEntries.findIndex((e) => e.date === date);
-          if (idx >= 0) setSelectedIdx(idx);
-        }}
-        onPrev={() => setSelectedIdx((i) => Math.min(i + 1, dailyEntries.length - 1))}
-        onNext={() => setSelectedIdx((i) => Math.max(i - 1, 0))}
-        hasNext={selectedIdx > 0}
-        playerCard={{
-          points: entry.points,
-          wordsFound: entry.wordsFound,
-          longestWord: 'SNOB',
-          rank,
-          totalPlayers,
-          topPercent: rank <= Math.ceil(totalPlayers * 0.3) ? Math.round((rank / totalPlayers) * 100) : null,
-          accolade: 'Only <b>6%</b> of players found <b>SNOB</b>',
-        }}
+        entries={dailyEntries}
+        currentIndex={selectedIdx}
+        onChangeIndex={setSelectedIdx}
         rankingType={rankingType}
         onRankingTypeChange={setRankingType}
         topThree={topThree}

--- a/client/src/stories/MissedCard.stories.tsx
+++ b/client/src/stories/MissedCard.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MissedCard } from '../pages/daily/components/MissedCard';
+
+const meta: Meta<typeof MissedCard> = {
+  title: 'Daily/MissedCard',
+  component: MissedCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof MissedCard>;
+
+export const Light: Story = {
+  args: { puzzleNumber: 41, playersCount: 94 },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: { puzzleNumber: 41, playersCount: 94 },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const HighPlayerCountLight: Story = {
+  args: { puzzleNumber: 1, playersCount: 1243 },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const HighPlayerCountDark: Story = {
+  args: { puzzleNumber: 1, playersCount: 1243 },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/PerformanceStamp.stories.tsx
+++ b/client/src/stories/PerformanceStamp.stories.tsx
@@ -1,0 +1,189 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PerformanceStamp } from '../pages/daily/components/PerformanceStamp';
+
+const meta: Meta<typeof PerformanceStamp> = {
+  title: 'Daily/PerformanceStamp',
+  component: PerformanceStamp,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof PerformanceStamp>;
+
+export const FirstLight: Story = {
+  args: { tier: 'first' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const FirstDark: Story = {
+  args: { tier: 'first' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SecondLight: Story = {
+  args: { tier: 'second' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SecondDark: Story = {
+  args: { tier: 'second' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ThirdLight: Story = {
+  args: { tier: 'third' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ThirdDark: Story = {
+  args: { tier: 'third' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Top30Light: Story = {
+  args: { tier: 'top30' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Top30Dark: Story = {
+  args: { tier: 'top30' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NoTierLight: Story = {
+  args: { tier: null },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const NoTierDark: Story = {
+  args: { tier: null },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+// Small variants (for inline use in date picker rows, etc.)
+
+export const SmallFirstLight: Story = {
+  args: { tier: 'first', size: 'sm' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SmallFirstDark: Story = {
+  args: { tier: 'first', size: 'sm' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SmallTop30Light: Story = {
+  args: { tier: 'top30', size: 'sm' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SmallTop30Dark: Story = {
+  args: { tier: 'top30', size: 'sm' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SmallNoTierLight: Story = {
+  args: { tier: null, size: 'sm' },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const SmallNoTierDark: Story = {
+  args: { tier: null, size: 'sm' },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/StatsCard.stories.tsx
+++ b/client/src/stories/StatsCard.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatsCard } from '../pages/daily/components/StatsCard';
+
+const meta: Meta<typeof StatsCard> = {
+  title: 'Daily/StatsCard',
+  component: StatsCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatsCard>;
+
+const defaultStats = {
+  currentStreak: 5,
+  streakDays: [true, true, false, true, true, true, true],
+  avgPoints: 72.4,
+  avgWords: 18.6,
+};
+
+export const Light: Story = {
+  args: { stats: defaultStats },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: { stats: defaultStats },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const HighStatsLight: Story = {
+  args: {
+    stats: {
+      currentStreak: 7,
+      streakDays: [true, true, true, true, true, true, true],
+      avgPoints: 124.8,
+      avgWords: 31.2,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const HighStatsDark: Story = {
+  args: {
+    stats: {
+      currentStreak: 7,
+      streakDays: [true, true, true, true, true, true, true],
+      avgPoints: 124.8,
+      avgWords: 31.2,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/StreakCard.stories.tsx
+++ b/client/src/stories/StreakCard.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StreakCard } from '../pages/daily/components/StreakCard';
+
+const meta: Meta<typeof StreakCard> = {
+  title: 'Daily/StreakCard',
+  component: StreakCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof StreakCard>;
+
+const activeStreak = {
+  currentStreak: 5,
+  streakDays: [true, true, false, true, true, true, true],
+  avgPoints: 72,
+  avgWords: 18,
+};
+
+const perfectStreak = {
+  currentStreak: 7,
+  streakDays: [true, true, true, true, true, true, true],
+  avgPoints: 95,
+  avgWords: 24,
+};
+
+const brokenStreak = {
+  currentStreak: 0,
+  streakDays: [true, true, true, false, false, false, false],
+  avgPoints: 40,
+  avgWords: 10,
+};
+
+export const Light: Story = {
+  args: { stats: activeStreak },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: { stats: activeStreak },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const PerfectStreakLight: Story = {
+  args: { stats: perfectStreak },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const PerfectStreakDark: Story = {
+  args: { stats: perfectStreak },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const BrokenStreakLight: Story = {
+  args: { stats: brokenStreak },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const BrokenStreakDark: Story = {
+  args: { stats: brokenStreak },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[340px]" style={{ backgroundColor: 'var(--page-bg)', padding: '16px', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/UnplayedCard.stories.tsx
+++ b/client/src/stories/UnplayedCard.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UnplayedCard } from '../pages/daily/components/UnplayedCard';
+
+const meta: Meta<typeof UnplayedCard> = {
+  title: 'Daily/UnplayedCard',
+  component: UnplayedCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof UnplayedCard>;
+
+const defaultConfig = {
+  boardSize: 4,
+  timeLimit: 180,
+  minWordLength: 3,
+};
+
+export const Light: Story = {
+  args: { config: defaultConfig, onStart: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Dark: Story = {
+  args: { config: defaultConfig, onStart: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const LargeBoardLight: Story = {
+  args: { config: { boardSize: 5, timeLimit: 300, minWordLength: 4 }, onStart: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="light" className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const LargeBoardDark: Story = {
+  args: { config: { boardSize: 5, timeLimit: 300, minWordLength: 4 }, onStart: () => {} },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="w-[300px] p-4" style={{ backgroundColor: 'var(--page-bg)', borderRadius: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/client/src/stories/mockDefinition.ts
+++ b/client/src/stories/mockDefinition.ts
@@ -1,0 +1,16 @@
+import type { WordDefinition } from '../pages/results/hooks/useDefinition';
+
+// Builds a minimal valid WordDefinition for stories. Accepts a raw string so
+// existing story copy can stay readable.
+export function mockDefinition(word: string, text: string): WordDefinition {
+  return {
+    word: word.toLowerCase(),
+    phonetic: undefined,
+    meanings: [
+      {
+        partOfSpeech: 'noun',
+        definitions: [{ definition: text }],
+      },
+    ],
+  };
+}

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -27,24 +27,155 @@ export function scoreResult(foundWords: string[]): ScoredResult {
   return { points, wordCount: foundWords.length, longestWord };
 }
 
+// ─── Definition lookup ────────────────────────────────────────────────────
+//
+// Mirrors the WordDefinition shape the results page already renders
+// (client/src/pages/results/hooks/useDefinition.ts) so the Daily page and
+// Results page can share a single component tree for definition display.
+
+export interface WordDefinition {
+  word: string;
+  phonetic?: string;
+  meanings: Array<{
+    partOfSpeech: string;
+    definitions: Array<{ definition: string; example?: string }>;
+  }>;
+}
+
+// Module-level cache. Shared across all users and requests; warms back up on
+// restart. No TTL — definitions don't change and the space of "daily longest
+// words" is naturally bounded. `null` is cached too so repeated lookups of a
+// word neither API knows don't re-fetch.
+const definitionCache = new Map<string, WordDefinition | null>();
+
+function parsePrimaryApi(data: unknown): WordDefinition | null {
+  const d = data as {
+    word: string;
+    entries?: {
+      partOfSpeech: string;
+      pronunciations?: { text?: string }[];
+      senses: { definition: string; examples?: string[] }[];
+    }[];
+  };
+  if (!d || !d.entries || d.entries.length === 0) return null;
+
+  const phonetic = d.entries[0]?.pronunciations?.find((p) => p.text)?.text;
+  const seen = new Set<string>();
+  const meanings: WordDefinition['meanings'] = [];
+  for (const entry of d.entries) {
+    if (seen.has(entry.partOfSpeech)) continue;
+    seen.add(entry.partOfSpeech);
+    meanings.push({
+      partOfSpeech: entry.partOfSpeech,
+      definitions: entry.senses.slice(0, 2).map((s) => ({
+        definition: s.definition,
+        example: s.examples?.[0],
+      })),
+    });
+  }
+  return { word: d.word, phonetic, meanings };
+}
+
+function parseFallbackApi(data: unknown): WordDefinition | null {
+  const arr = data as {
+    word: string;
+    phonetic?: string;
+    phonetics?: { text?: string }[];
+    meanings: {
+      partOfSpeech: string;
+      definitions: { definition: string; example?: string }[];
+    }[];
+  }[];
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+
+  const entry = arr[0];
+  return {
+    word: entry.word,
+    phonetic: entry.phonetic || entry.phonetics?.find((p) => p.text)?.text,
+    meanings: entry.meanings.map((m) => ({
+      partOfSpeech: m.partOfSpeech,
+      definitions: m.definitions.slice(0, 2).map((d) => ({
+        definition: d.definition,
+        example: d.example,
+      })),
+    })),
+  };
+}
+
+async function fetchDefinitionUncached(word: string): Promise<WordDefinition | null> {
+  try {
+    const res = await fetch(
+      `https://freedictionaryapi.com/api/v1/entries/en/${word}`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (res.ok) {
+      const parsed = parsePrimaryApi(await res.json());
+      if (parsed) return parsed;
+    }
+  } catch {
+    // Primary failed or timed out; fall through to the backup.
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.dictionaryapi.dev/api/v2/entries/en/${word}`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (res.ok) return parseFallbackApi(await res.json());
+  } catch {
+    // Both APIs failed — treat the word as undefinable.
+  }
+
+  return null;
+}
+
+async function getDefinitions(words: string[]): Promise<Map<string, WordDefinition | null>> {
+  const result = new Map<string, WordDefinition | null>();
+  const misses: string[] = [];
+
+  for (const raw of words) {
+    const w = raw.toLowerCase();
+    if (result.has(w)) continue;
+    if (definitionCache.has(w)) {
+      result.set(w, definitionCache.get(w)!);
+    } else {
+      misses.push(w);
+    }
+  }
+
+  // Parallel so total latency ≈ slowest single call, not sum of all calls.
+  const fetched = await Promise.all(
+    misses.map(async (w) => [w, await fetchDefinitionUncached(w)] as const),
+  );
+  for (const [w, def] of fetched) {
+    definitionCache.set(w, def);
+    result.set(w, def);
+  }
+  return result;
+}
+
+// ─── Stats endpoint ───────────────────────────────────────────────────────
+
+export type DailyState = 'completed' | 'missed' | 'unplayed';
+export type StampTier = 'first' | 'second' | 'third' | 'top30' | null;
+
 export interface DailyStatsDay {
   date: string;
   puzzleNumber: number;
-  played: boolean;
-  result: {
-    points: number;
-    wordsFound: number;
-    longestWord: string;
-    rank: number;
-    totalPlayers: number;
-    placedTop3: boolean;
-    placedTop30Percent: boolean;
-  } | null;
+  state: DailyState;
+  points: number | null;
+  wordsFound: number | null;
+  longestWord: string | null;
+  longestWordDefinition: WordDefinition | null;
+  stampTier: StampTier;
+  playersCount: number;
 }
 
 export interface DailyStatsResponse {
-  streak: number;
-  sevenDayAvg: { points: number; wordsFound: number };
+  currentStreak: number;
+  streakDays: boolean[];
+  avgPoints: number;
+  avgWords: number;
   windowStart: string;
   windowEnd: string;
   days: DailyStatsDay[];
@@ -69,6 +200,14 @@ function maxDate(a: string, b: string): string {
   return a >= b ? a : b;
 }
 
+function stampTierFor(rank: number, totalPlayers: number): StampTier {
+  if (rank === 1) return 'first';
+  if (rank === 2) return 'second';
+  if (rank === 3) return 'third';
+  if (rank <= Math.ceil(totalPlayers * 0.3)) return 'top30';
+  return null;
+}
+
 export async function getDailyStats(
   db: Kysely<Database>,
   userId: string,
@@ -79,11 +218,8 @@ export async function getDailyStats(
   const windowStart = maxDate(addDays(today, -(windowDays - 1)), launchDate);
   const windowEnd = today;
 
-  // Single query: per-day rank + total_players, filtered to this user's rows.
-  // Tiebreak order matches what "placed top 3" promises to users:
-  // points DESC, word_count DESC, earliest completion wins.
-  // Window functions go through sql fragments since Kysely has no first-class
-  // window-function builder, but the CTE and column wiring stay type-safe.
+  // Query 1: this user's rank + aggregates per date they played.
+  // Tiebreak matches "placed top 3" as presented to users.
   const rankedRows = await db
     .with('ranked', (qb) =>
       qb
@@ -95,72 +231,111 @@ export async function getDailyStats(
           'word_count',
           'longest_word',
           sql<number>`rank() over (partition by ${eb.ref('date')} order by ${eb.ref('points')} desc, ${eb.ref('word_count')} desc, ${eb.ref('completed_at')} asc)`.as('rank'),
-          sql<number>`count(*) over (partition by ${eb.ref('date')})`.as('total_players'),
         ])
         .where('date', '>=', windowStart)
         .where('date', '<=', windowEnd)
     )
     .selectFrom('ranked')
-    .select(['date', 'points', 'word_count', 'longest_word', 'rank', 'total_players'])
+    .select(['date', 'points', 'word_count', 'longest_word', 'rank'])
     .where('user_id', '=', userId)
     .execute();
 
-  const byDate = new Map<string, typeof rankedRows[number]>();
-  for (const row of rankedRows) byDate.set(row.date, row);
+  // Query 2: total players per date in the window — needed for every day,
+  // not just days this user played, so the UI can show player counts on
+  // missed/unplayed days too.
+  const playerCountRows = await db
+    .selectFrom('daily_results')
+    .select((eb) => ['date', eb.fn.countAll<number>().as('players')])
+    .where('date', '>=', windowStart)
+    .where('date', '<=', windowEnd)
+    .groupBy('date')
+    .execute();
+
+  const userByDate = new Map<string, typeof rankedRows[number]>();
+  for (const row of rankedRows) userByDate.set(row.date, row);
+
+  const playersByDate = new Map<string, number>();
+  for (const row of playerCountRows) playersByDate.set(row.date, Number(row.players));
+
+  // Fetch definitions once per unique longest word — dedupe before calling.
+  const uniqueLongestWords = Array.from(
+    new Set(rankedRows.map((r) => r.longest_word).filter((w): w is string => !!w)),
+  );
+  const definitions = await getDefinitions(uniqueLongestWords);
 
   const days: DailyStatsDay[] = [];
   for (let d = windowStart; d <= windowEnd; d = addDays(d, 1)) {
-    const row = byDate.get(d);
-    if (!row) {
+    const userRow = userByDate.get(d);
+    const playersCount = playersByDate.get(d) ?? 0;
+
+    if (!userRow) {
+      // User didn't play this day. "Unplayed" only applies to today; past
+      // dates without a row are misses.
       days.push({
         date: d,
         puzzleNumber: getPuzzleNumber(d),
-        played: false,
-        result: null,
+        state: d === today ? 'unplayed' : 'missed',
+        points: null,
+        wordsFound: null,
+        longestWord: null,
+        longestWordDefinition: null,
+        stampTier: null,
+        playersCount,
       });
       continue;
     }
 
-    // Postgres returns bigint for count(); rank() is int but Kysely types it
-    // loosely. Coerce both defensively in case the driver hands back strings.
-    const rank = Number(row.rank);
-    const totalPlayers = Number(row.total_players);
+    const rank = Number(userRow.rank);
     days.push({
       date: d,
       puzzleNumber: getPuzzleNumber(d),
-      played: true,
-      result: {
-        points: row.points,
-        wordsFound: row.word_count,
-        longestWord: row.longest_word,
-        rank,
-        totalPlayers,
-        placedTop3: rank <= 3,
-        // Ceiling so the single-player case (1 of 1) still counts as top 30%.
-        placedTop30Percent: rank <= Math.ceil(totalPlayers * 0.3),
-      },
+      state: 'completed',
+      points: userRow.points,
+      wordsFound: userRow.word_count,
+      longestWord: userRow.longest_word,
+      longestWordDefinition: definitions.get(userRow.longest_word.toLowerCase()) ?? null,
+      stampTier: stampTierFor(rank, playersCount),
+      playersCount,
     });
   }
 
   // Streak: walk backwards from today; today missing is not a break yet.
-  // Starting point is today if played, else yesterday.
-  let streak = 0;
+  let currentStreak = 0;
   for (let i = days.length - 1; i >= 0; i--) {
     const day = days[i];
-    if (i === days.length - 1 && !day.played) continue; // today unplayed: OK
-    if (!day.played) break;
-    streak++;
+    if (i === days.length - 1 && day.state === 'unplayed') continue;
+    if (day.state !== 'completed') break;
+    currentStreak++;
   }
 
-  // 7-day avg: last 7 PLAYED days (any time in window).
-  const playedDays = days.filter((d) => d.played);
-  const recentPlayed = playedDays.slice(-7);
-  const sevenDayAvg = recentPlayed.length === 0
-    ? { points: 0, wordsFound: 0 }
-    : {
-        points: recentPlayed.reduce((s, d) => s + (d.result?.points ?? 0), 0) / recentPlayed.length,
-        wordsFound: recentPlayed.reduce((s, d) => s + (d.result?.wordsFound ?? 0), 0) / recentPlayed.length,
-      };
+  // streakDays: last 7 PST days ending at today, oldest-to-newest.
+  // Slicing the tail of `days` works because days is already in that order
+  // and the window always ends at today. If the window is shorter than 7
+  // (very early post-launch), pad the front with `false`.
+  const tail = days.slice(-7);
+  const streakDays: boolean[] = [
+    ...Array(Math.max(0, 7 - tail.length)).fill(false),
+    ...tail.map((d) => d.state === 'completed'),
+  ];
 
-  return { streak, sevenDayAvg, windowStart, windowEnd, days };
+  // 7-day avg: last 7 PLAYED days anywhere in window. Includes today if
+  // played, so a user who just submitted sees it reflected immediately.
+  const completed = days.filter((d) => d.state === 'completed');
+  const recent = completed.slice(-7);
+  const avgPoints = recent.length === 0
+    ? 0
+    : recent.reduce((s, d) => s + (d.points ?? 0), 0) / recent.length;
+  const avgWords = recent.length === 0
+    ? 0
+    : recent.reduce((s, d) => s + (d.wordsFound ?? 0), 0) / recent.length;
+
+  return {
+    currentStreak,
+    streakDays,
+    avgPoints,
+    avgWords,
+    windowStart,
+    windowEnd,
+    days,
+  };
 }


### PR DESCRIPTION
## Summary

Finishes Phase 5 of the daily page work. The parked FE commit (carousel, cards, date selector, stamps) now runs against the real \`GET /api/daily/stats\` endpoint shipped in #39, and \`/daily\` is the canonical Daily Puzzle page — landing card always routes here regardless of whether today is played.

- **Endpoint reshape**: \`days[]\` returns a flat, UI-ready shape (\`state\` enum, \`stampTier\`, \`playersCount\`, \`longestWordDefinition\` as structured \`WordDefinition\`). Rank / placedTop3 / placedTop30Percent are folded into \`stampTier\`. Per-date player counts come from a second query so missed / unplayed days still surface participation.
- **Definitions**: fetched server-side per unique longest word, parallelized, cached in a module-level \`Map\` across requests. Structure matches what the results page already renders.
- **Client wiring**: \`DailyRoute\` calls \`fetchDailyStats\` + \`fetchDaily\` and adapts to \`DailyEntry[]\` + \`DailyStats\`. \"Start\" button bypasses the config page and begins the daily game directly.
- **Share parity**: completed card share button now uses the same popover UX as the results page (native share + copy-to-clipboard with feedback). Share text is built by fetching the day's submission and scoring client-side.
- **Navigation polish**: back buttons unified on the \`‹\` glyph across Daily / Leaderboard / Config / Results. Results page gets a back button that skips the game page (daily → \`/daily\`, freeplay → \`/play\`). Leaderboard back uses \`navigate(-1)\`.
- **Leaderboard picker**: swapped \`DailyNav\` for the daily page's \`DateSelector\` + \`BlurOverlay\`, both driven by the same stats endpoint so entries are identical in data and UI.
- **Layout fixes**: \`BlurOverlay\` promoted to fixed/inset-0 so it covers the App padding; \`DateSelector\` dropdown positioned below its trigger in any host layout; picker stamp honors its \`sm\` size (a stray hardcoded 25px circle overrode it).
- **Stories**: updated to match new types, added a scrolling many-entries story for the picker.

## Test plan

- [x] TypeScript passes on client + server
- [x] Local smoke test of endpoint shape against staging data
- [ ] Start daily game from the new page → gameplay → results → back lands on \`/daily\`
- [ ] Freeplay → results → back lands on \`/play\`
- [ ] Daily card on landing (pre- and post-play) lands on \`/daily\` (not leaderboard)
- [ ] Share popover: native option on mobile, copy on desktop, \"Copied!\" feedback
- [ ] Leaderboard picker renders identically to daily's
- [ ] Blur overlay covers the full viewport on both daily and leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)