### PR TITLE
chore(deploy): disable auto start/stop, keep 1 machine always running

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -9,9 +9,9 @@ primary_region = 'iad'
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
-  min_machines_running = 0
+  auto_stop_machines = 'off'
+  auto_start_machines = false
+  min_machines_running = 1
 
   [http_service.concurrency]
     type = 'connections'

--- a/fly.toml
+++ b/fly.toml
@@ -9,8 +9,8 @@ primary_region = 'iad'
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
+  auto_stop_machines = 'off'
+  auto_start_machines = false
   min_machines_running = 1
 
   [http_service.concurrency]


### PR DESCRIPTION
## Summary
- Disable auto start/stop on both prod and staging Fly configs so machines stay running at all times
- Set `min_machines_running = 1` on staging (was 0) to match prod

## Why this approach
Auto start/stop adds cold-start latency on first request after idle. With a single always-on machine the app stays warm and WebSocket connections (Socket.io) aren't interrupted by machine stop/start cycles.

## Follow-ups
- None