### PR TITLE
feat(landing): show zen rank badge during in-progress sessions

### DIFF
--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -82,8 +82,12 @@ export function LandingRoute() {
     };
   }, [authReady, cachedDaily, cachedDailyResult]);
 
+  // Fetch zen rank as soon as the player has any session for the day —
+  // in-progress sessions are on the zen leaderboard too, so the badge is
+  // worth surfacing while play is ongoing. Re-runs when found_words changes
+  // so the displayed rank tracks the player's progress.
   useEffect(() => {
-    if (!authReady || !cachedDailyZen || !cachedDailyZenSession?.ended_at) return;
+    if (!authReady || !cachedDailyZen || !cachedDailyZenSession) return;
     let cancelled = false;
     fetchDailyZenLeaderboard(cachedDailyZen.date)
       .then((lb) => {
@@ -93,7 +97,7 @@ export function LandingRoute() {
     return () => {
       cancelled = true;
     };
-  }, [authReady, cachedDailyZen, cachedDailyZenSession?.ended_at]);
+  }, [authReady, cachedDailyZen, cachedDailyZenSession?.date, cachedDailyZenSession?.word_count, cachedDailyZenSession?.ended_at]);
 
   const handleFreePlay = async () => {
     setDailyInfo(null);

--- a/client/src/pages/landing/components/ZenDailyCard.tsx
+++ b/client/src/pages/landing/components/ZenDailyCard.tsx
@@ -33,8 +33,11 @@ export function ZenDailyCard({
   onSeeLeaderboard,
 }: ZenDailyCardProps) {
   const state = deriveState(session);
+  // Zen leaderboard surfaces in-progress players, so the rank is real and
+  // worth showing the moment the player has started — not only after they
+  // finalize. The badge updates as their session evolves.
   const podiumRank: PodiumRank | null =
-    state === 'ended' && (rank === 1 || rank === 2 || rank === 3) ? rank : null;
+    state !== 'unplayed' && (rank === 1 || rank === 2 || rank === 3) ? rank : null;
 
   return (
     <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] flex flex-col overflow-hidden">


### PR DESCRIPTION
## Summary

Surfaces the podium glyph on the zen daily card the moment a player has any session for the day, not just after they finalize. The zen leaderboard already includes in-progress players (with an \`inProgress\` flag), so the rank is meaningful from the first found word.

## Why

Previously the gating was \`state === 'ended'\`, which mirrored timed daily's "result exists" rule. But timed daily and zen have different lifecycles — a timed result is insert-once, while a zen session evolves through the day. Holding the badge until the player ends the puzzle was hiding information they'd already earned.

The leaderboard fetch in \`LandingRoute\` now re-runs whenever \`word_count\` or \`ended_at\` changes, so the displayed rank tracks live progress.

## Test plan

- [ ] Start a zen session today, find a few words, return to landing — badge appears once you're top-3.
- [ ] Find more words, ranking changes — badge updates on next return to landing.
- [ ] Finalize the session — badge persists.
- [ ] Player who hasn't started zen — no badge (unplayed gating still applies).
- [ ] Player ranked 4+ — no badge.
- [ ] \`tsc --noEmit\` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)