### PR TITLE
fix(config): prevent selection animations replaying on Play click

### DIFF
--- a/client/src/pages/config/ConfigRoute.tsx
+++ b/client/src/pages/config/ConfigRoute.tsx
@@ -72,12 +72,12 @@ export function ConfigRoute({ mode }: { mode: 'freeplay' | 'daily' }) {
     } else if (isSharedGame) {
       await startGame(sharedGame.timer, sharedGame.boardSize, sharedGame.minWordLength, undefined, sharedGame.seed);
     } else if (config) {
-      setLastConfig(config);
       const effectiveBoardSize = sharedSeed ? sharedSeed.boardSize : config.boardSize;
       const seed = sharedSeed?.seed;
       await startGame(config.timer, effectiveBoardSize, config.minWordLength, undefined, seed);
       setBoardCode('');
       handleCodeChange('');
+      setLastConfig(config);
     }
     navigate('/game');
   };


### PR DESCRIPTION
## Summary
- Move `setLastConfig(config)` after `startGame()` in `ConfigRoute.handleStart` so it no longer triggers a remount of `GameConfigPage` before navigation

## Why this approach
`setLastConfig` updated `lastConfig` in GameContext, which changed the computed `configKey` used as the `key` prop on `<GameConfigPage>`. React treated the key change as a new component instance, unmounting and remounting the entire page — replaying the segmented-control pill slide and board-card cell-pop animations during the ~350ms `startGame` network call. By deferring `setLastConfig` to after `startGame` resolves, the key change coincides with `navigate('/game')` and the config page is already transitioning away.

## Follow-ups
- None