### PR TITLE
refactor(dates): short date labels + rank zen leaderboard by words

### DIFF
--- a/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
+++ b/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
@@ -14,6 +14,7 @@ import { DateTimelinePicker } from '../../shared/components/DateTimelinePicker';
 import { InlineStats } from '../leaderboard/components/InlineStats';
 import { LeaderboardList, type LbListEntry } from '../leaderboard/components/LeaderboardList';
 import type { DailyEntry } from '../daily/types';
+import { formatDateLabel } from '../../shared/utils/formatDate';
 
 function adaptDay(day: DailyStatsDay): DailyEntry {
   return {
@@ -32,13 +33,6 @@ function adaptDay(day: DailyStatsDay): DailyEntry {
 
 function getTodayPST(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
-}
-
-function formatDateLabel(dateIso: string): string {
-  const d = new Date(dateIso + 'T12:00:00');
-  const weekday = d.toLocaleString('en-US', { weekday: 'long' });
-  const month = d.toLocaleString('en-US', { month: 'long' });
-  return `${weekday}, ${month} ${d.getDate()}`;
 }
 
 export function ZenLeaderboardRoute() {
@@ -85,12 +79,15 @@ export function ZenLeaderboardRoute() {
 
   const entries: LbListEntry[] = useMemo(() => {
     if (!data) return [];
-    return data.rankings.points.map((e) => ({
+    // Zen leaderboard is ranked by words found rather than points — the
+    // primary value players are chasing in the untimed mode is breadth, not
+    // score-per-minute.
+    return data.rankings.words.map((e) => ({
       rank: e.rank,
       userId: e.userId,
       displayName: e.displayName,
-      subLabel: `${e.wordCount} ${e.wordCount === 1 ? 'word' : 'words'}`,
-      value: e.points,
+      subLabel: `${e.points} ${e.points === 1 ? 'pt' : 'pts'}`,
+      value: e.wordCount,
       isCurrentUser: e.userId === currentUserId,
       inProgress: e.inProgress,
     }));

--- a/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
+++ b/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
@@ -88,6 +88,7 @@ export function ZenLeaderboardRoute() {
       displayName: e.displayName,
       subLabel: `${e.points} ${e.points === 1 ? 'pt' : 'pts'}`,
       value: e.wordCount,
+      valueUnit: e.wordCount === 1 ? 'word' : 'words',
       isCurrentUser: e.userId === currentUserId,
       inProgress: e.inProgress,
     }));

--- a/client/src/pages/dailyZen/ZenResultsRoute.tsx
+++ b/client/src/pages/dailyZen/ZenResultsRoute.tsx
@@ -21,13 +21,7 @@ import { HeroScore } from '../results/components/HeroScore';
 import { WordDefinitionPanel } from '../results/components/WordDefinitionPanel';
 import { useShareText } from '../results/hooks/useShareText';
 import { generateShareText } from '../results/utils/shareResults';
-
-function formatDateLabel(dateIso: string): string {
-  const d = new Date(dateIso + 'T12:00:00');
-  const weekday = d.toLocaleString('en-US', { weekday: 'long' });
-  const month = d.toLocaleString('en-US', { month: 'long' });
-  return `${weekday}, ${month} ${d.getDate()}`;
-}
+import { formatDateLabel } from '../../shared/utils/formatDate';
 
 function getTodayPST(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -85,6 +85,7 @@ export function LeaderboardRoute() {
         displayName: r.displayName,
         subLabel: r.subLabel,
         value: r.value,
+        valueUnit: r.value === 1 ? 'pt' : 'pts',
         isCurrentUser: r.isCurrentUser,
       })),
     [pointsRankings],

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -11,16 +11,10 @@ import {
 import { LeaderboardPage } from './LeaderboardPage';
 import { useShareText } from '../results/hooks/useShareText';
 import type { DailyEntry } from '../daily/types';
+import { formatDateLabel } from '../../shared/utils/formatDate';
 
 function getTodayPST(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
-}
-
-function formatDateLabel(dateIso: string): string {
-  const d = new Date(dateIso + 'T12:00:00');
-  const weekday = d.toLocaleString('en-US', { weekday: 'long' });
-  const month = d.toLocaleString('en-US', { month: 'long' });
-  return `${weekday}, ${month} ${d.getDate()}`;
 }
 
 function adaptDay(day: DailyStatsDay): DailyEntry {

--- a/client/src/pages/leaderboard/components/LeaderboardList.tsx
+++ b/client/src/pages/leaderboard/components/LeaderboardList.tsx
@@ -7,6 +7,9 @@ export interface LbListEntry {
   displayName: string;
   subLabel: string;
   value: number;
+  /** Optional unit rendered as visually-secondary text next to `value`
+   *  (e.g. "words" for the zen leaderboard). Pre-pluralized by the caller. */
+  valueUnit?: string;
   isCurrentUser: boolean;
   inProgress?: boolean;
 }
@@ -107,7 +110,7 @@ export function LeaderboardList({ entries, onCompare, onSelfClick }: Leaderboard
         >
           <span aria-hidden>{pillPosition === 'above' ? '↑' : '↓'}</span>
           <span>
-            You · #{you.rank} · {you.value}
+            You · #{you.rank} · {you.value}{you.valueUnit ? ` ${you.valueUnit}` : ''}
           </span>
         </button>
       )}
@@ -211,10 +214,18 @@ function Row({
         </div>
       </div>
       <span
-        className="text-[15px] tabular-nums text-[color:var(--ink)] font-[family-name:var(--font-structure)]"
+        className="flex items-baseline gap-1 text-[15px] tabular-nums text-[color:var(--ink)] font-[family-name:var(--font-structure)]"
         style={{ fontWeight: 700, letterSpacing: '-0.01em' }}
       >
         {entry.value}
+        {entry.valueUnit && (
+          <span
+            className="text-[10px] text-[color:var(--ink-soft)] normal-case tracking-normal"
+            style={{ fontWeight: 500 }}
+          >
+            {entry.valueUnit}
+          </span>
+        )}
       </span>
     </div>
   );

--- a/client/src/pages/results/DailyResultsRoute.tsx
+++ b/client/src/pages/results/DailyResultsRoute.tsx
@@ -12,16 +12,10 @@ import {
   type LeaderboardResponse,
 } from '../../shared/api/gameApi';
 import { scoreWord } from '../../shared/utils/score';
+import { formatDateLabel } from '../../shared/utils/formatDate';
 import { ResultsPage, type DailyResultsExtras } from './ResultsPage';
 import type { LeaderboardTeaserEntry } from './components/LeaderboardTeaser';
 import type { DailyEntry } from '../daily/types';
-
-function formatDateLabel(dateIso: string): string {
-  const d = new Date(dateIso + 'T12:00:00');
-  const weekday = d.toLocaleString('en-US', { weekday: 'long' });
-  const month = d.toLocaleString('en-US', { month: 'short' });
-  return `${weekday}, ${month} ${d.getDate()}`;
-}
 
 function getTodayPST(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });

--- a/client/src/pages/results/__fixtures__/daily.ts
+++ b/client/src/pages/results/__fixtures__/daily.ts
@@ -131,7 +131,7 @@ const pickerEntries: DailyEntry[] = [
 ];
 
 export const dailyDefaultExtras: DailyResultsExtras = {
-  dateLabel: 'Timed Daily · Tuesday, Apr 21',
+  dateLabel: 'Timed Daily · Tue, Apr 21',
   leaderboardTop: [
     { rank: 1, name: 'wordsmith42', score: 218 },
     { rank: 2, name: 'lexicon', score: 201 },

--- a/client/src/shared/components/DateTimelinePicker.tsx
+++ b/client/src/shared/components/DateTimelinePicker.tsx
@@ -41,7 +41,7 @@ function weeksBetween(a: Date, b: Date): number {
 
 function formatSelected(dateIso: string): string {
   const d = new Date(dateIso + 'T12:00:00');
-  return d.toLocaleString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+  return d.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
 function groupByWeek(entries: DailyEntry[], today: Date): WeekGroup[] {
@@ -245,9 +245,8 @@ function DayCard({
 }) {
   const missed = entry.state !== 'completed';
   const wday = WEEKDAY_SHORT[entry.date.getDay()];
-  const wdayLong = entry.date.toLocaleString('en-US', { weekday: 'long' });
   const day = entry.date.getDate();
-  const headline = isToday ? 'Today' : relativeHeadline(wdayLong, iso);
+  const headline = isToday ? 'Today' : relativeHeadline(wday, iso);
 
   return (
     <button
@@ -406,9 +405,9 @@ function DateSquare({
   );
 }
 
-function relativeHeadline(wdayLong: string, iso: string): string {
+function relativeHeadline(wday: string, iso: string): string {
   // "Yesterday" for the calendar day immediately before today; past that,
-  // fall back to the plain weekday name.
+  // fall back to the short weekday name.
   const today = new Date();
   const asDate = new Date(iso + 'T12:00:00');
   const days = Math.round(
@@ -416,5 +415,5 @@ function relativeHeadline(wdayLong: string, iso: string): string {
       (24 * 60 * 60 * 1000),
   );
   if (days === 1) return 'Yesterday';
-  return wdayLong;
+  return wday;
 }

--- a/client/src/shared/utils/formatDate.ts
+++ b/client/src/shared/utils/formatDate.ts
@@ -1,0 +1,8 @@
+// Short, fixed-width date label used on results / leaderboard / picker
+// headers — e.g. "Wed, Apr 29". Long weekday/month forms wrap on narrow
+// viewports (Wednesday is the worst offender), so the whole app standardizes
+// on the short form.
+export function formatDateLabel(dateIso: string): string {
+  const d = new Date(dateIso + 'T12:00:00');
+  return d.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}

--- a/server/routes/dailyZen.ts
+++ b/server/routes/dailyZen.ts
@@ -231,15 +231,17 @@ dailyZenRouter.get('/leaderboard/:date', async (req, res) => {
       totalPlayers: number;
     } | null = null;
     if (requestingUserId) {
-      const idx = byPoints.findIndex((e) => e.userId === requestingUserId);
+      // Zen ranks by words found, not points — the rank we hand to the
+      // client must reflect that primary sort.
+      const idx = byWords.findIndex((e) => e.userId === requestingUserId);
       if (idx >= 0) {
-        const me = byPoints[idx];
+        const me = byWords[idx];
         currentPlayer = {
           points: me.points,
           wordsFound: me.wordCount,
           longestWord: me.longestWord,
           rank: idx + 1,
-          totalPlayers: byPoints.length,
+          totalPlayers: byWords.length,
         };
       }
     }


### PR DESCRIPTION
## Summary

- Extracts a shared \`formatDateLabel(dateIso) → \"Wed, Apr 29\"\` helper and replaces four near-identical inline copies (timed/zen results pages and timed/zen leaderboard pages). Long weekday + long month was wrapping on narrow viewports.
- DateTimelinePicker's selected-date header and per-row headline switch to short weekday names too. \`Today\` / \`Yesterday\` are unchanged.
- Zen leaderboard now ranks by words found rather than points, since untimed mode rewards breadth, not score-per-minute. Server's \`currentPlayer.rank\` reads from \`byWords\` to match.

## Why

Date label drift was already 4-deep — extracting once means there's one place to change the format if we ever need to (e.g. add the year for historical entries). Zen's primary metric flipping is a UX call: in timed daily, points-per-minute is the obvious goal; in zen, you have unlimited time, so finding more words is the only differentiator worth ranking on.

## Follow-ups

- \`DailyConfirmRoute\` has its own \`formatLongDate\` (\`weekday · month day\` separator). Left alone since it's a header layout where the long form is intentional and doesn't wrap. Worth revisiting if it grows a sibling.

## Test plan

- [ ] Visit \`/daily/results\` on a Wednesday (e.g. today) — header chip reads \`Timed Daily · Wed, Apr 29\`, no wrap.
- [ ] Open the date picker; selected-date header reads \`Wed, Apr 29\`; past Wednesdays show \`Wed\` not \`Wednesday\`; \`Today\` and \`Yesterday\` unchanged.
- [ ] \`/leaderboard\` (timed) and \`/daily/zen/results\` show the short label too.
- [ ] \`/daily/zen/leaderboard\` is sorted by word count descending; the primary number per row is the word count and the sublabel is \`N pts\`. Player's own rank/percentile reflects words-based standing.
- [ ] \`tsc --noEmit\` passes in client and server (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)