### PR TITLE
fix(daily-zen): remove duplicate mode badge under date picker

### DIFF
--- a/client/src/pages/dailyZen/ZenResultsRoute.tsx
+++ b/client/src/pages/dailyZen/ZenResultsRoute.tsx
@@ -146,12 +146,11 @@ export function ZenResultsRoute() {
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>
           </IconAction>
-          <div className="flex flex-col items-center gap-2">
+          <div className="flex justify-center">
             <DateChip
               label={`Zen Daily · ${formatDateLabel(targetDate)}`}
               onClick={() => setPickerOpen(true)}
             />
-            <ZenModeBadge isCompetitive={result.is_competitive} />
           </div>
           <IconAction onClick={share} label={copied ? 'Copied to clipboard' : 'Share'}>
             {copied ? (


### PR DESCRIPTION
## What

One-line cleanup: removes the standalone \`ZenModeBadge\` under the date picker on the zen results page so the only badge is the one inline with the HeroScore subtitle.

## Why

The badge was supposed to move into the HeroScore subtitle (#59). The intended diff included both the addition (under HeroScore) and the removal (under DateChip). When #59 was retargeted from its stacked base (\`feat/zen-casual-competitive-mode\`) to main, GitHub's squash-merge silently dropped the removal half — net result was both badges rendering on staging.

This restores the single intended placement.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)