### PR TITLE
fix(daily): polish daily page nav and carousel load

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const showTitle = ['/game', '/results', '/daily/results'].includes(location.pathname);
+  const showTitle = ['/game'].includes(location.pathname);
 
   const handleTitleClick = () => {
     if (game?.status === GameState.InProgress) {

--- a/client/src/pages/daily/DailyRoute.tsx
+++ b/client/src/pages/daily/DailyRoute.tsx
@@ -104,10 +104,14 @@ export function DailyPuzzleRoute() {
     [statsResponse],
   );
 
-  const [currentIndex, setCurrentIndex] = useState(0);
+  // Seeded lazily once entries are available so the carousel mounts
+  // already pointing at today instead of animating from index 0.
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
   useEffect(() => {
-    if (entries.length > 0) setCurrentIndex(entries.length - 1);
-  }, [entries.length]);
+    if (currentIndex === null && entries.length > 0) {
+      setCurrentIndex(entries.length - 1);
+    }
+  }, [entries.length, currentIndex]);
 
   const nextPuzzleCountdown = useCountdownToNextPuzzle();
 
@@ -137,10 +141,16 @@ export function DailyPuzzleRoute() {
   );
 
   const handleViewLeaderboard = useCallback(
-    (_puzzleNumber: number) => {
-      navigate(`/leaderboard`);
+    (puzzleNumber: number) => {
+      const entry = entries.find((e) => e.puzzleNumber === puzzleNumber);
+      if (!entry) {
+        navigate('/leaderboard');
+        return;
+      }
+      const dateStr = entry.date.toISOString().slice(0, 10);
+      navigate(`/leaderboard?date=${dateStr}`);
     },
-    [navigate],
+    [navigate, entries],
   );
 
   // Given a puzzle number in the current window, build the share text the
@@ -175,7 +185,7 @@ export function DailyPuzzleRoute() {
     );
   }
 
-  if (!statsResponse || !dailyInfo) {
+  if (!statsResponse || !dailyInfo || currentIndex === null) {
     return (
       <div className="p-8 text-center" style={{ color: "var(--text-muted)" }}>
         Loading…

--- a/client/src/pages/daily/components/CardCarousel.tsx
+++ b/client/src/pages/daily/components/CardCarousel.tsx
@@ -128,10 +128,14 @@ export function CardCarousel({
     track.style.transform = `translateX(${offset}px)`;
   }
 
-  // Animate to the current index whenever it changes
+  // Animate to the current index whenever it changes. The first transform
+  // after mount skips the transition so the carousel appears already
+  // positioned on the initial card instead of scrolling into place.
+  const hasPositioned = useRef(false);
   useEffect(() => {
     if (cardWidth > 0) {
-      applyTransform(getOffset(currentIndex), true);
+      applyTransform(getOffset(currentIndex), hasPositioned.current);
+      hasPositioned.current = true;
     }
   }, [currentIndex, cardWidth, getOffset]);
 

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useGame } from '../../GameContext';
 import {
   fetchLeaderboard,
@@ -35,9 +35,14 @@ function adaptDay(day: DailyStatsDay, config: DailyInfo['config']): DailyEntry {
 
 export function LeaderboardRoute() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { dailyInfo } = useGame();
 
-  const [selectedDate, setSelectedDate] = useState<string>(dailyInfo?.date ?? getTodayPST());
+  // ?date=YYYY-MM-DD takes precedence so the daily page's leaderboard button
+  // can deep-link to whichever day the user was viewing.
+  const [selectedDate, setSelectedDate] = useState<string>(
+    searchParams.get('date') ?? dailyInfo?.date ?? getTodayPST(),
+  );
   const [rankingType, setRankingType] = useState<RankingType>('points');
   const [leaderboard, setLeaderboard] = useState<LeaderboardResponse | null>(null);
   const [stats, setStats] = useState<DailyStatsResponse | null>(null);

--- a/client/src/pages/results/ResultsPage.tsx
+++ b/client/src/pages/results/ResultsPage.tsx
@@ -99,16 +99,34 @@ export const ResultsPage = ({ results, onPlayAgain, onBack, game, gameSeed, dail
   };
 
   return (
-    <div className="py-2.5 relative">
-      <button
-        type="button"
-        onClick={onBack}
-        aria-label="Back"
-        className="absolute left-0 top-2.5 text-lg cursor-pointer leading-none flex bg-transparent border-none z-10"
-        style={{ color: "var(--text-muted)", WebkitTapHighlightColor: "transparent" }}
-      >
-        &#8249;
-      </button>
+    <div className="py-2.5">
+      {/* Page header — matches the daily/leaderboard pattern: chevron on
+          the left, title centered. Replaces the App-level title on these
+          routes so the back button can sit inline with "Froggle". */}
+      <div className="flex items-center justify-center relative mb-2.5">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back"
+          className="absolute left-[18px] top-1/2 -translate-y-1/2 text-lg cursor-pointer leading-none flex bg-transparent border-none"
+          style={{ color: "var(--text-muted)", WebkitTapHighlightColor: "transparent" }}
+        >
+          &#8249;
+        </button>
+        <h1
+          className="m-0"
+          style={{
+            fontSize: '1.35rem',
+            letterSpacing: '-0.025em',
+            fontFamily: 'var(--font-heading)',
+            fontWeight: 'var(--font-heading-weight)' as any,
+            color: 'var(--text)',
+          }}
+        >
+          Froggle
+        </h1>
+      </div>
+
       <div className={boardMinimized ? 'flex flex-row gap-4 items-start h-[440px]' : 'flex flex-col gap-4 h-auto'}>
         {/* Board section */}
         <div className={`flex flex-col min-w-0 max-h-full ${boardMinimized ? 'w-1/2 shrink-0' : 'w-full max-w-[500px]'}`}>


### PR DESCRIPTION
## Summary

Three small follow-ups surfaced while testing #40 on staging:

- **Leaderboard deep-linking from daily cards** — the Leaderboard button on a card now navigates to \`/leaderboard?date=<that-day>\` so older dates open the leaderboard for the correct day, not today.
- **Results back button placement** — moved into a proper header row with \"Froggle\" centered, matching the daily/leaderboard pattern. \`App.tsx\` drops \`/results\` + \`/daily/results\` from its title-rendering list so there's no duplication.
- **Daily carousel initial load** — the page used to flash rendering at index 0 and then animate to today. \`DailyRoute\` seeds \`currentIndex\` lazily once entries arrive, and \`CardCarousel\` skips the transition on its first transform. The page mounts already positioned on today's card.

## Test plan

- [ ] Daily page → Leaderboard button on today's card → lands on today's leaderboard
- [ ] Daily page → Leaderboard button on a past day's card → lands on that day's leaderboard
- [ ] Play a daily → results page shows a back button inline with \"Froggle\" → back goes to \`/daily\`
- [ ] Freeplay → results page back button goes to \`/play\`
- [ ] Visit \`/daily\` — carousel mounts on today's card with no animation
- [ ] Swipe between carousel cards — animations still play

🤖 Generated with [Claude Code](https://claude.com/claude-code)