### PR TITLE
fix(landing): streak bars no longer conditional on today's play state

### DIFF
--- a/client/src/pages/landing/components/DailyCard.tsx
+++ b/client/src/pages/landing/components/DailyCard.tsx
@@ -42,7 +42,7 @@ export function DailyCard({
         </span>
       </div>
 
-      <div className="px-5 pt-[14px] pb-5 flex flex-col gap-[14px]">
+      <div className="px-5 pt-[14px] pb-3 flex flex-col gap-[14px]">
         <StreakBar streak={streak} days={streakDays} todayUnplayed={!completed} />
 
         {completed && results ? (

--- a/client/src/pages/landing/components/StreakBar.tsx
+++ b/client/src/pages/landing/components/StreakBar.tsx
@@ -10,12 +10,8 @@ interface StreakBarProps {
 
 export function StreakBar({ streak, days, todayUnplayed }: StreakBarProps) {
   const windowSize = days.length;
-  const pastFilled = todayUnplayed
-    ? "bg-[var(--ink-mid)]"
-    : "bg-[var(--streak-green-soft)]";
-  const pastEmpty = todayUnplayed
-    ? "bg-[var(--ink-trace)]"
-    : "bg-[var(--streak-green-soft)]";
+  const pastFilled = "bg-[var(--streak-green-filled)]";
+  const pastEmpty = "bg-[var(--ink-trace)]";
 
   return (
     <div className="flex flex-col gap-[10px]">

--- a/client/src/tailwind-v2.css
+++ b/client/src/tailwind-v2.css
@@ -50,6 +50,7 @@
   --ink-whisper: rgba(34, 32, 28, 0.05);
 
   --streak-green: #6B8E4E;
+  --streak-green-filled: rgba(107, 142, 78, 0.55);
   --streak-green-soft: rgba(107, 142, 78, 0.30);
   --streak-green-glow: rgba(107, 142, 78, 0.22);
   --logo-dot: #7A9B5E;
@@ -123,6 +124,7 @@
   --ink-whisper: rgba(238, 232, 220, 0.05);
 
   --streak-green: #8BB366;
+  --streak-green-filled: rgba(139, 179, 102, 0.58);
   --streak-green-soft: rgba(139, 179, 102, 0.32);
   --streak-green-glow: rgba(139, 179, 102, 0.22);
   --logo-dot: #8FB06E;


### PR DESCRIPTION
## Summary
- Past-day streak bars now show consistent colors regardless of whether today's daily is completed: played days are always green (`--streak-green-filled`), unplayed days are always grey (`--ink-trace`)
- Added `--streak-green-filled` theme token (light: 55% opacity, dark: 58% opacity) for visible-but-subdued past-played bars in both themes

## Why this approach
The old logic branched `pastFilled` and `pastEmpty` on `todayUnplayed`, which caused two bugs: (1) when today was completed, both played and unplayed past bars resolved to `--streak-green-soft`, making the `days` boolean array meaningless; (2) when today was unplayed, played past bars showed as `--ink-mid` grey instead of green. The root issue was coupling past-bar appearance to today's state. Removing the conditional entirely is the simplest fix. A new `--streak-green-filled` token at ~55% opacity sits between the faint `--streak-green-soft` (30%) and the full `--streak-green`, giving clear visual separation from the grey empty bars in both light and dark mode.

## Follow-ups
- None — `--streak-green-soft` is still available for other decorative uses (glow, etc.) and is unchanged.