### PR TITLE
feat(landing): user-facing changelog with auto-open and pulse indicator

### DIFF
--- a/client/src/pages/landing/components/AppHeader.tsx
+++ b/client/src/pages/landing/components/AppHeader.tsx
@@ -1,3 +1,4 @@
+import { ChangelogControl } from "./ChangelogControl";
 import { ProfileAvatar } from "./ProfileAvatar";
 
 interface AppHeaderProps {
@@ -6,36 +7,11 @@ interface AppHeaderProps {
   onDisplayNameChange: (name: string) => void;
 }
 
-// Calendar slot is intentionally inert while the hub-style daily page is
-// being phased out — clicking it used to route into the daily confirm
-// flow, which let mid-play users start a fresh attempt. Left as a
-// disabled affordance so the header balance is preserved.
 export function AppHeader({ dateLabel, displayName, onDisplayNameChange }: AppHeaderProps) {
   return (
     <div className="flex flex-col items-center gap-3 pt-[18px] pb-[22px]">
       <div className="w-full flex justify-between items-center">
-        <button
-          type="button"
-          disabled
-          aria-label="Calendar (coming soon)"
-          aria-disabled="true"
-          tabIndex={-1}
-          className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center bg-transparent border-none text-[color:var(--ink-soft)] opacity-50 cursor-not-allowed"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect x="3" y="4" width="18" height="18" rx="2" />
-            <path d="M16 2v4M8 2v4M3 10h18" />
-          </svg>
-        </button>
+        <ChangelogControl />
 
         <div
           className="text-logo italic leading-none tracking-[-0.02em] font-[family-name:var(--font-display)]"

--- a/client/src/pages/landing/components/ChangelogControl.tsx
+++ b/client/src/pages/landing/components/ChangelogControl.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from 'react';
+import { useChangelog } from '../../../shared/changelog';
+import type { ChangelogEntry } from '../../../shared/changelog';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + 'T12:00:00');
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function ChangelogControl() {
+  const { entries, hasUnseen, hasUnseenMajor, markAllSeen } = useChangelog();
+  const [open, setOpen] = useState(false);
+  const autoOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (autoOpenedRef.current) return;
+    autoOpenedRef.current = true;
+    if (hasUnseenMajor) setOpen(true);
+  }, [hasUnseenMajor]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  const handleClose = () => {
+    setOpen(false);
+    markAllSeen();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={hasUnseen ? "What's new (unread updates)" : "What's new"}
+        className="relative w-[34px] h-[34px] rounded-[10px] flex items-center justify-center bg-transparent border-none text-[color:var(--ink)] cursor-pointer"
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+      >
+        <SparklesIcon />
+        {hasUnseen && (
+          <span
+            aria-hidden="true"
+            className="absolute top-[2px] right-[2px] w-2.5 h-2.5 rounded-full bg-[var(--podium-gold)] animate-[changelog-dot-pulse_2.2s_ease-out_infinite]"
+          />
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[150] flex items-center justify-center p-6 bg-black/40 backdrop-blur-md font-[family-name:var(--font-ui)]"
+          onClick={handleClose}
+          role="dialog"
+          aria-modal="true"
+          aria-label="What's new"
+        >
+          <div
+            className="w-full max-w-[340px] max-h-[80vh] rounded-2xl bg-[var(--surface-card)] shadow-[var(--shadow-card)] flex flex-col overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <header className="flex flex-col items-center pt-6 pb-4 px-6 border-b border-[var(--ink-border-subtle)]">
+              <div
+                className="text-title italic leading-none tracking-[-0.01em] font-[family-name:var(--font-display)] text-[color:var(--ink)]"
+                style={{ fontWeight: 600 }}
+              >
+                What&apos;s new
+                <span className="inline-block w-[5px] h-[5px] rounded-full bg-[var(--logo-dot)] ml-[2px] align-baseline mb-[3px]" />
+              </div>
+              <div
+                className="mt-2 text-caption uppercase tracking-[0.12em] text-[color:var(--ink-soft)] font-[family-name:var(--font-structure)]"
+                style={{ fontWeight: 600 }}
+              >
+                the changelog
+              </div>
+            </header>
+
+            <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-6">
+              {entries.length === 0 ? (
+                <p className="text-body text-[color:var(--ink-soft)] text-center">
+                  Nothing yet — check back soon.
+                </p>
+              ) : (
+                entries.map((entry) => <EntryView key={entry.id} entry={entry} />)
+              )}
+            </div>
+
+            <div className="px-6 py-4 border-t border-[var(--ink-border-subtle)]">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="w-full rounded-xl py-3 text-sm border-none cursor-pointer bg-[var(--ink)] text-[color:var(--ink-inverse)] shadow-[var(--shadow-btn-primary)]"
+                style={{ fontWeight: 700, WebkitTapHighlightColor: 'transparent' }}
+              >
+                Got it
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function EntryView({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <article className="flex flex-col gap-1.5">
+      <header className="flex items-center justify-between gap-3">
+        <span
+          className="text-caption uppercase tracking-[0.12em] text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 600 }}
+        >
+          {formatDate(entry.date)}
+        </span>
+        {entry.kind === 'major' && (
+          <span
+            className="text-caption uppercase tracking-[0.12em] text-[color:var(--podium-gold)] font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 700 }}
+          >
+            New
+          </span>
+        )}
+      </header>
+      <h3
+        className="text-heading italic leading-tight font-[family-name:var(--font-display)] text-[color:var(--ink)]"
+        style={{ fontWeight: 600 }}
+      >
+        {entry.title}
+      </h3>
+      <div
+        className={[
+          'text-body leading-relaxed text-[color:var(--ink-muted)] flex flex-col gap-2',
+          '[&_p]:m-0',
+          '[&_strong]:text-[color:var(--ink)] [&_strong]:font-semibold',
+          '[&_em]:italic',
+          '[&_a]:text-[color:var(--accent)] [&_a]:underline [&_a]:underline-offset-2',
+          '[&_ul]:list-disc [&_ul]:pl-5 [&_ul]:my-0 [&_ul]:flex [&_ul]:flex-col [&_ul]:gap-1',
+          '[&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:my-0 [&_ol]:flex [&_ol]:flex-col [&_ol]:gap-1',
+          '[&_li]:marker:text-[color:var(--ink-faint)]',
+          '[&_code]:font-mono [&_code]:text-small [&_code]:bg-[var(--ink-whisper)] [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5',
+        ].join(' ')}
+      >
+        {entry.body}
+      </div>
+    </article>
+  );
+}
+
+function SparklesIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 3l1.6 5.4L19 10l-5.4 1.6L12 17l-1.6-5.4L5 10l5.4-1.6L12 3z" />
+      <path d="M18.5 15.5l.7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7.7-2.1z" />
+    </svg>
+  );
+}

--- a/client/src/pages/landing/components/index.ts
+++ b/client/src/pages/landing/components/index.ts
@@ -1,4 +1,5 @@
 export { AppHeader } from "./AppHeader";
+export { ChangelogControl } from "./ChangelogControl";
 export { DailyCard } from "./DailyCard";
 export { ZenDailyCard } from "./ZenDailyCard";
 export { FreePlayCard } from "./FreePlayCard";

--- a/client/src/shared/changelog/entries.tsx
+++ b/client/src/shared/changelog/entries.tsx
@@ -1,0 +1,26 @@
+import type { ChangelogEntry } from './types';
+
+// Newest first. `kind: 'major'` auto-pops the modal once for users who haven't
+// dismissed that entry yet; `kind: 'minor'` only lights the notification dot.
+// Body accepts any ReactNode — use <strong>, <em>, <a>, <ul>/<li>, <code>, and
+// <p> blocks freely; the modal styles them for you.
+export const changelogEntries: ChangelogEntry[] = [
+  {
+    id: 'changelog-launch-2026-05-04',
+    date: '2026-05-04',
+    kind: 'minor',
+    title: "What's new lives here",
+    body: (
+      <>
+        <p>
+          Tap the sparkle on the top left of the landng page to see what&apos;s changed — new features,
+          fixes, and the occasional tweak.
+        </p>
+        <p>
+          <strong>Big updates</strong> pop open on their own. Smaller ones just
+          light up the gold dot.
+        </p>
+      </>
+    ),
+  },
+];

--- a/client/src/shared/changelog/index.ts
+++ b/client/src/shared/changelog/index.ts
@@ -1,0 +1,2 @@
+export { useChangelog } from './useChangelog';
+export type { ChangelogEntry, ChangelogKind } from './types';

--- a/client/src/shared/changelog/types.ts
+++ b/client/src/shared/changelog/types.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export type ChangelogKind = 'major' | 'minor';
+
+export interface ChangelogEntry {
+  id: string;
+  date: string;
+  kind: ChangelogKind;
+  title: string;
+  body: ReactNode;
+}

--- a/client/src/shared/changelog/useChangelog.ts
+++ b/client/src/shared/changelog/useChangelog.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo, useState } from 'react';
+import { changelogEntries } from './entries';
+import type { ChangelogEntry } from './types';
+
+const SEEN_KEY = 'froggle-changelog-seen';
+
+const loadSeen = (): string[] => {
+  try {
+    const raw = localStorage.getItem(SEEN_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+};
+
+const saveSeen = (ids: string[]): void => {
+  try {
+    localStorage.setItem(SEEN_KEY, JSON.stringify(ids));
+  } catch {
+    // localStorage can throw in private mode / quota — non-fatal.
+  }
+};
+
+interface UseChangelog {
+  entries: ChangelogEntry[];
+  hasUnseen: boolean;
+  hasUnseenMajor: boolean;
+  markAllSeen: () => void;
+}
+
+export function useChangelog(): UseChangelog {
+  const [seen, setSeen] = useState<Set<string>>(() => new Set(loadSeen()));
+
+  const unseenEntries = useMemo(
+    () => changelogEntries.filter((e) => !seen.has(e.id)),
+    [seen],
+  );
+
+  const markAllSeen = useCallback(() => {
+    const allIds = changelogEntries.map((e) => e.id);
+    setSeen(new Set(allIds));
+    saveSeen(allIds);
+  }, []);
+
+  return {
+    entries: changelogEntries,
+    hasUnseen: unseenEntries.length > 0,
+    hasUnseenMajor: unseenEntries.some((e) => e.kind === 'major'),
+    markAllSeen,
+  };
+}

--- a/client/src/tailwind.css
+++ b/client/src/tailwind.css
@@ -187,6 +187,23 @@ button, input, select, textarea {
   100% { transform: translateX(0); }
 }
 
+/* Changelog notification dot — gentle pulse to draw the eye without
+   demanding attention. Composes a static surface-panel ring with an
+   expanding gold halo so the dot stays visually separated from the
+   button at all phases of the animation. */
+@keyframes changelog-dot-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 2px var(--surface-panel),
+      0 0 0 0 rgba(202, 158, 52, 0.55);
+  }
+  70% {
+    box-shadow:
+      0 0 0 2px var(--surface-panel),
+      0 0 0 7px rgba(202, 158, 52, 0);
+  }
+}
+
 /* Results page gold glow animations */
 @keyframes gold-glow-square {
   0%   { box-shadow: 2px 0 4px rgba(232,189,80,0.5), -1px 0 2px rgba(196,144,10,0.15); }

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env && npm install"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "boggle",
+  "name": "froggle",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "boggle",
+      "name": "froggle",
       "workspaces": [
         "models",
         "engine",


### PR DESCRIPTION
## Summary

- Replaces the disabled calendar slot in the landing header with a sparkles "What's new" button that opens a changelog modal over a blurred backdrop.
- **Major** entries auto-open the modal once for users who haven't dismissed them. **Minor** entries only light a pulsing gold dot on the button — visible but not demanding.
- Seen state is tracked per entry ID in `localStorage` (`froggle-changelog-seen`), so the modal won't re-pop after dismissal until a new major entry ships.
- Adds a `conductor.json` setup hook so new Conductor workspaces auto-symlink the root `.env` and run `npm install` on creation — no manual fiddling before `npm run dev`.

## Why this approach

- **JSX bodies in `entries.tsx`** instead of markdown: keeps the dependency surface zero, lets the writer use semantic tags (`<strong>`, `<em>`, `<a>`, `<ul>`, `<code>`, `<p>`), and the modal styles them via descendant selectors so entry authors don't think about classes.
- **Self-contained `ChangelogControl`** (button + modal + hook) drops into `AppHeader` where the calendar lived. `AppHeader` and `LandingRoute` learn nothing new.
- **Per-entry `id` set in localStorage** instead of a "highest seen timestamp" — so re-issuing a missed major entry on a future date still triggers the auto-open for users who never saw the original.
- **Major vs minor only differ in trigger behaviour**, not visual styling. The list looks the same; the kind controls whether the modal interrupts on mount.
- **Pulse animation** lives in `tailwind.css` next to existing keyframes, composing a static `--surface-panel` ring with an expanding `--podium-gold` halo so the dot stays separated from the button at every animation phase.

## Adding new entries

Append to the top of `client/src/shared/changelog/entries.tsx`:

```tsx
{
  id: 'unique-stable-id',
  date: '2026-05-12',
  kind: 'minor', // or 'major' to auto-open
  title: 'Catchy title',
  body: (
    <>
      <p>Friendly copy with <strong>bold</strong>, <em>italics</em>, or <a href="/somewhere">links</a>.</p>
      <ul><li>Bullet</li><li>Another</li></ul>
    </>
  ),
},
```

## Follow-ups

- The `conductor.json` symlinks `.env` rather than copying. If `$CONDUCTOR_ROOT_PATH/.env` is missing the symlink will be dangling and vite will error loudly — swap to `cp` if you'd prefer the setup script to fail at provision time instead.
- Changelog entries currently don't link to anchor URLs, screenshots, or PR numbers. Easy to layer on later via the JSX bodies; deferred until there's a real entry that wants it.
- No telemetry on opens / dismissals. If we later want to know which entries get read, we'd add a fire-once event on `markAllSeen`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] First-visit major entry auto-opens the modal
- [x] "Got it" button dismisses, marks all entries seen, dot disappears
- [x] Backdrop click dismisses
- [x] Escape key dismisses
- [x] On-demand reopen via sparkles button works after dismissal
- [x] Minor-only unseen entry shows pulsing gold dot but does NOT auto-open
- [x] Light + dark mode rendering verified
- [x] Inline styling (`<strong>`, `<p>`) renders correctly inside the entry body

🤖 Generated with [Claude Code](https://claude.com/claude-code)