### PR TITLE
Fix daily performance hotspots

### DIFF
--- a/client/src/pages/daily/DailyConfirmRoute.tsx
+++ b/client/src/pages/daily/DailyConfirmRoute.tsx
@@ -63,7 +63,7 @@ export function DailyConfirmRoute() {
   useEffect(() => {
     if (mockFixture || !authReady) return;
     let cancelled = false;
-    fetchDailyStats()
+    fetchDailyStats({ definitions: false })
       .then((stats) => {
         if (cancelled) return;
         const today = stats.days[stats.days.length - 1];

--- a/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
+++ b/client/src/pages/dailyZen/ZenLeaderboardRoute.tsx
@@ -60,7 +60,7 @@ export function ZenLeaderboardRoute() {
 
   useEffect(() => {
     if (!authReady) return;
-    fetchDailyZenStats()
+    fetchDailyZenStats({ definitions: false })
       .then(setStats)
       .catch(() => {
         // Non-fatal: picker falls back to empty entries.

--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -53,7 +53,7 @@ export function LandingRoute() {
   useEffect(() => {
     if (!authReady) return;
     let cancelled = false;
-    fetchDailyStats()
+    fetchDailyStats({ definitions: false })
       .then((s) => {
         if (!cancelled) setStats(s);
       })
@@ -82,15 +82,12 @@ export function LandingRoute() {
     };
   }, [authReady, cachedDaily, cachedDailyResult]);
 
-  // Fetch zen rank as soon as the player has any session for the day —
-  // in-progress sessions are on the zen leaderboard too, so the badge is
-  // worth surfacing while play is ongoing. Re-runs when found_words changes
-  // so the displayed rank tracks the player's progress. Skipped for casual
-  // players — they never appear on the leaderboard, so the badge wouldn't
-  // render and the request would be wasted.
+  // Fetch zen rank for completed competitive sessions. In-progress players
+  // do not have a stable rank yet, and refetching on every found word creates
+  // avoidable leaderboard traffic from the landing page.
   useEffect(() => {
     if (!authReady || !cachedDailyZen || !cachedDailyZenSession) return;
-    if (!cachedDailyZenSession.is_competitive) {
+    if (!cachedDailyZenSession.is_competitive || !cachedDailyZenSession.ended_at) {
       setZenRank(null);
       return;
     }
@@ -103,7 +100,7 @@ export function LandingRoute() {
     return () => {
       cancelled = true;
     };
-  }, [authReady, cachedDailyZen, cachedDailyZenSession?.date, cachedDailyZenSession?.word_count, cachedDailyZenSession?.ended_at, cachedDailyZenSession?.is_competitive]);
+  }, [authReady, cachedDailyZen?.date, cachedDailyZenSession?.date, cachedDailyZenSession?.ended_at, cachedDailyZenSession?.is_competitive]);
 
   const handleFreePlay = async () => {
     setDailyInfo(null);

--- a/client/src/pages/leaderboard/LeaderboardRoute.tsx
+++ b/client/src/pages/leaderboard/LeaderboardRoute.tsx
@@ -45,7 +45,7 @@ export function LeaderboardRoute() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchDailyStats().then(setStats);
+    fetchDailyStats({ definitions: false }).then(setStats);
   }, []);
 
   useEffect(() => {

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -5,6 +5,7 @@ import { supabase } from '../supabase';
 const API_URL = '/api';
 
 let sessionId: string | null = null;
+const inFlightGets = new Map<string, Promise<unknown>>();
 
 export function getSessionId(): string | null {
   return sessionId;
@@ -23,6 +24,35 @@ async function sessionHeaders(): Promise<Record<string, string>> {
   }
 
   return headers;
+}
+
+async function getJson<T>(
+  url: string,
+  options: { auth?: boolean; errorPrefix?: string } = {},
+): Promise<T> {
+  const headers = options.auth ? await sessionHeaders() : undefined;
+  const key = [
+    url,
+    headers?.Authorization ?? '',
+    headers?.['X-Session-Id'] ?? '',
+  ].join('|');
+
+  const existing = inFlightGets.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const pending = fetch(url, headers ? { headers } : undefined)
+    .then(async (response) => {
+      if (options.errorPrefix && !response.ok) {
+        throw new Error(`${options.errorPrefix}: ${response.status}`);
+      }
+      return response.json() as Promise<T>;
+    })
+    .finally(() => {
+      inFlightGets.delete(key);
+    });
+
+  inFlightGets.set(key, pending);
+  return pending;
 }
 
 export const createGame = async (): Promise<{
@@ -119,8 +149,7 @@ export interface DailyInfo {
 }
 
 export const fetchDaily = async (): Promise<DailyInfo> => {
-  const response = await fetch(`${API_URL}/daily`);
-  return response.json();
+  return getJson<DailyInfo>(`${API_URL}/daily`);
 };
 
 // Mirrors DailyStatsResponse in server/services/DailyService.ts.
@@ -152,12 +181,14 @@ export interface DailyStatsResponse {
   days: DailyStatsDay[];
 }
 
-export const fetchDailyStats = async (): Promise<DailyStatsResponse> => {
-  const response = await fetch(`${API_URL}/daily/stats`, {
-    headers: await sessionHeaders(),
+export const fetchDailyStats = async (
+  options: { definitions?: boolean } = {},
+): Promise<DailyStatsResponse> => {
+  const definitions = options.definitions === false ? '?definitions=0' : '';
+  return getJson<DailyStatsResponse>(`${API_URL}/daily/stats${definitions}`, {
+    auth: true,
+    errorPrefix: 'fetchDailyStats',
   });
-  if (!response.ok) throw new Error(`fetchDailyStats: ${response.status}`);
-  return response.json();
 };
 
 export interface DailyZenStatsResponse {
@@ -166,12 +197,14 @@ export interface DailyZenStatsResponse {
   days: DailyStatsDay[];
 }
 
-export const fetchDailyZenStats = async (): Promise<DailyZenStatsResponse> => {
-  const response = await fetch(`${API_URL}/daily/zen/stats`, {
-    headers: await sessionHeaders(),
+export const fetchDailyZenStats = async (
+  options: { definitions?: boolean } = {},
+): Promise<DailyZenStatsResponse> => {
+  const definitions = options.definitions === false ? '?definitions=0' : '';
+  return getJson<DailyZenStatsResponse>(`${API_URL}/daily/zen/stats${definitions}`, {
+    auth: true,
+    errorPrefix: 'fetchDailyZenStats',
   });
-  if (!response.ok) throw new Error(`fetchDailyZenStats: ${response.status}`);
-  return response.json();
 };
 
 export interface DailyConfig {
@@ -214,10 +247,10 @@ export interface DailyResultResponse {
 }
 
 export const fetchDailyResult = async (date: string): Promise<DailyResultResponse | null> => {
-  const response = await fetch(`${API_URL}/daily/results/${date}`, {
-    headers: await sessionHeaders(),
-  });
-  const data = await response.json();
+  const data = await getJson<{ result?: DailyResultResponse | null }>(
+    `${API_URL}/daily/results/${date}`,
+    { auth: true },
+  );
   return data.result ?? null;
 };
 
@@ -254,10 +287,7 @@ export interface LeaderboardResponse {
 }
 
 export const fetchLeaderboard = async (date: string): Promise<LeaderboardResponse> => {
-  const response = await fetch(`${API_URL}/daily/leaderboard/${date}`, {
-    headers: await sessionHeaders(),
-  });
-  return response.json();
+  return getJson<LeaderboardResponse>(`${API_URL}/daily/leaderboard/${date}`, { auth: true });
 };
 
 export interface DailyCompareScoredWord {
@@ -364,8 +394,7 @@ export interface DailyZenSession {
 }
 
 export const fetchDailyZen = async (): Promise<DailyZenInfo> => {
-  const response = await fetch(`${API_URL}/daily/zen`);
-  return response.json();
+  return getJson<DailyZenInfo>(`${API_URL}/daily/zen`);
 };
 
 export const fetchDailyZenSession = async (
@@ -493,10 +522,10 @@ export interface DailyZenLeaderboardResponse {
 export const fetchDailyZenLeaderboard = async (
   date: string,
 ): Promise<DailyZenLeaderboardResponse> => {
-  const response = await fetch(`${API_URL}/daily/zen/leaderboard/${date}`, {
-    headers: await sessionHeaders(),
-  });
-  return response.json();
+  return getJson<DailyZenLeaderboardResponse>(
+    `${API_URL}/daily/zen/leaderboard/${date}`,
+    { auth: true },
+  );
 };
 
 /** Fetches a side-by-side compare payload for a zen daily. The shape

--- a/server/httpCache.ts
+++ b/server/httpCache.ts
@@ -1,0 +1,13 @@
+import type { Response } from 'express';
+
+export function cachePublic(res: Response, seconds: number): void {
+  res.set('Cache-Control', `public, max-age=${seconds}`);
+}
+
+export function cachePrivate(res: Response, seconds: number): void {
+  res.set('Cache-Control', `private, max-age=${seconds}`);
+}
+
+export function noStore(res: Response): void {
+  res.set('Cache-Control', 'no-store');
+}

--- a/server/routes/daily.ts
+++ b/server/routes/daily.ts
@@ -5,9 +5,10 @@ import { findAllWords } from 'engine/solver.js';
 import { scoreWord } from 'engine/scoring.js';
 import { requireAuth } from '../middleware/auth.js';
 import { getDb } from '../db/index.js';
-import { getSupabaseAdmin } from '../supabaseAdmin.js';
+import { cachePrivate, cachePublic, noStore } from '../httpCache.js';
 import { dictionary } from '../services/dictionary.js';
 import { scoreResult, scoreWords, getDailyStats } from '../services/DailyService.js';
+import { getDisplayNames } from '../services/displayNames.js';
 import {
   DAILY_LAUNCH_DATE,
   dailyConfigFromSeed,
@@ -24,6 +25,7 @@ dailyRouter.get('/', (_req, res) => {
   const seed = getDailySeed(date);
   const config = getDailyConfig(date);
   const board = generateSeededBoard(config.boardSize, seed);
+  cachePublic(res, 60);
   res.json({
     date,
     number,
@@ -97,6 +99,7 @@ dailyRouter.post('/results', requireAuth, async (req, res) => {
       )
       .execute();
 
+    noStore(res);
     res.json({ success: true });
   } catch (err) {
     console.error('Failed to record daily result:', err);
@@ -115,6 +118,7 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
       .executeTakeFirst();
 
     if (!result) {
+      noStore(res);
       return res.json({ result: null });
     }
 
@@ -141,6 +145,7 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
       .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }))
       .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
 
+    cachePrivate(res, 60);
     res.json({
       result: {
         date: result.date,
@@ -192,15 +197,9 @@ dailyRouter.get('/compare/:date', requireAuth, async (req, res) => {
       return res.status(404).json({ error: 'Opponent has not played this daily' });
     }
 
-    const admin = getSupabaseAdmin();
-    const [meMeta, themMeta] = await Promise.all(
-      [meUserId, otherUserId].map((uid) =>
-        admin.auth.admin
-          .getUserById(uid)
-          .then((r) => r.data.user?.user_metadata?.display_name || 'Anonymous')
-          .catch(() => 'Anonymous'),
-      ),
-    );
+    const displayNames = await getDisplayNames([meUserId, otherUserId]);
+    const meMeta = displayNames.get(meUserId) ?? 'Anonymous';
+    const themMeta = displayNames.get(otherUserId) ?? 'Anonymous';
 
     const parse = (r: typeof rows[number]) => {
       const board: string[][] = typeof r.board === 'string' ? JSON.parse(r.board) : r.board;
@@ -236,6 +235,7 @@ dailyRouter.get('/compare/:date', requireAuth, async (req, res) => {
       timeLimit: mine.time_limit,
     };
 
+    cachePrivate(res, 30);
     res.json({
       date,
       puzzleNumber: getDailyNumber(date),
@@ -276,6 +276,7 @@ dailyRouter.get('/history', requireAuth, async (req, res) => {
       };
     });
 
+    cachePrivate(res, 60);
     res.json({ entries });
   } catch (err) {
     console.error('Failed to fetch daily history:', err);
@@ -289,11 +290,14 @@ dailyRouter.get('/history', requireAuth, async (req, res) => {
 dailyRouter.get('/stats', requireAuth, async (req, res) => {
   try {
     const db = getDb();
+    const includeDefinitions = req.query.definitions !== '0';
     const stats = await getDailyStats(db, req.userId!, {
       launchDate: DAILY_LAUNCH_DATE,
       today: getDailyDatePST(),
       getPuzzleNumber: getDailyNumber,
+      includeDefinitions,
     });
+    cachePrivate(res, includeDefinitions ? 60 : 120);
     res.json(stats);
   } catch (err) {
     console.error('Failed to fetch daily stats:', err);

--- a/server/routes/dailyZen.ts
+++ b/server/routes/dailyZen.ts
@@ -6,6 +6,7 @@ import { findAllWords } from 'engine/solver.js';
 import { scoreWord } from 'engine/scoring.js';
 import { requireAuth } from '../middleware/auth.js';
 import { getDb } from '../db/index.js';
+import { cachePrivate, cachePublic, noStore } from '../httpCache.js';
 import { dictionary } from '../services/dictionary.js';
 import {
   endSession,
@@ -32,6 +33,7 @@ dailyZenRouter.get('/', (_req, res) => {
   const config = getDailyZenConfig(date);
   const board = generateSeededBoard(config.boardSize, seed);
   const { salt, wordHashes } = solveBoard(board, date);
+  cachePublic(res, 60);
   res.json({
     date,
     number,
@@ -64,8 +66,12 @@ function solveBoard(board: string[][], date: string): {
 dailyZenRouter.get('/session/:date', requireAuth, async (req, res) => {
   try {
     const session = await getSession(getDb(), req.userId!, req.params.date);
-    if (!session) return res.json({ session: null });
+    if (!session) {
+      noStore(res);
+      return res.json({ session: null });
+    }
     const { totalFindable, salt, wordHashes } = solveBoard(session.board, req.params.date);
+    noStore(res);
     res.json({
       session: { ...session, total_findable: totalFindable, salt, wordHashes },
     });
@@ -90,6 +96,7 @@ dailyZenRouter.post('/session/:date/start', requireAuth, async (req, res) => {
     const isCompetitive = req.body?.isCompetitive !== false;
     const session = await startSession(getDb(), req.userId!, date, board, isCompetitive);
     const { totalFindable, salt, wordHashes } = solveBoard(session.board, date);
+    noStore(res);
     res.json({ session: { ...session, total_findable: totalFindable, salt, wordHashes } });
   } catch (err) {
     console.error('Failed to start zen session:', err);
@@ -104,6 +111,7 @@ dailyZenRouter.post('/session/:date/word', requireAuth, async (req, res) => {
   }
   try {
     const outcome = await submitWord(getDb(), req.userId!, req.params.date, path);
+    noStore(res);
     res.json(outcome);
   } catch (err) {
     console.error('Failed to submit zen word:', err);
@@ -117,6 +125,7 @@ dailyZenRouter.post('/session/:date/end', requireAuth, async (req, res) => {
     if (!session) {
       return res.status(404).json({ error: 'No session to end' });
     }
+    noStore(res);
     res.json({ session });
   } catch (err) {
     console.error('Failed to end zen session:', err);
@@ -130,6 +139,7 @@ dailyZenRouter.get('/results/:date', requireAuth, async (req, res) => {
   try {
     const session = await getSession(getDb(), req.userId!, req.params.date);
     if (!session || !session.ended_at) {
+      noStore(res);
       return res.json({ result: null });
     }
     const foundSet = new Set(session.found_words.map((w) => w.toUpperCase()));
@@ -157,6 +167,7 @@ dailyZenRouter.get('/results/:date', requireAuth, async (req, res) => {
       .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }))
       .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
 
+    cachePrivate(res, 60);
     res.json({
       result: {
         date: session.date,
@@ -181,7 +192,9 @@ dailyZenRouter.get('/stats', requireAuth, async (req, res) => {
     const stats = await getDailyZenStats(getDb(), req.userId!, {
       launchDate: DAILY_ZEN_LAUNCH_DATE,
       today: getDailyDatePST(),
+      includeDefinitions: req.query.definitions !== '0',
     });
+    cachePrivate(res, req.query.definitions !== '0' ? 60 : 120);
     res.json(stats);
   } catch (err) {
     console.error('Failed to fetch zen stats:', err);
@@ -199,7 +212,10 @@ dailyZenRouter.get('/compare/:date', requireAuth, async (req, res) => {
   }
   try {
     const result = await getZenCompare(getDb(), req.params.date, req.userId!, otherUserId);
-    if (result.ok) return res.json(result.data);
+    if (result.ok) {
+      cachePrivate(res, 30);
+      return res.json(result.data);
+    }
     if (result.error === 'unplayed') return res.status(409).json({ error: 'You have not finished this zen daily yet' });
     if (result.error === 'opponent-missing') return res.status(404).json({ error: 'Opponent has not finished this zen daily' });
     return res.status(400).json({ error: 'Cannot compare with yourself' });
@@ -216,6 +232,7 @@ dailyZenRouter.get('/compare/:date', requireAuth, async (req, res) => {
 dailyZenRouter.get('/leaderboard/:date', async (req, res) => {
   try {
     const result = await getZenLeaderboard(getDb(), req.params.date, req.userId);
+    cachePrivate(res, 10);
     res.json(result);
   } catch (err) {
     console.error('Failed to fetch zen leaderboard:', err);

--- a/server/routes/leaderboard.ts
+++ b/server/routes/leaderboard.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { scoreWord } from 'engine/scoring.js';
 import { getDb } from '../db/index.js';
-import { getSupabaseAdmin } from '../supabaseAdmin.js';
 import { scoreWords } from '../services/DailyService.js';
 import { getDailyNumber } from '../services/dailyConfig.js';
+import { getDisplayNames } from '../services/displayNames.js';
+import { cachePrivate } from '../httpCache.js';
 
 export const leaderboardRouter = Router();
 
@@ -16,7 +17,6 @@ leaderboardRouter.get('/:date', async (req, res) => {
 
   try {
     const db = getDb();
-    const admin = getSupabaseAdmin();
 
     const results = await db
       .selectFrom('daily_results')
@@ -27,6 +27,7 @@ leaderboardRouter.get('/:date', async (req, res) => {
     const totalPlayers = results.length;
 
     if (totalPlayers === 0) {
+      cachePrivate(res, 10);
       return res.json({
         puzzleNumber: getDailyNumber(date),
         totalPlayers: 0,
@@ -35,15 +36,7 @@ leaderboardRouter.get('/:date', async (req, res) => {
       });
     }
 
-    const userMap = new Map<string, string>();
-    await Promise.all(results.map(async (r) => {
-      try {
-        const { data } = await admin.auth.admin.getUserById(r.user_id);
-        userMap.set(r.user_id, data.user?.user_metadata?.display_name || 'Anonymous');
-      } catch {
-        userMap.set(r.user_id, 'Anonymous');
-      }
-    }));
+    const userMap = await getDisplayNames(results.map((r) => r.user_id));
 
     const wordCounts = new Map<string, number>();
     const parsedResults = results.map((r) => {
@@ -159,6 +152,7 @@ leaderboardRouter.get('/:date', async (req, res) => {
       ? 0
       : Math.round(scored.reduce((sum, p) => sum + p.points, 0) / scored.length);
 
+    cachePrivate(res, 10);
     res.json({
       puzzleNumber: getDailyNumber(date),
       totalPlayers,

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { getSupabaseAdmin } from '../supabaseAdmin.js';
+import { cachePrivate, noStore } from '../httpCache.js';
+import { setCachedDisplayName } from '../services/displayNames.js';
 
 export const userRouter = Router();
 
@@ -18,6 +20,7 @@ userRouter.get('/profile', requireAuth, async (req, res) => {
     }
 
     const displayName = data.user.user_metadata?.display_name || 'Anonymous';
+    cachePrivate(res, 60);
     res.json({ display_name: displayName });
   } catch (err) {
     console.error('Failed to fetch user profile:', err);
@@ -45,7 +48,10 @@ userRouter.put('/profile', requireAuth, async (req, res) => {
       return res.status(500).json({ error: 'Failed to update profile' });
     }
 
-    res.json({ display_name: data.user.user_metadata?.display_name || trimmed });
+    const displayName = data.user.user_metadata?.display_name || trimmed;
+    setCachedDisplayName(req.userId!, displayName);
+    noStore(res);
+    res.json({ display_name: displayName });
   } catch (err) {
     console.error('Failed to update user profile:', err);
     res.status(500).json({ error: 'Failed to update profile' });

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -194,6 +194,7 @@ export interface DailyStatsConfig {
   today: string;
   getPuzzleNumber: (date: string) => number;
   windowDays?: number;
+  includeDefinitions?: boolean;
 }
 
 // Pure PST calendar arithmetic on YYYY-MM-DD strings. Noon UTC avoids
@@ -221,7 +222,13 @@ export async function getDailyStats(
   userId: string,
   config: DailyStatsConfig
 ): Promise<DailyStatsResponse> {
-  const { launchDate, today, getPuzzleNumber, windowDays = 30 } = config;
+  const {
+    launchDate,
+    today,
+    getPuzzleNumber,
+    windowDays = 30,
+    includeDefinitions = true,
+  } = config;
 
   const windowStart = maxDate(addDays(today, -(windowDays - 1)), launchDate);
   const windowEnd = today;
@@ -268,11 +275,11 @@ export async function getDailyStats(
   const playersByDate = new Map<string, number>();
   for (const row of playerCountRows) playersByDate.set(row.date, Number(row.players));
 
-  // Fetch definitions once per unique longest word — dedupe before calling.
-  const uniqueLongestWords = Array.from(
-    new Set(rankedRows.map((r) => r.longest_word).filter((w): w is string => !!w)),
-  );
-  const definitions = await getDefinitions(uniqueLongestWords);
+  const definitions = includeDefinitions
+    ? await getDefinitions(Array.from(
+      new Set(rankedRows.map((r) => r.longest_word).filter((w): w is string => !!w)),
+    ))
+    : new Map<string, WordDefinition | null>();
 
   const days: DailyStatsDay[] = [];
   for (let d = windowStart; d <= windowEnd; d = addDays(d, 1)) {

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -5,8 +5,8 @@ import { isValidWord } from 'engine/dictionary.js';
 import { scoreWord } from 'engine/scoring.js';
 import { findAllWords } from 'engine/solver.js';
 import type { Database } from '../db/types.js';
-import { getSupabaseAdmin } from '../supabaseAdmin.js';
 import { dictionary } from './dictionary.js';
+import { getDisplayNames } from './displayNames.js';
 import {
   scoreResult,
   scoreWords,
@@ -220,9 +220,19 @@ export interface DailyZenStatsResponse {
 export async function getDailyZenStats(
   db: Kysely<Database>,
   userId: string,
-  config: { launchDate: string; today: string; windowDays?: number },
+  config: {
+    launchDate: string;
+    today: string;
+    windowDays?: number;
+    includeDefinitions?: boolean;
+  },
 ): Promise<DailyZenStatsResponse> {
-  const { launchDate, today, windowDays = 30 } = config;
+  const {
+    launchDate,
+    today,
+    windowDays = 30,
+    includeDefinitions = true,
+  } = config;
 
   const windowStart = maxDate(addDays(today, -(windowDays - 1)), launchDate);
   const windowEnd = today;
@@ -249,10 +259,11 @@ export async function getDailyZenStats(
   const playersByDate = new Map<string, number>();
   for (const row of playerCountRows) playersByDate.set(row.date, Number(row.players));
 
-  const uniqueLongestWords = Array.from(
-    new Set(userRows.map((r) => r.longest_word).filter((w): w is string => !!w)),
-  );
-  const definitions = await getDefinitions(uniqueLongestWords);
+  const definitions = includeDefinitions
+    ? await getDefinitions(Array.from(
+      new Set(userRows.map((r) => r.longest_word).filter((w): w is string => !!w)),
+    ))
+    : new Map<string, DailyStatsDay['longestWordDefinition']>();
 
   const days: DailyStatsDay[] = [];
   for (let d = windowStart; d <= windowEnd; d = addDays(d, 1)) {
@@ -397,15 +408,9 @@ export async function getZenCompare(
   if (!mine || mine.ended_at === null) return { ok: false, error: 'unplayed' };
   if (!theirs || theirs.ended_at === null) return { ok: false, error: 'opponent-missing' };
 
-  const admin = getSupabaseAdmin();
-  const [meName, themName] = await Promise.all(
-    [meUserId, otherUserId].map((uid) =>
-      admin.auth.admin
-        .getUserById(uid)
-        .then((r) => r.data.user?.user_metadata?.display_name || 'Anonymous')
-        .catch(() => 'Anonymous'),
-    ),
-  );
+  const displayNames = await getDisplayNames([meUserId, otherUserId]);
+  const meName = displayNames.get(meUserId) ?? 'Anonymous';
+  const themName = displayNames.get(otherUserId) ?? 'Anonymous';
 
   const parse = (r: typeof rows[number]) => {
     const board: string[][] = typeof r.board === 'string' ? JSON.parse(r.board) : (r.board as string[][]);
@@ -461,29 +466,23 @@ export async function getZenLeaderboard(
     .where('date', '=', date)
     .execute();
 
-  const admin = getSupabaseAdmin();
-  const enriched = await Promise.all(
-    rows.map(async (row) => {
-      const words = typeof row.found_words === 'string'
-        ? (JSON.parse(row.found_words) as string[])
-        : (row.found_words as string[]);
-      const points = scoreWords(words);
-      const wordCount = words.length;
-      const displayName = await admin.auth.admin
-        .getUserById(row.user_id)
-        .then((r) => r.data.user?.user_metadata?.display_name || 'Anonymous')
-        .catch(() => 'Anonymous');
-      return {
-        userId: row.user_id,
-        displayName,
-        points,
-        wordCount,
-        longestWord: row.longest_word,
-        inProgress: row.ended_at === null,
-        isCompetitive: row.is_competitive,
-      };
-    }),
-  );
+  const displayNames = await getDisplayNames(rows.map((row) => row.user_id));
+  const enriched = rows.map((row) => {
+    const words = typeof row.found_words === 'string'
+      ? (JSON.parse(row.found_words) as string[])
+      : (row.found_words as string[]);
+    const points = scoreWords(words);
+    const wordCount = words.length;
+    return {
+      userId: row.user_id,
+      displayName: displayNames.get(row.user_id) ?? 'Anonymous',
+      points,
+      wordCount,
+      longestWord: row.longest_word,
+      inProgress: row.ended_at === null,
+      isCompetitive: row.is_competitive,
+    };
+  });
 
   const ranked = enriched.filter((e) => !e.inProgress && e.isCompetitive);
   // Casual in-progress players are excluded — they've opted out of the

--- a/server/services/displayNames.ts
+++ b/server/services/displayNames.ts
@@ -1,0 +1,60 @@
+import { getSupabaseAdmin } from '../supabaseAdmin.js';
+
+const ANONYMOUS = 'Anonymous';
+const DISPLAY_NAME_TTL_MS = 10 * 60 * 1000;
+
+const cache = new Map<string, { displayName: string; expiresAt: number }>();
+const inFlight = new Map<string, Promise<string>>();
+
+function normalizeDisplayName(value: unknown): string {
+  if (typeof value !== 'string') return ANONYMOUS;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : ANONYMOUS;
+}
+
+async function fetchDisplayName(userId: string): Promise<string> {
+  try {
+    const { data } = await getSupabaseAdmin().auth.admin.getUserById(userId);
+    return normalizeDisplayName(data.user?.user_metadata?.display_name);
+  } catch {
+    return ANONYMOUS;
+  }
+}
+
+export async function getDisplayName(userId: string): Promise<string> {
+  const now = Date.now();
+  const cached = cache.get(userId);
+  if (cached && cached.expiresAt > now) return cached.displayName;
+  if (cached) cache.delete(userId);
+
+  const existing = inFlight.get(userId);
+  if (existing) return existing;
+
+  const pending = fetchDisplayName(userId).then((displayName) => {
+    cache.set(userId, {
+      displayName,
+      expiresAt: Date.now() + DISPLAY_NAME_TTL_MS,
+    });
+    return displayName;
+  }).finally(() => {
+    inFlight.delete(userId);
+  });
+
+  inFlight.set(userId, pending);
+  return pending;
+}
+
+export async function getDisplayNames(userIds: string[]): Promise<Map<string, string>> {
+  const uniqueIds = Array.from(new Set(userIds));
+  const entries = await Promise.all(
+    uniqueIds.map(async (userId) => [userId, await getDisplayName(userId)] as const),
+  );
+  return new Map(entries);
+}
+
+export function setCachedDisplayName(userId: string, displayName: string): void {
+  cache.set(userId, {
+    displayName: normalizeDisplayName(displayName),
+    expiresAt: Date.now() + DISPLAY_NAME_TTL_MS,
+  });
+}

--- a/supabase/migrations/20260506000000_leaderboard_performance_indexes.sql
+++ b/supabase/migrations/20260506000000_leaderboard_performance_indexes.sql
@@ -1,0 +1,11 @@
+-- Match the timed daily leaderboard/rank ordering used by
+-- server/routes/leaderboard.ts and server/services/DailyService.ts.
+create index if not exists idx_daily_results_date_rank
+  on public.daily_results(date, points desc, word_count desc, completed_at asc);
+
+-- Zen leaderboards rank only completed competitive rows, with word count as
+-- a secondary sort in the API.
+drop index if exists idx_daily_zen_results_date_competitive;
+create index if not exists idx_daily_zen_results_date_competitive
+  on public.daily_zen_results(date, points desc, word_count desc)
+  where ended_at is not null and is_competitive = true;


### PR DESCRIPTION
## Summary
- Cache/dedupe Supabase Auth display-name lookups and reuse them across timed/zen leaderboards and compare endpoints
- Stop landing from refetching zen leaderboard rank on every word, and skip dictionary-definition fetches on landing/leaderboard/confirm stats calls
- Add short Cache-Control headers for safe read endpoints plus no-store on mutable/session responses
- Add lightweight client in-flight GET dedupe and leaderboard/stat indexes

## Verification
- npm run build --workspace=client
- npx tsc -p server/tsconfig.json --noEmit
- npm test

Note: client build still reports the existing Tailwind arbitrary-value CSS warning and Rollup chunk-size warning.