### PR TITLE
feat(landing,picker): next-daily countdown + picker player count

### DIFF
--- a/client/src/pages/landing/components/DailyCard.tsx
+++ b/client/src/pages/landing/components/DailyCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { StreakBar } from "./StreakBar";
 import { InkButton } from "../../../shared/components/InkButton";
 import type { DailyResults } from "../types";
@@ -51,6 +52,7 @@ export function DailyCard({
               <SecondaryButton onClick={onSeeResult}>See result</SecondaryButton>
               <SecondaryButton onClick={onSeeLeaderboard}>Leaderboard</SecondaryButton>
             </div>
+            <NextDailyCountdown />
           </>
         ) : (
           <>
@@ -107,6 +109,61 @@ function ScoreBlock({
       </div>
     </div>
   );
+}
+
+function NextDailyCountdown() {
+  const [msLeft, setMsLeft] = useState(msUntilNextDailyPST);
+  useEffect(() => {
+    const id = setInterval(() => setMsLeft(msUntilNextDailyPST()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div
+      className="flex items-center justify-center gap-[5px] text-[11px] text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-ui)] -mt-0.5"
+      style={{ fontWeight: 500 }}
+    >
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className="opacity-80"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+      Next daily in {formatCountdown(msLeft)}
+    </div>
+  );
+}
+
+function msUntilNextDailyPST(): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date());
+  const h = Number(parts.find((p) => p.type === 'hour')!.value) % 24;
+  const m = Number(parts.find((p) => p.type === 'minute')!.value);
+  const s = Number(parts.find((p) => p.type === 'second')!.value);
+  return Math.max(0, (24 * 3600 - (h * 3600 + m * 60 + s)) * 1000);
+}
+
+function formatCountdown(ms: number): string {
+  const totalS = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalS / 3600);
+  const m = Math.floor((totalS % 3600) / 60);
+  const s = totalS % 60;
+  if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m`;
+  return `${m}m ${String(s).padStart(2, '0')}s`;
 }
 
 function PrimaryPlayButton({ onClick }: { onClick: () => void }) {

--- a/client/src/pages/results/__fixtures__/daily.ts
+++ b/client/src/pages/results/__fixtures__/daily.ts
@@ -1,6 +1,7 @@
 import { GameState, type Game } from 'models';
 import type { GameResults } from '../../../shared/types';
 import type { DailyResultsExtras } from '../ResultsPage';
+import type { DailyEntry } from '../../daily/types';
 
 // Canned daily-results payload used by the dev-only `?mock=daily` branch in
 // ResultsRoute. Words span every rarity tier so the stripes are visible.
@@ -48,6 +49,87 @@ export const dailyDefaultGame: Game = {
   },
 };
 
+const stubConfig = { boardSize: 5, timeLimit: 120, minWordLength: 3 };
+
+const pickerEntries: DailyEntry[] = [
+  {
+    puzzleNumber: 14,
+    date: new Date('2026-04-21T12:00:00'),
+    state: 'completed',
+    points: 142,
+    wordsFound: 19,
+    longestWord: 'CAPTIONS',
+    longestWordDefinition: null,
+    stampTier: 'top30',
+    playersCount: 38,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 13,
+    date: new Date('2026-04-20T12:00:00'),
+    state: 'completed',
+    points: 91,
+    wordsFound: 15,
+    longestWord: 'BRIDGE',
+    longestWordDefinition: null,
+    stampTier: null,
+    playersCount: 42,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 12,
+    date: new Date('2026-04-19T12:00:00'),
+    state: 'missed',
+    stampTier: null,
+    playersCount: 29,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 11,
+    date: new Date('2026-04-18T12:00:00'),
+    state: 'completed',
+    points: 78,
+    wordsFound: 12,
+    longestWord: 'CANDLE',
+    longestWordDefinition: null,
+    stampTier: 'first',
+    playersCount: 31,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 10,
+    date: new Date('2026-04-17T12:00:00'),
+    state: 'completed',
+    points: 104,
+    wordsFound: 17,
+    longestWord: 'PLATES',
+    longestWordDefinition: null,
+    stampTier: 'top30',
+    playersCount: 47,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 9,
+    date: new Date('2026-04-16T12:00:00'),
+    state: 'missed',
+    stampTier: null,
+    playersCount: 35,
+    config: stubConfig,
+  },
+  {
+    puzzleNumber: 8,
+    date: new Date('2026-04-15T12:00:00'),
+    state: 'completed',
+    points: 88,
+    wordsFound: 14,
+    longestWord: 'CLAMP',
+    longestWordDefinition: null,
+    stampTier: null,
+    playersCount: 26,
+    config: stubConfig,
+  },
+];
+
 export const dailyDefaultExtras: DailyResultsExtras = {
   dateLabel: 'Tuesday, Apr 21',
   leaderboardTop: [
@@ -56,4 +138,8 @@ export const dailyDefaultExtras: DailyResultsExtras = {
   ],
   leaderboardYou: { rank: 47, name: 'you', score: 142 },
   onOpenLeaderboard: () => {},
+  pickerEntries,
+  onPickerSelect: () => {},
+  todayDate: '2026-04-21',
+  selectedDate: '2026-04-21',
 };

--- a/client/src/shared/components/DateTimelinePicker.tsx
+++ b/client/src/shared/components/DateTimelinePicker.tsx
@@ -262,22 +262,25 @@ function DayCard({
     >
       <DateSquare day={day} wday={wday} missed={missed} isToday={isToday} />
       <div className="flex flex-col gap-[3px] min-w-0">
-        <div
-          className={[
-            'italic text-[13px] tracking-[-0.01em] leading-[1.1] font-[family-name:var(--font-display)]',
-            missed ? 'text-[color:var(--ink-soft)]' : 'text-[color:var(--ink)]',
-          ].join(' ')}
-          style={{ fontWeight: 500 }}
-        >
-          {headline}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span
+            className={[
+              'italic text-[13px] tracking-[-0.01em] leading-[1.1] font-[family-name:var(--font-display)] truncate',
+              missed ? 'text-[color:var(--ink-soft)]' : 'text-[color:var(--ink)]',
+            ].join(' ')}
+            style={{ fontWeight: 500 }}
+          >
+            {headline}
+          </span>
           {isToday && (
             <span
-              className="inline-flex items-center ml-1.5 px-1.5 rounded-full bg-[var(--ink)] text-[color:var(--ink-inverse)] text-[8px] uppercase tracking-[0.08em] align-middle not-italic font-[family-name:var(--font-structure)]"
+              className="shrink-0 inline-flex items-center px-1.5 rounded-full bg-[var(--ink)] text-[color:var(--ink-inverse)] text-[8px] uppercase tracking-[0.08em] font-[family-name:var(--font-structure)]"
               style={{ fontWeight: 700, lineHeight: '1.4' }}
             >
               Now
             </span>
           )}
+          <PlayerCount count={entry.playersCount} />
         </div>
         {missed ? (
           <div
@@ -313,6 +316,24 @@ function DayCard({
         <span aria-hidden />
       )}
     </button>
+  );
+}
+
+function PlayerCount({ count }: { count: number }) {
+  return (
+    <span
+      className="shrink-0 flex items-center gap-[3px] text-[10px] tabular-nums text-[color:var(--ink-faint)] font-[family-name:var(--font-structure)]"
+      style={{ fontWeight: 600 }}
+      aria-label={`${count} ${count === 1 ? 'player' : 'players'}`}
+    >
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M17 20v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 20v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+      {count}
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Two small additions to the post-daily surfaces.

- **Daily card countdown (landing, completed state)** — once today's daily is done, show a small "Next daily in Xh YYm" line below the result/leaderboard buttons. Ticks every 1s; format shrinks to "Mm SSs" once under an hour. Computes the delta to the next PST (America/Los_Angeles) midnight via `Intl.DateTimeFormat` parts, so DST transitions are handled by the browser rather than hard-coded offsets.
- **Picker player counts** — each row in the date timeline picker now surfaces the puzzle's total players next to the day label. On Today the count sits after the "Now" badge so the badge stays adjacent to the headline; on every other row it sits right against the day name. Uses a small person icon + tabular-nums in ink-faint so it reads as supporting info.

Fixture extended to exercise the picker from `?mock=daily` for visual verification.

## Why

- The completion state gave no sense of *when* the next daily lands — users had to check the clock. A small countdown is the lightest way to close that loop without pulling anyone off the page.
- The picker already groups days by week and shows per-day score/words, but players had no sense of how competitive a historical day was. Player count is a cheap signal that rides in the headline row without adding a new column.

## Follow-ups

- Countdown ticks every second. If this ever lives on a page with other 1s tickers we can share a tick hook, but for the single-card case `setInterval(1000)` is fine.

## Test plan

- [ ] Landing (completed state): countdown below the two secondary buttons, updates each second, transitions from `Hh MMm` to `Mm SSs` crossing the hour boundary
- [ ] Countdown respects PST regardless of viewer timezone (verify by changing system TZ or by checking the value at a known PST clock)
- [ ] Picker: player count renders on every row — completed, missed, today
- [ ] Picker: on today, the order reads `Today` → `Now` badge → player count
- [ ] iPhone SE (375×667): no horizontal overflow in the picker row even with 3-digit player counts