### PR TITLE
chore(changelog): bump entry dates to 2026-05-05

### DIFF
--- a/client/src/shared/changelog/entries/2026-05-05-launch.tsx
+++ b/client/src/shared/changelog/entries/2026-05-05-launch.tsx
@@ -1,8 +1,8 @@
 import type { ChangelogEntry } from '../types';
 
 const entry: ChangelogEntry = {
-  id: 'changelog-launch-2026-05-04',
-  date: '2026-05-04',
+  id: 'changelog-launch-2026-05-05',
+  date: '2026-05-05',
   kind: 'minor',
   title: "What's new lives here",
   body: (

--- a/client/src/shared/changelog/entries/2026-05-05-scoring-fibonacci.tsx
+++ b/client/src/shared/changelog/entries/2026-05-05-scoring-fibonacci.tsx
@@ -11,8 +11,8 @@ function RarityDot({ color }: { color: string }) {
 }
 
 const entry: ChangelogEntry = {
-  id: 'scoring-fibonacci-2026-05-04',
-  date: '2026-05-04',
+  id: 'scoring-fibonacci-2026-05-05',
+  date: '2026-05-05',
   kind: 'major',
   title: 'New scoring',
   body: (


### PR DESCRIPTION
## What
Renames the two `2026-05-04-*` changelog entries (launch, scoring-fibonacci) to `2026-05-05-*` and updates their `id` + `date` fields to today.

## Why
The entries were authored ahead of the actual user-facing rollout. Bumping the dates lines the changelog up with when users will actually see them, and the new `id` also resurfaces them as unseen for anyone who already had local "seen" state from a pre-rollout build.

## Follow-ups
- None.