### PR TITLE
feat(timer): add 3min option, swap daily 60s→180s, fix picker a11y

### DIFF
--- a/client/src/pages/config/ConfigRoute.tsx
+++ b/client/src/pages/config/ConfigRoute.tsx
@@ -54,13 +54,13 @@ export function ConfigRoute({ mode }: { mode: 'freeplay' | 'daily' }) {
 
   const dailyDefaults = isDaily && dailyInfo ? {
     boardSize: dailyInfo.config.boardSize as 4 | 5 | 6,
-    timer: dailyInfo.config.timeLimit as 60 | 120 | -1,
+    timer: dailyInfo.config.timeLimit as 60 | 120 | 180 | -1,
     minWordLength: dailyInfo.config.minWordLength as 3 | 4 | 5,
   } : undefined;
 
   const sharedDefaults = isSharedGame ? {
     boardSize: sharedGame.boardSize as 4 | 5 | 6,
-    timer: sharedGame.timer as 60 | 120 | -1,
+    timer: sharedGame.timer as 60 | 120 | 180 | -1,
     minWordLength: sharedGame.minWordLength as 3 | 4 | 5,
   } : undefined;
 

--- a/client/src/pages/config/components/SegmentedControl.tsx
+++ b/client/src/pages/config/components/SegmentedControl.tsx
@@ -43,13 +43,13 @@ export function SegmentedControl<T extends string | number>({
       <div
         ref={trackRef}
         key={shakeKey}
-        className="grid grid-cols-3 bg-[var(--surface-bg)] rounded-xl p-[3px] relative"
-        style={shakeStyle}
+        className="grid bg-[var(--surface-bg)] rounded-xl p-[3px] relative"
+        style={{ ...shakeStyle, gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }}
       >
         <div
           className="seg-pill absolute top-[3px] h-[calc(100%-6px)] bg-[var(--surface-card)] rounded-[10px] pointer-events-none z-0 shadow-[var(--shadow-card)]"
           style={{
-            width: `calc(33.333% - 2px)`,
+            width: `calc(${100 / options.length}% - 2px)`,
             left: pillLeft,
           }}
         />

--- a/client/src/pages/config/components/TimerConfig.tsx
+++ b/client/src/pages/config/components/TimerConfig.tsx
@@ -4,6 +4,7 @@ import type { TimerOption } from "../types";
 const OPTIONS: SegmentedOption<TimerOption>[] = [
   { value: 60, label: "1:00", sub: "Sprint" },
   { value: 120, label: "2:00", sub: "Standard" },
+  { value: 180, label: "3:00", sub: "Relaxed" },
   { value: -1, label: "∞", sub: "Zen" },
 ];
 

--- a/client/src/pages/config/types.ts
+++ b/client/src/pages/config/types.ts
@@ -1,6 +1,6 @@
 export type BoardSize = 4 | 5 | 6;
 
-export type TimerOption = 60 | 120 | -1;
+export type TimerOption = 60 | 120 | 180 | -1;
 
 export type MinWordLength = 3 | 4 | 5;
 

--- a/client/src/shared/components/DateTimelinePicker.tsx
+++ b/client/src/shared/components/DateTimelinePicker.tsx
@@ -102,14 +102,22 @@ export function DateTimelinePicker({
     el?.scrollIntoView({ block: 'center' });
   }, [open, selectedDate]);
 
+  // `inert` blocks focus + hides from assistive tech in one go. Using it
+  // instead of aria-hidden avoids the "aria-hidden on a focused ancestor"
+  // warning when a date button retains focus across the close transition.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (rootRef.current) rootRef.current.inert = !open;
+  }, [open]);
+
   return (
     <div
+      ref={rootRef}
       onClick={onClose}
       className={[
         'fixed inset-0 z-[150] flex justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] transition-opacity duration-200',
         open ? 'opacity-100' : 'opacity-0 pointer-events-none',
       ].join(' ')}
-      aria-hidden={!open}
     >
       <div className="w-full max-w-[360px] min-h-0 flex flex-col px-[22px] pt-[14px] pb-5">
         <div

--- a/server/services/dailyConfig.ts
+++ b/server/services/dailyConfig.ts
@@ -31,7 +31,7 @@ const BOARD_COMBOS: Array<{ boardSize: number; minWordLength: number }> = [
   { boardSize: 6, minWordLength: 4 },
   { boardSize: 6, minWordLength: 5 },
 ];
-const TIME_LIMITS = [60, 120];
+const TIME_LIMITS = [120, 180];
 
 export function dailyConfigFromSeed(seed: number): DailyConfig {
   const prng = mulberry32(seed);


### PR DESCRIPTION
## What

Three small, related changes to the timer / daily-config / accessibility surface.

- **Daily timer rotation**: `TIME_LIMITS` swaps `60` for `180` (now `[120, 180]`).
- **Free-play timer**: `TimerConfig` adds a 3:00 "Relaxed" option alongside Sprint / Standard / Zen. `TimerOption` widens to include 180.
- **Picker a11y**: `DateTimelinePicker` overlay uses `inert` (set via ref) instead of `aria-hidden={!open}`, fixing the "aria-hidden on a focused ancestor" console warning when a date button keeps focus across the close transition.

## Why this approach

60s on a 6×6 / min-5 daily was punishing for what's meant to be an inviting puzzle; leaning toward more time than less keeps the daily approachable while randomization still varies the difficulty. Keeping the daily rotation at exactly two timer values preserves predictability — easier to widen later if the variety feels too small.

`inert` is the correct primitive for "this overlay should block focus and be invisible to AT" — `aria-hidden` only does the latter, which is why the warning fires when something inside still has focus. React 18's JSX types don't include `inert` yet, so it's set imperatively via a ref `useEffect` rather than as a prop.

## Follow-ups

- None for this change set. The daily rotation can be tuned further (e.g. `[90, 120, 180]`) once we have telemetry on how players react to the longer baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)