### PR TITLE
fix(results): polish word list + leaderboard teaser

### DIFF
--- a/client/src/pages/results/DailyResultsRoute.tsx
+++ b/client/src/pages/results/DailyResultsRoute.tsx
@@ -34,7 +34,7 @@ function toTeaserEntry(
 }
 
 export function DailyResultsRoute() {
-  const { dailyInfo, setDailyInfo, cancelGame, game, results } = useGame();
+  const { dailyInfo, setDailyInfo, cancelGame, game, results, cachedDailyResult } = useGame();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const fromSource = searchParams.get('from');
@@ -80,16 +80,14 @@ export function DailyResultsRoute() {
     const fetchResult = liveDailyResults
       ? Promise.resolve(null)
       : fetchDailyResult(targetDate);
-    const fetchLb = fetchLeaderboard(targetDate).catch(() => null);
 
-    Promise.all([fetchResult, fetchLb])
-      .then(([result, lb]) => {
+    fetchResult
+      .then((result) => {
         if (!liveDailyResults && !result) {
           navigate('/');
           return;
         }
         setServerResult(result);
-        setLeaderboard(lb);
         setLoading(false);
       })
       .catch(() => {
@@ -97,6 +95,19 @@ export function DailyResultsRoute() {
         setLoading(false);
       });
   }, [targetDate, liveDailyResults, navigate]);
+
+  // Leaderboard fetch is decoupled from the result fetch. On a fresh daily
+  // completion (liveDailyResults truthy) the server hasn't yet recorded
+  // the player's row — firing `fetchLeaderboard` immediately would return
+  // a teaser that omits the current user. Wait for GameContext to confirm
+  // the server record via `cachedDailyResult` before fetching.
+  useEffect(() => {
+    if (!targetDate) return;
+    if (liveDailyResults && !cachedDailyResult) return;
+    fetchLeaderboard(targetDate)
+      .then(setLeaderboard)
+      .catch(() => setLeaderboard(null));
+  }, [targetDate, liveDailyResults, cachedDailyResult]);
 
   // Stats for the picker entries — fetched once, independent of the
   // current target date.

--- a/client/src/pages/results/components/LeaderboardTeaser.tsx
+++ b/client/src/pages/results/components/LeaderboardTeaser.tsx
@@ -66,24 +66,24 @@ function Row({
   return (
     <div
       className={[
-        'flex justify-between items-center tabular-nums text-xs',
+        'flex items-center gap-2 tabular-nums text-xs',
         separated ? 'py-[5px] border-t border-b border-[var(--ink-border-subtle)]' : '',
       ].join(' ')}
     >
       <span
         className={[
-          'min-w-6 text-[11px] font-[family-name:var(--font-structure)]',
+          'shrink-0 min-w-6 text-[11px] font-[family-name:var(--font-structure)]',
           you ? 'text-[color:var(--ink)]' : 'text-[color:var(--ink-soft)]',
         ].join(' ')}
         style={{ fontWeight: 700, letterSpacing: '0.02em' }}
       >
         #{entry.rank}
       </span>
-      <span className={`flex-1 truncate ${nameColor}`} style={{ fontWeight: nameWeight }}>
+      <span className={`flex-1 min-w-0 truncate ${nameColor}`} style={{ fontWeight: nameWeight }}>
         {you ? 'you' : entry.name}
       </span>
       <span
-        className="text-[color:var(--ink)] font-[family-name:var(--font-structure)]"
+        className="shrink-0 text-[color:var(--ink)] font-[family-name:var(--font-structure)]"
         style={{ fontWeight: 700 }}
       >
         {entry.score}

--- a/client/src/pages/results/components/WordsCard.tsx
+++ b/client/src/pages/results/components/WordsCard.tsx
@@ -116,10 +116,10 @@ export function WordsCard({
         <button
           type="button"
           onClick={() => swapTo(mode === 'found' ? 'missed' : 'found')}
-          className="flex items-center justify-between px-3 py-[9px] text-label-xs uppercase tracking-[0.08em] text-[color:var(--ink-soft)] bg-[var(--ink-whisper)] border-t border-[var(--ink-border-subtle)] cursor-pointer hover:text-[color:var(--ink-muted)] transition-colors duration-150 font-[family-name:var(--font-structure)]"
+          className="flex items-center justify-between px-3 py-[9px] text-label-xs uppercase tracking-[0.08em] text-[color:var(--ink-muted)] bg-[var(--ink-whisper)] border-x-0 border-b-0 border-t border-[var(--ink-border-subtle)] leading-none cursor-pointer hover:text-[color:var(--ink)] transition-colors duration-150 font-[family-name:var(--font-structure)]"
           style={{ fontWeight: 700, WebkitTapHighlightColor: 'transparent' }}
         >
-          <span>{mode === 'found' ? 'Missed' : 'Found'}</span>
+          <span>{mode === 'found' ? 'All words' : 'Found'}</span>
           <span aria-hidden className="text-[color:var(--ink-faint)]">
             {mode === 'found' ? '›' : '‹'}
           </span>

--- a/client/src/pages/results/components/WordsCard.tsx
+++ b/client/src/pages/results/components/WordsCard.tsx
@@ -82,7 +82,7 @@ export function WordsCard({
     <div className="flex flex-col min-h-0 rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
       <SectionHeader
         label={mode === 'found' ? 'Found' : 'All words'}
-        count={mode === 'found' ? foundWords.length : foundWords.length + missedWords.length}
+        count={mode === 'found' ? foundWords.length : null}
         trailing={mode === 'found' ? String(foundTotal) : `${foundWords.length}/${foundWords.length + missedWords.length}`}
       />
 
@@ -135,7 +135,7 @@ function SectionHeader({
   trailing,
 }: {
   label: string;
-  count: number;
+  count: number | null;
   trailing: string | null;
 }) {
   return (
@@ -144,7 +144,8 @@ function SectionHeader({
       style={{ fontWeight: 700 }}
     >
       <span>
-        {label} <span className="tabular-nums">· {count}</span>
+        {label}
+        {count !== null && <span className="tabular-nums"> · {count}</span>}
       </span>
       {trailing !== null && <span className="tabular-nums">{trailing}</span>}
     </div>


### PR DESCRIPTION
## Summary

Four small post-staging fixes on the results page, plus a typography cleanup on the "All words" header.

- **Rename** the anchored toggle label from **Missed → All words** so the label matches what the list actually shows after swap (found + missed combined).
- **Anchored toggle visual** now matches the "Found" header. Root cause of the ghost border: the anchored element is a `<button>` and inherits the browser default side/bottom borders on top of our explicit `border-t`. Zeroed with `border-x-0 border-b-0`.
- **Leaderboard teaser truncation** — added `min-w-0` to the flex-1 name cell so `truncate` actually kicks in. Without it iOS Safari refuses to shrink the flex item, and long names crushed the score against the name on narrow devices. Also swapped `justify-between` for an explicit `gap-2` so the spacing rules out of layout, not out of residual space.
- **Teaser missing the current user on a fresh completion** — `DailyResultsRoute` was firing `fetchLeaderboard` inside the same `Promise.all` as the result fetch, which raced the `recordDailyResultToServer` call in `GameContext`. Decoupled the leaderboard fetch and gated it on `cachedDailyResult` when `liveDailyResults` is truthy, so the teaser waits until the server record is confirmed. Historical views and non-live entries still fetch immediately.
- **All words header** dropped the bare count on the left since the `x/y` ratio on the right already carries the total. "FOUND · 11" keeps its count since there's no ratio to pair it with.

## Why

All five issues were surfaced on staging from a real phone session. The teaser race was the only one with a non-visual root cause — the rest were polish that didn't show up on the desktop dev loop.

## Follow-ups

- None. Each fix is local to its file.

## Test plan

- [ ] Fresh daily completion: on first land, teaser shows the player's own row alongside the top rankings
- [ ] Historical daily results (`?date=YYYY-MM-DD`): teaser still shows top + self row, no extra loading
- [ ] Free play results: Missed tab swaps to "All words" header with "x/y" on the right, no bare count on the left
- [ ] Anchored toggle: single top border, matches the Found header's bg/color, no ghost side/bottom borders
- [ ] iPhone SE (375×667): long player names in the teaser truncate and the score stays right-aligned