### PR TITLE
fix(daily-zen): show current word while tracing path

### DIFF
--- a/client/src/pages/dailyZen/ZenGameRoute.tsx
+++ b/client/src/pages/dailyZen/ZenGameRoute.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { Position } from 'models';
 import { useGame, type ZenModeChoice } from '../../GameContext';
 import { Board, type FeedbackType, computeFeedbackColors } from '../game/components';
 import { InkButton } from '../../shared/components/InkButton';
@@ -44,6 +43,39 @@ export function ZenGameRoute() {
 
   const [showEndConfirm, setShowEndConfirm] = useState(false);
   const [starting, setStarting] = useState(false);
+  const [displayWord, setDisplayWord] = useState('');
+  const [wordFeedback, setWordFeedback] = useState<FeedbackType>(null);
+  const [isFading, setIsFading] = useState(false);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCurrentWordChange = useCallback((word: string) => {
+    if (word) {
+      setDisplayWord(word);
+      setWordFeedback(null);
+      setIsFading(false);
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!feedback || !cachedDailyZen) return;
+    const word = feedback.path.map((p) => cachedDailyZen.board[p.row]?.[p.col] ?? '').join('');
+    setDisplayWord(word);
+    setWordFeedback(feedback.type);
+    setIsFading(false);
+    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    fadeTimerRef.current = setTimeout(() => {
+      setIsFading(true);
+      clearTimerRef.current = setTimeout(() => {
+        setDisplayWord('');
+        setWordFeedback(null);
+        setIsFading(false);
+      }, 300);
+    }, 800);
+  }, [feedback, cachedDailyZen]);
 
   // If the session is already ended, the play page is the wrong destination.
   useEffect(() => {
@@ -103,7 +135,12 @@ export function ZenGameRoute() {
         onEnd={() => setShowEndConfirm(true)}
       />
 
-      <CurrentWordBanner feedback={feedback} board={cachedDailyZen.board} colors={colors} />
+      <CurrentWordBanner
+        word={displayWord}
+        feedbackType={wordFeedback}
+        isFading={isFading}
+        colors={colors}
+      />
 
       <div className="w-full">
         <Board
@@ -118,6 +155,7 @@ export function ZenGameRoute() {
           preactStyleIndex={BOARD_STYLE.preact}
           preactRadius={BOARD_STYLE.preactRadius}
           preactIntensity={BOARD_STYLE.preactIntensity}
+          onCurrentWordChange={handleCurrentWordChange}
         />
       </div>
 
@@ -336,28 +374,34 @@ function ScoreHeader({
 }
 
 function CurrentWordBanner({
-  feedback,
-  board,
+  word,
+  feedbackType,
+  isFading,
   colors,
 }: {
-  feedback: { type: FeedbackType; path: Position[] } | null;
-  board: string[][];
+  word: string;
+  feedbackType: FeedbackType;
+  isFading: boolean;
   colors: Record<string, string>;
 }) {
-  const word = feedback ? feedback.path.map((p) => board[p.row]?.[p.col] ?? '').join('') : '';
   const color =
-    feedback?.type === 'valid'
+    feedbackType === 'valid'
       ? colors.valid
-      : feedback?.type === 'invalid'
+      : feedbackType === 'invalid'
       ? colors.invalid
-      : feedback?.type === 'duplicate'
+      : feedbackType === 'duplicate'
       ? colors.duplicate
       : '#bbb';
+  const animation =
+    feedbackType === 'invalid' || feedbackType === 'duplicate'
+      ? 'word-shake 0.3s ease'
+      : undefined;
   return (
     <div
-      className="h-9 flex items-center justify-center tracking-wider my-2 shrink-0"
+      className={`h-9 flex items-center justify-center tracking-wider my-2 shrink-0 transition-opacity duration-300 ${isFading ? 'opacity-0' : 'opacity-100'}`}
       style={{
         color,
+        animation,
         fontFamily: 'var(--font-cell)',
         fontWeight: 800,
         fontSize: '1.4rem',


### PR DESCRIPTION
## What
The current-word display in Zen Daily now updates live as you drag across the board, matching Free Play and Timed Daily.

## Why
`ZenGameRoute` rendered a `CurrentWordBanner` that derived its word from `feedback.path`, but `feedback` is only set on submit — so nothing showed mid-trace. Free Play / Timed Daily (`GamePage`) handle this with a local `displayWord` state fed by `Board`'s `onCurrentWordChange` callback, with the `feedback` effect taking over post-submit (color + 800ms hold + 300ms fade). Zen now mirrors that pattern instead of inventing a parallel mechanism, so behavior stays in sync if `GamePage` evolves.

## Follow-ups
- Could promote the displayWord/fade state into a shared hook if a third caller appears, but per CLAUDE.md (DRY after 3 instances) two is fine.

## Test plan
- [ ] Start a Zen Daily session, drag across cells, confirm the word appears live above the board
- [ ] Submit a valid word — green flash + fade
- [ ] Submit an invalid / duplicate word — red shake + fade
- [ ] Confirm Free Play and Timed Daily still behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)