### PR TITLE
feat(daily-zen): rank zen leaderboard by points

### DIFF
--- a/client/src/pages/dailyZen/ZenGameRoute.tsx
+++ b/client/src/pages/dailyZen/ZenGameRoute.tsx
@@ -352,13 +352,13 @@ function ScoreHeader({
           className="text-2xl leading-none font-[family-name:var(--font-structure)] tabular-nums tracking-[-0.02em]"
           style={{ fontWeight: 800 }}
         >
-          {words}
+          {points}
         </span>
         <span className="text-small text-[color:var(--ink-muted)]" style={{ fontWeight: 600 }}>
-          {words === 1 ? 'word' : 'words'}
+          {points === 1 ? 'pt' : 'pts'}
         </span>
         <span className="text-small text-[color:var(--ink-soft)] ml-2 tabular-nums" style={{ fontWeight: 500 }}>
-          {points} {points === 1 ? 'pt' : 'pts'}
+          {words} {words === 1 ? 'word' : 'words'}
         </span>
       </div>
       <button

--- a/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
+++ b/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
@@ -81,17 +81,15 @@ export function ZenLeaderboardRoute() {
 
   const entries: LbListEntry[] = useMemo(() => {
     if (!data) return [];
-    // Zen leaderboard is ranked by words found rather than points — the
-    // primary value players are chasing in the untimed mode is breadth, not
-    // score-per-minute. Server already filters to completed competitive
-    // rows; in-progress players surface in the presence section instead.
-    return data.rankings.words.map((e) => ({
+    // Server already filters to completed competitive rows; in-progress
+    // players surface in the presence section instead.
+    return data.rankings.points.map((e) => ({
       rank: e.rank,
       userId: e.userId,
       displayName: e.displayName,
-      subLabel: `${e.points} ${e.points === 1 ? 'pt' : 'pts'}`,
-      value: e.wordCount,
-      valueUnit: e.wordCount === 1 ? 'word' : 'words',
+      subLabel: `${e.wordCount} ${e.wordCount === 1 ? 'word' : 'words'}`,
+      value: e.points,
+      valueUnit: e.points === 1 ? 'pt' : 'pts',
       isCurrentUser: e.userId === currentUserId,
     }));
   }, [data, currentUserId]);

--- a/client/src/pages/dailyZen/ZenResultsRoute.tsx
+++ b/client/src/pages/dailyZen/ZenResultsRoute.tsx
@@ -170,7 +170,7 @@ export function ZenResultsRoute() {
         <HeroScore
           points={totals.points}
           words={totals.words}
-          primary="words"
+          primary="points"
           accessory={<ZenModeBadge isCompetitive={result.is_competitive} />}
         />
 

--- a/client/src/pages/landing/components/ZenDailyCard.tsx
+++ b/client/src/pages/landing/components/ZenDailyCard.tsx
@@ -119,18 +119,10 @@ function ScoreBlock({
           className="text-display-lg leading-none font-[family-name:var(--font-structure)] tracking-[-0.03em] tabular-nums"
           style={{ fontWeight: 800 }}
         >
-          {words}
-          {totalWords !== undefined && (
-            <span
-              className="text-logo text-[color:var(--ink-muted)]"
-              style={{ fontWeight: 600 }}
-            >
-              /{totalWords}
-            </span>
-          )}
+          {points}
         </span>
         <span className="text-small text-[color:var(--ink-muted)]" style={{ fontWeight: 600 }}>
-          {words === 1 ? "word" : "words"}
+          {points === 1 ? "pt" : "pts"}
         </span>
       </div>
       <div className="flex flex-col items-end gap-0.5 leading-tight min-w-0">
@@ -138,7 +130,8 @@ function ScoreBlock({
           className="text-small text-[color:var(--ink-muted)] tabular-nums"
           style={{ fontWeight: 500 }}
         >
-          {points} pts
+          {words}
+          {totalWords !== undefined && `/${totalWords}`} {words === 1 ? "word" : "words"}
         </span>
         {longestWord && (
           <span

--- a/client/src/pages/results/components/HeroScore.tsx
+++ b/client/src/pages/results/components/HeroScore.tsx
@@ -1,9 +1,7 @@
 interface HeroScoreProps {
   points: number;
   words: number;
-  /** Which stat headlines the hero. Defaults to 'points'; zen results
-   *  pass 'words' since breadth (not score-per-minute) is what the
-   *  untimed mode optimizes for. */
+  /** Which stat headlines the hero. Defaults to 'points'. */
   primary?: 'points' | 'words';
   /** Optional run-level metadata rendered inline next to the subtitle
    *  (e.g. a mode badge). Sits alongside the secondary stat so callers

--- a/client/src/shared/changelog/entries/2026-05-05-zen-points-primary.tsx
+++ b/client/src/shared/changelog/entries/2026-05-05-zen-points-primary.tsx
@@ -1,0 +1,18 @@
+import type { ChangelogEntry } from '../types';
+
+const entry: ChangelogEntry = {
+  id: 'zen-points-primary-2026-05-05',
+  date: '2026-05-05',
+  kind: 'minor',
+  title: 'Zen daily ranks by points',
+  body: (
+    <>
+      <p>
+        The zen daily now leads with <strong>points</strong>, matching the
+        timed daily, so longer words pull more weight in the standings.
+      </p>
+    </>
+  ),
+};
+
+export default entry;

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -393,15 +393,13 @@ export async function getZenLeaderboard(
   if (requestingUserId) {
     const myRow = enriched.find((e) => e.userId === requestingUserId);
     if (myRow) {
-      // Zen ranks by words found, not points — the rank we hand to the
-      // client must reflect that primary sort. Casual and in-progress
-      // players surface a row with rank=null so the client can render the
-      // appropriate "not on the leaderboard" / "rank shows when you finish"
-      // copy without an extra round-trip.
+      // Casual and in-progress players surface a row with rank=null so the
+      // client can render the appropriate "not on the leaderboard" / "rank
+      // shows when you finish" copy without an extra round-trip.
       let rank: number | null = null;
       let ranked = false;
       if (myRow.isCompetitive && !myRow.inProgress) {
-        const idx = byWords.findIndex((e) => e.userId === requestingUserId);
+        const idx = byPoints.findIndex((e) => e.userId === requestingUserId);
         if (idx >= 0) {
           rank = idx + 1;
           ranked = true;
@@ -414,7 +412,7 @@ export async function getZenLeaderboard(
         points: myRow.points,
         wordsFound: myRow.wordCount,
         longestWord: myRow.longestWord,
-        totalRankedPlayers: byWords.length,
+        totalRankedPlayers: byPoints.length,
       };
     }
   }


### PR DESCRIPTION
## What
Zen daily now leads with **points** as the primary scoring metric instead of words found, matching the timed daily. Words remain visible everywhere as the secondary stat.

Surfaces updated:
- In-game `ScoreHeader` (`ZenGameRoute.tsx`)
- Landing `ZenDailyCard` (in-progress and ended states; preserves `x/y words` indicator)
- Results page `HeroScore` (flipped `primary="words"` → `primary="points"`)
- Zen leaderboard list (`ZenLeaderboardRoute.tsx`) — values are now `pts`, sub-label is the word count
- Server ranking in `DailyZenService.ts` — `currentPlayer.rank` and `totalRankedPlayers` now derive from the points sort
- New changelog entry under the new one-file-per-entry layout

## Why
Words-as-primary undersold longer finds, since the Fibonacci rarity points already encode the breadth-vs-depth tradeoff more meaningfully than a raw word count. Aligning with the timed daily collapses two mental models into one and lets the leaderboard reward both quantity *and* quality.

No data migration needed: `daily_zen_results` already stores `points` per row, and the recent Fibonacci re-scoring updated `points` for every historical row. The ranking is computed at read time, so historic leaderboards re-rank automatically when viewed.

## Follow-ups
- The `cachedDailyZenSession.word_count` dependency in `LandingRoute.tsx`'s zen-rank fetch effect is still words-keyed — works fine in practice (points and word_count update together) but could switch to `points` for clarity if we touch it again.
- No fixtures exist for `ZenLeaderboardRoute` or `ZenResultsRoute`, so those surfaces were verified by typecheck + the mechanical nature of the swap rather than visual screenshot.

## Test plan
- [x] `tsc` passes for client and server
- [x] Landing page `?mock=zen-ended` shows `198 pts` primary with `24/60 words` + `STARLIGHT` secondary
- [x] Landing page `?mock=zen-progress` shows `84 pts` primary with `11 words` secondary
- [x] Changelog modal renders the new "Zen daily ranks by points" entry under May 5, 2026
- [ ] Spot-check zen results page on a real session
- [ ] Spot-check zen leaderboard with multiple players where points and word-count rankings would differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)