### PR TITLE
feat(daily): persist per-day config and gate randomization

### DIFF
--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -189,7 +189,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       if (localResult) {
         const wordStrings = localResult.foundWords.map(w => w.word);
         try {
-          await recordDailyResultToServer(info.date, wordStrings, localResult.board);
+          await recordDailyResultToServer(info.date, wordStrings, localResult.board, info.config);
           setCachedDailyResult({ found_words: wordStrings, board: localResult.board });
           // Clean up localStorage now that the result is persisted on the server
           clearDailyResult(info.date);
@@ -215,7 +215,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     if (resultsFlat !== expectedFlat) return;
 
     const wordStrings = results.foundWords.map(w => w.word);
-    recordDailyResultToServer(dailyInfo.date, wordStrings, results.board)
+    recordDailyResultToServer(dailyInfo.date, wordStrings, results.board, dailyInfo.config)
       .then(() => {
         setCachedDailyResult({ found_words: wordStrings, board: results.board });
       })

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -4,11 +4,9 @@ import { useGame } from '../../GameContext';
 import {
   fetchLeaderboard,
   fetchDailyStats,
-  fetchDaily,
   type LeaderboardResponse,
   type DailyStatsResponse,
   type DailyStatsDay,
-  type DailyInfo,
 } from '../../shared/api/gameApi';
 import { LeaderboardPage } from './LeaderboardPage';
 import { useShareText } from '../results/hooks/useShareText';
@@ -25,7 +23,7 @@ function formatDateLabel(dateIso: string): string {
   return `${weekday}, ${month} ${d.getDate()}`;
 }
 
-function adaptDay(day: DailyStatsDay, config: DailyInfo['config']): DailyEntry {
+function adaptDay(day: DailyStatsDay): DailyEntry {
   return {
     puzzleNumber: day.puzzleNumber,
     date: new Date(day.date + 'T12:00:00'),
@@ -36,7 +34,7 @@ function adaptDay(day: DailyStatsDay, config: DailyInfo['config']): DailyEntry {
     longestWordDefinition: day.longestWordDefinition,
     stampTier: day.stampTier,
     playersCount: day.playersCount,
-    config,
+    config: day.config,
   };
 }
 
@@ -50,14 +48,10 @@ export function LeaderboardRoute() {
   );
   const [leaderboard, setLeaderboard] = useState<LeaderboardResponse | null>(null);
   const [stats, setStats] = useState<DailyStatsResponse | null>(null);
-  const [config, setConfig] = useState<DailyInfo['config'] | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    Promise.all([fetchDailyStats(), fetchDaily()]).then(([s, info]) => {
-      setStats(s);
-      setConfig(info.config);
-    });
+    fetchDailyStats().then(setStats);
   }, []);
 
   useEffect(() => {
@@ -69,9 +63,9 @@ export function LeaderboardRoute() {
   }, [selectedDate]);
 
   const entries: DailyEntry[] = useMemo(() => {
-    if (!stats || !config) return [];
-    return stats.days.map((d) => adaptDay(d, config));
-  }, [stats, config]);
+    if (!stats) return [];
+    return stats.days.map(adaptDay);
+  }, [stats]);
 
   const pointsRankings = leaderboard?.rankings.points ?? [];
 

--- a/client/src/pages/results/DailyResultsRoute.tsx
+++ b/client/src/pages/results/DailyResultsRoute.tsx
@@ -121,11 +121,6 @@ export function DailyResultsRoute() {
 
   const pickerEntries: DailyEntry[] = useMemo(() => {
     if (!stats) return [];
-    const config = {
-      boardSize: dailyInfo?.config.boardSize ?? 5,
-      timeLimit: dailyInfo?.config.timeLimit ?? 120,
-      minWordLength: dailyInfo?.config.minWordLength ?? 3,
-    };
     return stats.days.map((d: DailyStatsDay) => ({
       puzzleNumber: d.puzzleNumber,
       date: new Date(d.date + 'T12:00:00'),
@@ -136,9 +131,9 @@ export function DailyResultsRoute() {
       longestWordDefinition: d.longestWordDefinition,
       stampTier: d.stampTier,
       playersCount: d.playersCount,
-      config,
+      config: d.config,
     }));
-  }, [stats, dailyInfo]);
+  }, [stats]);
 
   const handlePlayAgain = async () => {
     setDailyInfo(null);
@@ -236,9 +231,9 @@ export function DailyResultsRoute() {
         startedAt: 0,
         status: GameState.Finished,
         config: {
-          durationSeconds: dailyInfo?.config.timeLimit ?? 120,
+          durationSeconds: serverResult?.config?.timeLimit ?? dailyInfo?.config.timeLimit ?? 120,
           boardSize: displayed.board.length,
-          minWordLength: dailyInfo?.config.minWordLength ?? 3,
+          minWordLength: serverResult?.config?.minWordLength ?? dailyInfo?.config.minWordLength ?? 3,
         },
       }}
       gameSeed={dailyInfo?.seed}

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -139,6 +139,7 @@ export interface DailyStatsDay {
   longestWordDefinition: WordDefinition | null;
   stampTier: StampTier;
   playersCount: number;
+  config: DailyConfig;
 }
 
 export interface DailyStatsResponse {
@@ -159,12 +160,27 @@ export const fetchDailyStats = async (): Promise<DailyStatsResponse> => {
   return response.json();
 };
 
-export const recordDailyResultToServer = async (date: string, foundWords: string[], board: string[][]): Promise<{ success: boolean }> => {
+export interface DailyConfig {
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+}
+
+export const recordDailyResultToServer = async (
+  date: string,
+  foundWords: string[],
+  board: string[][],
+  config: DailyConfig,
+): Promise<{ success: boolean }> => {
   const response = await fetch(`${API_URL}/daily/results`, {
     method: 'POST',
     headers: await sessionHeaders(),
-    body: JSON.stringify({ date, found_words: foundWords, board }),
+    body: JSON.stringify({ date, found_words: foundWords, board, config }),
   });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`recordDailyResultToServer ${response.status}: ${body}`);
+  }
   return response.json();
 };
 
@@ -180,6 +196,7 @@ export interface DailyResultResponse {
   /** Computed server-side at read time; absent in very old stored results
    *  but always present from the current endpoint. */
   missed_words?: DailyResultMissedWord[];
+  config: DailyConfig;
 }
 
 export const fetchDailyResult = async (date: string): Promise<DailyResultResponse | null> => {

--- a/client/src/stories/DailyPreview.stories.tsx
+++ b/client/src/stories/DailyPreview.stories.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Board } from '../pages/game/components/Board';
+import type { FeedbackType } from '../pages/game/components/Board';
+import type { Position } from 'models';
+
+// Hits the server's dev-only /api/daily/preview endpoint, which returns
+// `{ seed, config, board }` for any seed without spoiling future dailies.
+// Storybook runs on its own port, so we go straight to the server rather
+// than relying on a proxy.
+const PREVIEW_URL = 'http://localhost:3000/api/daily/preview';
+
+interface PreviewResponse {
+  seed: number;
+  config: { boardSize: number; minWordLength: number; timeLimit: number };
+  board: string[][];
+}
+
+function DailyPreview({ initialSeed }: { initialSeed: string }) {
+  const [seedInput, setSeedInput] = useState(initialSeed);
+  const [data, setData] = useState<PreviewResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: FeedbackType; path: Position[] } | null>(null);
+
+  const load = useCallback(async (seed: string) => {
+    if (!seed) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${PREVIEW_URL}?seed=${encodeURIComponent(seed)}`);
+      if (!res.ok) throw new Error(`Server returned ${res.status} (is the dev server running on :3000?)`);
+      setData(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(initialSeed);
+  }, [initialSeed, load]);
+
+  const randomize = () => {
+    const next = String(Math.floor(Math.random() * 1_000_000));
+    setSeedInput(next);
+    load(next);
+  };
+
+  const handleSubmitWord = useCallback((path: Position[]) => {
+    setFeedback({ type: 'valid', path });
+    setTimeout(() => setFeedback(null), 800);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6 max-w-md">
+      <div className="flex gap-2 items-center">
+        <input
+          type="text"
+          value={seedInput}
+          onChange={(e) => setSeedInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') load(seedInput);
+          }}
+          placeholder="seed (numeric or string)"
+          className="flex-1 px-3 py-2 border border-[var(--border)] rounded text-sm"
+        />
+        <button
+          onClick={() => load(seedInput)}
+          className="px-3 py-2 border border-[var(--border)] rounded text-sm"
+          disabled={loading}
+        >
+          Load
+        </button>
+        <button
+          onClick={randomize}
+          className="px-3 py-2 border border-[var(--border)] rounded text-sm"
+          disabled={loading}
+        >
+          🎲
+        </button>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-600">{error}</div>
+      )}
+
+      {data && (
+        <>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            {[
+              { label: 'Board', value: `${data.config.boardSize}×${data.config.boardSize}` },
+              { label: 'Min word', value: `${data.config.minWordLength} letters` },
+              { label: 'Time', value: `${data.config.timeLimit}s` },
+            ].map(({ label, value }) => (
+              <div key={label} className="px-3 py-2 border border-[var(--border)] rounded">
+                <div className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{label}</div>
+                <div className="text-base font-semibold">{value}</div>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{ '--board-size': data.config.boardSize, width: 360 } as React.CSSProperties}
+          >
+            <Board
+              board={data.board}
+              onSubmitWord={handleSubmitWord}
+              feedback={feedback}
+            />
+          </div>
+
+          <div className="text-xs text-[var(--text-muted)]">
+            Resolved seed: <code>{data.seed}</code>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const meta: Meta<typeof DailyPreview> = {
+  title: 'Daily/Randomized Config Preview',
+  component: DailyPreview,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Live preview of the randomized daily config rotation. Calls the dev-only ' +
+          '`GET /api/daily/preview?seed=...` endpoint and renders the resulting board, ' +
+          'board size, min word length, and time limit. Try the dice button to roll ' +
+          'across combos without burning real puzzle dates.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DailyPreview>;
+
+export const Interactive: Story = {
+  args: { initialSeed: '1231' },
+};

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -10,6 +10,9 @@ export interface DailyResultsTable {
   points: Generated<number>;
   word_count: Generated<number>;
   longest_word: Generated<string>;
+  board_size: number;
+  min_word_length: number;
+  time_limit: number;
 }
 
 export interface Database {

--- a/server/routes/daily.ts
+++ b/server/routes/daily.ts
@@ -9,10 +9,8 @@ import { getSupabaseAdmin } from '../supabaseAdmin.js';
 import { dictionary } from '../services/dictionary.js';
 import { scoreResult, scoreWords, getDailyStats } from '../services/DailyService.js';
 import {
-  DAILY_BOARD_SIZE,
   DAILY_LAUNCH_DATE,
-  DAILY_MIN_WORD_LENGTH,
-  DAILY_TIME_LIMIT,
+  getDailyConfig,
   getDailyDatePST,
   getDailyNumber,
 } from '../services/dailyConfig.js';
@@ -23,17 +21,14 @@ dailyRouter.get('/', (_req, res) => {
   const date = getDailyDatePST();
   const number = getDailyNumber(date);
   const seed = getDailySeed(date);
-  const board = generateSeededBoard(DAILY_BOARD_SIZE, seed);
+  const config = getDailyConfig(date);
+  const board = generateSeededBoard(config.boardSize, seed);
   res.json({
     date,
     number,
     seed,
     board,
-    config: {
-      boardSize: DAILY_BOARD_SIZE,
-      timeLimit: DAILY_TIME_LIMIT,
-      minWordLength: DAILY_MIN_WORD_LENGTH,
-    },
+    config,
   });
 });
 
@@ -94,7 +89,7 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
     // Compute missed words on demand. The found_words column is canonical;
     // we re-solve the board each time rather than storing the full solution
     // so old results automatically pick up any future dictionary or
-    // scoring changes. The 5x5 board + ~170k-word dictionary runs in a
+    // scoring changes. The board + ~170k-word dictionary runs in a
     // couple of ms so the compute cost is negligible at this endpoint's
     // volume.
     const board: string[][] = typeof result.board === 'string'
@@ -104,7 +99,8 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
       ? JSON.parse(result.found_words)
       : result.found_words;
     const foundSet = new Set(foundWords.map((w) => w.toUpperCase()));
-    const missedWords = findAllWords(board, dictionary, DAILY_MIN_WORD_LENGTH)
+    const config = getDailyConfig(req.params.date);
+    const missedWords = findAllWords(board, dictionary, config.minWordLength)
       .filter((w) => !foundSet.has(w.word))
       .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }))
       .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
@@ -197,17 +193,15 @@ dailyRouter.get('/compare/:date', requireAuth, async (req, res) => {
       foundWords: them.words.map((word) => ({ word, score: scoreWord(word) })),
     };
 
+    const config = getDailyConfig(date);
+
     res.json({
       date,
       puzzleNumber: getDailyNumber(date),
       board,
       me: mePayload,
       them: themPayload,
-      config: {
-        boardSize: DAILY_BOARD_SIZE,
-        timeLimit: DAILY_TIME_LIMIT,
-        minWordLength: DAILY_MIN_WORD_LENGTH,
-      },
+      config,
     });
   } catch (err) {
     console.error('Failed to fetch daily compare:', err);

--- a/server/routes/daily.ts
+++ b/server/routes/daily.ts
@@ -10,6 +10,7 @@ import { dictionary } from '../services/dictionary.js';
 import { scoreResult, scoreWords, getDailyStats } from '../services/DailyService.js';
 import {
   DAILY_LAUNCH_DATE,
+  dailyConfigFromSeed,
   getDailyConfig,
   getDailyDatePST,
   getDailyNumber,
@@ -32,11 +33,36 @@ dailyRouter.get('/', (_req, res) => {
   });
 });
 
-dailyRouter.post('/results', requireAuth, async (req, res) => {
-  const { date, found_words, board } = req.body;
+// Dev-only: preview the config + board for an arbitrary seed without
+// spoiling future dailies. Accepts numeric or string seeds; strings are
+// hashed to a 32-bit integer.
+if (process.env.NODE_ENV !== 'production') {
+  dailyRouter.get('/preview', (req, res) => {
+    const raw = typeof req.query.seed === 'string' ? req.query.seed : '';
+    if (!raw) return res.status(400).json({ error: 'Missing query param: seed' });
+    const numeric = Number(raw);
+    let seed: number;
+    if (Number.isFinite(numeric)) {
+      seed = Math.floor(numeric) >>> 0;
+    } else {
+      let h = 2166136261 >>> 0;
+      for (let i = 0; i < raw.length; i++) {
+        h ^= raw.charCodeAt(i);
+        h = Math.imul(h, 16777619) >>> 0;
+      }
+      seed = h;
+    }
+    const config = dailyConfigFromSeed(seed);
+    const board = generateSeededBoard(config.boardSize, seed);
+    res.json({ seed, config, board });
+  });
+}
 
-  if (!date || !found_words || !board) {
-    return res.status(400).json({ error: 'Missing required fields: date, found_words, board' });
+dailyRouter.post('/results', requireAuth, async (req, res) => {
+  const { date, found_words, board, config } = req.body;
+
+  if (!date || !found_words || !board || !config) {
+    return res.status(400).json({ error: 'Missing required fields: date, found_words, board, config' });
   }
 
   try {
@@ -52,6 +78,9 @@ dailyRouter.post('/results', requireAuth, async (req, res) => {
         points,
         word_count: wordCount,
         longest_word: longestWord,
+        board_size: config.boardSize,
+        min_word_length: config.minWordLength,
+        time_limit: config.timeLimit,
       })
       .onConflict((oc) =>
         oc.columns(['user_id', 'date']).doUpdateSet({
@@ -61,6 +90,9 @@ dailyRouter.post('/results', requireAuth, async (req, res) => {
           points,
           word_count: wordCount,
           longest_word: longestWord,
+          board_size: config.boardSize,
+          min_word_length: config.minWordLength,
+          time_limit: config.timeLimit,
         }),
       )
       .execute();
@@ -99,7 +131,11 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
       ? JSON.parse(result.found_words)
       : result.found_words;
     const foundSet = new Set(foundWords.map((w) => w.toUpperCase()));
-    const config = getDailyConfig(req.params.date);
+    const config = {
+      boardSize: result.board_size,
+      minWordLength: result.min_word_length,
+      timeLimit: result.time_limit,
+    };
     const missedWords = findAllWords(board, dictionary, config.minWordLength)
       .filter((w) => !foundSet.has(w.word))
       .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }))
@@ -112,6 +148,7 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
         board,
         missed_words: missedWords,
         completed_at: result.completed_at,
+        config,
       },
     });
   } catch (err) {
@@ -193,7 +230,11 @@ dailyRouter.get('/compare/:date', requireAuth, async (req, res) => {
       foundWords: them.words.map((word) => ({ word, score: scoreWord(word) })),
     };
 
-    const config = getDailyConfig(date);
+    const config = {
+      boardSize: mine.board_size,
+      minWordLength: mine.min_word_length,
+      timeLimit: mine.time_limit,
+    };
 
     res.json({
       date,

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -1,6 +1,7 @@
 import { sql, type Kysely } from 'kysely';
 import { scoreWord } from 'engine/scoring.js';
 import type { Database } from '../db/types.js';
+import { getDailyConfig, type DailyConfig } from './dailyConfig.js';
 
 export interface ScoredResult {
   points: number;
@@ -175,6 +176,7 @@ export interface DailyStatsDay {
   longestWordDefinition: WordDefinition | null;
   stampTier: StampTier;
   playersCount: number;
+  config: DailyConfig;
 }
 
 export interface DailyStatsResponse {
@@ -236,13 +238,16 @@ export async function getDailyStats(
           'points',
           'word_count',
           'longest_word',
+          'board_size',
+          'min_word_length',
+          'time_limit',
           sql<number>`rank() over (partition by ${eb.ref('date')} order by ${eb.ref('points')} desc, ${eb.ref('word_count')} desc, ${eb.ref('completed_at')} asc)`.as('rank'),
         ])
         .where('date', '>=', windowStart)
         .where('date', '<=', windowEnd)
     )
     .selectFrom('ranked')
-    .select(['date', 'points', 'word_count', 'longest_word', 'rank'])
+    .select(['date', 'points', 'word_count', 'longest_word', 'board_size', 'min_word_length', 'time_limit', 'rank'])
     .where('user_id', '=', userId)
     .execute();
 
@@ -287,6 +292,7 @@ export async function getDailyStats(
         longestWordDefinition: null,
         stampTier: null,
         playersCount,
+        config: getDailyConfig(d),
       });
       continue;
     }
@@ -302,6 +308,11 @@ export async function getDailyStats(
       longestWordDefinition: definitions.get(userRow.longest_word.toLowerCase()) ?? null,
       stampTier: stampTierFor(rank, playersCount),
       playersCount,
+      config: {
+        boardSize: userRow.board_size,
+        minWordLength: userRow.min_word_length,
+        timeLimit: userRow.time_limit,
+      },
     });
   }
 

--- a/server/services/dailyConfig.ts
+++ b/server/services/dailyConfig.ts
@@ -1,6 +1,17 @@
-import { getDailySeed, mulberry32 } from 'models/seedCode.js';
+import { getDailySeed, mulberry32 } from 'models/seedCode';
 
 export const DAILY_LAUNCH_DATE = '2026-04-10';
+
+// First date for which the daily puzzle uses randomized config. Earlier dates
+// were all played at the legacy fixed config and must keep returning it so
+// stored results stay consistent with how they were played.
+export const FIRST_RANDOMIZED_DATE = '2026-04-27';
+
+const LEGACY_CONFIG: DailyConfig = {
+  boardSize: 5,
+  timeLimit: 120,
+  minWordLength: 4,
+};
 
 export interface DailyConfig {
   boardSize: number;
@@ -8,19 +19,30 @@ export interface DailyConfig {
   minWordLength: number;
 }
 
-const BOARD_SIZES = [4, 5, 6];
-const TIME_LIMITS = [60, 90, 120, 150, 180];
-const MIN_WORD_LENGTHS = [3, 4, 5];
+// Explicit (boardSize, minWordLength) pairs. Independent rolls produced
+// awkward combos (4×4 + min 5 too sparse, 6×6 + min 3 trivial-word soup),
+// so the rotation lives in one table that's easy to tune.
+const BOARD_COMBOS: Array<{ boardSize: number; minWordLength: number }> = [
+  { boardSize: 4, minWordLength: 3 },
+  { boardSize: 4, minWordLength: 4 },
+  { boardSize: 5, minWordLength: 3 },
+  { boardSize: 5, minWordLength: 4 },
+  { boardSize: 5, minWordLength: 5 },
+  { boardSize: 6, minWordLength: 4 },
+  { boardSize: 6, minWordLength: 5 },
+];
+const TIME_LIMITS = [60, 120];
+
+export function dailyConfigFromSeed(seed: number): DailyConfig {
+  const prng = mulberry32(seed);
+  const combo = BOARD_COMBOS[Math.floor(prng() * BOARD_COMBOS.length)];
+  const timeLimit = TIME_LIMITS[Math.floor(prng() * TIME_LIMITS.length)];
+  return { ...combo, timeLimit };
+}
 
 export function getDailyConfig(dateStr: string): DailyConfig {
-  const seed = getDailySeed(dateStr);
-  const prng = mulberry32(seed);
-
-  const boardSize = BOARD_SIZES[Math.floor(prng() * BOARD_SIZES.length)];
-  const timeLimit = TIME_LIMITS[Math.floor(prng() * TIME_LIMITS.length)];
-  const minWordLength = MIN_WORD_LENGTHS[Math.floor(prng() * MIN_WORD_LENGTHS.length)];
-
-  return { boardSize, timeLimit, minWordLength };
+  if (dateStr < FIRST_RANDOMIZED_DATE) return { ...LEGACY_CONFIG };
+  return dailyConfigFromSeed(getDailySeed(dateStr));
 }
 
 export function getDailyDatePST(): string {

--- a/server/services/dailyConfig.ts
+++ b/server/services/dailyConfig.ts
@@ -1,7 +1,27 @@
+import { getDailySeed, mulberry32 } from 'models/seedCode.js';
+
 export const DAILY_LAUNCH_DATE = '2026-04-10';
-export const DAILY_BOARD_SIZE = 5;
-export const DAILY_TIME_LIMIT = 120;
-export const DAILY_MIN_WORD_LENGTH = 4;
+
+export interface DailyConfig {
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+}
+
+const BOARD_SIZES = [4, 5, 6];
+const TIME_LIMITS = [60, 90, 120, 150, 180];
+const MIN_WORD_LENGTHS = [3, 4, 5];
+
+export function getDailyConfig(dateStr: string): DailyConfig {
+  const seed = getDailySeed(dateStr);
+  const prng = mulberry32(seed);
+
+  const boardSize = BOARD_SIZES[Math.floor(prng() * BOARD_SIZES.length)];
+  const timeLimit = TIME_LIMITS[Math.floor(prng() * TIME_LIMITS.length)];
+  const minWordLength = MIN_WORD_LENGTHS[Math.floor(prng() * MIN_WORD_LENGTHS.length)];
+
+  return { boardSize, timeLimit, minWordLength };
+}
 
 export function getDailyDatePST(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });

--- a/supabase/migrations/20260426000000_daily_results_config.sql
+++ b/supabase/migrations/20260426000000_daily_results_config.sql
@@ -1,0 +1,13 @@
+alter table public.daily_results
+  add column board_size smallint,
+  add column min_word_length smallint,
+  add column time_limit smallint;
+
+update public.daily_results
+set board_size = 5, min_word_length = 4, time_limit = 120
+where board_size is null;
+
+alter table public.daily_results
+  alter column board_size set not null,
+  alter column min_word_length set not null,
+  alter column time_limit set not null;


### PR DESCRIPTION
## What

Daily puzzle config (board size, min word length, time limit) is now persisted per `daily_results` row and rotated through a constrained combo table starting tomorrow.

- **Persisted config**: `daily_results` gains `board_size` / `min_word_length` / `time_limit`. POST writes them; GET `/results/:date` and `/compare/:date` read from the row instead of recomputing. Existing rows backfilled to `{5,4,120}`.
- **Constrained combos**: `BOARD_COMBOS` is an explicit pair table (4×4/3, 4×4/4, 5×5/3, 5×5/4, 5×5/5, 6×6/4, 6×6/5) rolled with an independent `[60,120]` timer.
- **Cutover gate**: `FIRST_RANDOMIZED_DATE = '2026-04-27'`. Earlier dates return the legacy fixed config so today's in-flight daily stays consistent across the deploy seam. **Bump this constant before merging if 2026-04-27 isn't the first PST day after deploy.**
- **Per-day picker config**: `daily/stats` returns `config` per day (from the row when played, derived from `getDailyConfig(date)` when missed/unplayed). Date-picker thumbnails on results and leaderboard render at the right grid size per day instead of reusing today's config.
- **Dev preview**: `GET /api/daily/preview?seed=<numeric|string>` (gated on `NODE_ENV !== 'production'`) returns `{seed, config, board}` for any seed. A Storybook story under *Daily / Randomized Config Preview* drives it interactively.

## Why this approach

Persisting config on the row is the only durable answer to "future tweaks to the combo table shouldn't rewrite history." A cutover gate alone leaves the config rules deterministic-from-date, which means any future change to the arrays silently re-derives past days. Storing the played config decouples row interpretation from config logic.

The pair-table rotation replaces three independent rolls because independent rolls produced poor-fit combos (4×4 + min 5 too sparse, 6×6 + min 3 trivial-word soup). One table is easier to tune and easier to test exhaustively.

The dev preview endpoint takes a seed instead of a date so combos can be reviewed without spoiling upcoming puzzle dates.

## Follow-ups

- Bump `FIRST_RANDOMIZED_DATE` if not deploying on/before 2026-04-26 PST.
- Server `dev` script lacks `--watch`, which already cost a debugging session; consider adding it in a chore PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)