### PR TITLE
fix(game): uppercase in-progress word including Qu tile

### DIFF
--- a/client/src/pages/game/GamePage.tsx
+++ b/client/src/pages/game/GamePage.tsx
@@ -136,12 +136,12 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
         }}
       >
         {wordFeedback === 'valid' && BOARD_STYLE.validAnim === 3
-          ? displayWord.split('').map((letter, i) => (
+          ? displayWord.toUpperCase().split('').map((letter, i) => (
               <span key={i} className="inline-block" style={{ animation: 'letter-wave 0.4s ease both', animationDelay: `${i * 0.04}s` }}>
                 {letter}
               </span>
             ))
-          : displayWord
+          : displayWord.toUpperCase()
         }
       </div>
 


### PR DESCRIPTION
## What

Uppercases the word display on the game screen so `Qu` tiles render as `QU` alongside the rest of the capitalised letters while a player is swiping, and when the post-submit feedback word briefly flashes.

## Why this approach

The board stores multi-letter cells literally as `"Qu"` (see `engine/board.ts`), so any string built from `board[row][col]` inherits that casing. Rather than changing the canonical string the Board component constructs (which may be useful to future consumers that care about the original casing), the fix is applied at the display layer in `GamePage.tsx` — one `.toUpperCase()` on each of the two render branches (per-letter wave animation and plain string).

## Follow-ups

- None. The submitted-word list and results page already go through `.toUpperCase()` / uppercase rendering, so no other surface shows mixed-case `Qu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)