### PR TITLE
fix(leaderboard): parallelize user lookups and guard null display name

### DIFF
--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -155,7 +155,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!authReady) return;
     fetchProfile()
-      .then(({ display_name }) => setDisplayName(display_name))
+      .then(({ display_name }) => { if (display_name) setDisplayName(display_name); })
       .catch(() => {}); // Fall back to default 'Anonymous'
   }, [authReady]);
 

--- a/server/routes/leaderboard.ts
+++ b/server/routes/leaderboard.ts
@@ -36,14 +36,14 @@ leaderboardRouter.get('/:date', async (req, res) => {
     }
 
     const userMap = new Map<string, string>();
-    for (const r of results) {
+    await Promise.all(results.map(async (r) => {
       try {
         const { data } = await admin.auth.admin.getUserById(r.user_id);
         userMap.set(r.user_id, data.user?.user_metadata?.display_name || 'Anonymous');
       } catch {
         userMap.set(r.user_id, 'Anonymous');
       }
-    }
+    }));
 
     const wordCounts = new Map<string, number>();
     const parsedResults = results.map((r) => {


### PR DESCRIPTION
## What changed
Parallelize leaderboard user metadata fetches and guard against null `display_name` in `GameContext`.

## Why this approach
The leaderboard endpoint was fetching user metadata sequentially in a `for` loop — each `getUserById` call waited for the previous one to finish. Switching to `Promise.all` runs them concurrently, cutting response time roughly proportional to the number of results.

The `GameContext` fix is a related drive-by: when `display_name` comes back `null` (e.g. a user who never set one), we were overwriting the `'Anonymous'` default with `null`. Now we only call `setDisplayName` when there's an actual value.

## Follow-ups
- Consider caching user display names server-side to avoid repeated auth lookups entirely.