### PR TITLE
Reduce landing startup splash latency

### DIFF
--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -220,15 +220,35 @@ export function GameProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  // Fetch today's daily info + result on mount (wait for auth to be ready)
-  // Also migrates any localStorage daily result to the server (one-time bridge for existing users)
+  // Fetch public daily puzzle data immediately. It does not need auth, so
+  // starting it before anonymous sign-in removes one startup waterfall from
+  // the landing splash.
   useEffect(() => {
-    if (!authReady) return;
-    fetchDaily().then(async (info) => {
-      setCachedDaily(info);
-      // Check if user has already played today
+    let cancelled = false;
+    fetchDaily()
+      .then((info) => {
+        if (!cancelled) setCachedDaily(info);
+      })
+      .catch(() => {
+        if (!cancelled) setDailyResultLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Fetch the user's daily result once auth and the public daily date are
+  // both available. Also migrates any localStorage daily result to the server
+  // as a one-time bridge for existing users.
+  useEffect(() => {
+    if (!authReady || !cachedDaily) return;
+    let cancelled = false;
+    setDailyResultLoaded(false);
+
+    (async () => {
       try {
-        const result = await fetchDailyResult(info.date);
+        const result = await fetchDailyResult(cachedDaily.date);
+        if (cancelled) return;
         if (result) {
           setCachedDailyResult(result);
           setDailyResultLoaded(true);
@@ -239,38 +259,65 @@ export function GameProvider({ children }: { children: ReactNode }) {
       }
 
       // Migration: if localStorage has a result for today, upload it to the server
-      const localResult = loadDailyResult(info.date);
+      const localResult = loadDailyResult(cachedDaily.date);
       if (localResult) {
         const wordStrings = localResult.foundWords.map(w => w.word);
         try {
-          await recordDailyResultToServer(info.date, wordStrings, localResult.board, info.config);
+          await recordDailyResultToServer(cachedDaily.date, wordStrings, localResult.board, cachedDaily.config);
+          if (cancelled) return;
           setCachedDailyResult({ found_words: wordStrings, board: localResult.board });
           // Clean up localStorage now that the result is persisted on the server
-          clearDailyResult(info.date);
+          clearDailyResult(cachedDaily.date);
         } catch (err) {
           console.warn('Failed to migrate localStorage daily result to server:', err);
         }
       }
-      setDailyResultLoaded(true);
-    }).catch(() => setDailyResultLoaded(true));
-  }, [authReady]);
+      if (!cancelled) setDailyResultLoaded(true);
+    })().catch(() => {
+      if (!cancelled) setDailyResultLoaded(true);
+    });
 
-  // Fetch zen daily puzzle + any in-progress / ended session for today.
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, cachedDaily]);
+
+  // Fetch public zen puzzle data immediately. The authenticated session row
+  // is loaded separately below once auth is ready.
   useEffect(() => {
-    if (!authReady) return;
+    let cancelled = false;
     fetchDailyZen()
-      .then(async (info) => {
-        setCachedDailyZen(info);
-        try {
-          const session = await fetchDailyZenSession(info.date);
-          setCachedDailyZenSession(session);
-        } catch {
-          // ignore — landing falls back to "Play"
-        }
-        setDailyZenLoaded(true);
+      .then((info) => {
+        if (!cancelled) setCachedDailyZen(info);
       })
-      .catch(() => setDailyZenLoaded(true));
-  }, [authReady]);
+      .catch(() => {
+        if (!cancelled) setDailyZenLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!authReady || !cachedDailyZen) return;
+    let cancelled = false;
+    setDailyZenLoaded(false);
+
+    fetchDailyZenSession(cachedDailyZen.date)
+      .then((session) => {
+        if (!cancelled) setCachedDailyZenSession(session);
+      })
+      .catch(() => {
+        // ignore — landing falls back to "Play"
+      })
+      .finally(() => {
+        if (!cancelled) setDailyZenLoaded(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, cachedDailyZen]);
 
   // Record daily results when a daily game is completed in the current session.
   // Skips if the result for this date has already been cached (either from a prior

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -10,14 +10,14 @@ import { useFeedbackSounds } from './pages/game';
 import type { FeedbackType } from './pages/game';
 import type { GameResults } from './shared/types';
 import { scoreWord } from './shared/utils/score';
-import type { DailyInfo, DailyZenInfo, DailyZenSession } from './shared/api/gameApi';
+import type { DailyInfo, DailyZenMeta, DailyZenSession } from './shared/api/gameApi';
 import {
   fetchDaily,
   recordDailyResultToServer,
   fetchDailyResult,
   fetchProfile,
   updateProfile,
-  fetchDailyZen,
+  fetchDailyZenMeta,
   fetchDailyZenSession,
   submitDailyZenWord,
 } from './shared/api/gameApi';
@@ -58,7 +58,7 @@ interface GameContextValue {
   refreshDaily: () => Promise<DailyInfo>;
 
   // Zen Daily
-  cachedDailyZen: DailyZenInfo | null;
+  cachedDailyZen: DailyZenMeta | null;
   cachedDailyZenSession: DailyZenSession | null;
   dailyZenLoaded: boolean;
   setCachedDailyZenSession: (session: DailyZenSession | null) => void;
@@ -200,7 +200,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
   const [dailyResultLoaded, setDailyResultLoaded] = useState(false);
 
   // Zen Daily state
-  const [cachedDailyZen, setCachedDailyZen] = useState<DailyZenInfo | null>(null);
+  const [cachedDailyZen, setCachedDailyZen] = useState<DailyZenMeta | null>(null);
   const [cachedDailyZenSession, setCachedDailyZenSession] = useState<DailyZenSession | null>(null);
   const [dailyZenLoaded, setDailyZenLoaded] = useState(false);
   const [lastZenModeChoice, setLastZenModeChoiceState] = useState<ZenModeChoice>(loadZenModeChoice);
@@ -286,7 +286,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
   // is loaded separately below once auth is ready.
   useEffect(() => {
     let cancelled = false;
-    fetchDailyZen()
+    fetchDailyZenMeta()
       .then((info) => {
         if (!cancelled) setCachedDailyZen(info);
       })
@@ -395,10 +395,10 @@ export function GameProvider({ children }: { children: ReactNode }) {
   const zenValidator = useWordValidator();
 
   useEffect(() => {
-    const salt = cachedDailyZenSession?.salt ?? cachedDailyZen?.salt ?? '';
-    const hashes = cachedDailyZenSession?.wordHashes ?? cachedDailyZen?.wordHashes ?? [];
+    const salt = cachedDailyZenSession?.salt ?? '';
+    const hashes = cachedDailyZenSession?.wordHashes ?? [];
     zenValidator.setSource(salt, hashes);
-  }, [cachedDailyZenSession?.salt, cachedDailyZenSession?.wordHashes, cachedDailyZen?.salt, cachedDailyZen?.wordHashes, zenValidator]);
+  }, [cachedDailyZenSession?.salt, cachedDailyZenSession?.wordHashes, zenValidator]);
 
   useEffect(() => {
     zenValidator.setSubmitted(cachedDailyZenSession?.found_words ?? []);

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -355,7 +355,7 @@ export const fetchDailyHistory = async (): Promise<{ entries: DailyHistoryEntry[
 
 // ─── Zen Daily mode ────────────────────────────────────────────────────
 
-export interface DailyZenInfo {
+export interface DailyZenMeta {
   date: string;
   number: number;
   seed: number;
@@ -364,6 +364,9 @@ export interface DailyZenInfo {
     boardSize: number;
     minWordLength: number;
   };
+}
+
+export interface DailyZenInfo extends DailyZenMeta {
   /** Salted word hashes + salt for client-side validation. The salt is per-fetch. */
   salt: string;
   wordHashes: string[];
@@ -395,6 +398,10 @@ export interface DailyZenSession {
 
 export const fetchDailyZen = async (): Promise<DailyZenInfo> => {
   return getJson<DailyZenInfo>(`${API_URL}/daily/zen`);
+};
+
+export const fetchDailyZenMeta = async (): Promise<DailyZenMeta> => {
+  return getJson<DailyZenMeta>(`${API_URL}/daily/zen/meta`);
 };
 
 export const fetchDailyZenSession = async (

--- a/server/routes/dailyZen.ts
+++ b/server/routes/dailyZen.ts
@@ -28,20 +28,27 @@ export const dailyZenRouter = Router();
 
 const solvedBoardCache = new Map<string, { totalFindable: number; words: string[] }>();
 
-dailyZenRouter.get('/', (_req, res) => {
+function getZenDailyPayload() {
   const date = getDailyDatePST();
   const number = getDailyZenNumber(date);
   const seed = getDailyZenSeed(date);
   const config = getDailyZenConfig(date);
   const board = generateSeededBoard(config.boardSize, seed);
+  return { date, number, seed, board, config };
+}
+
+dailyZenRouter.get('/meta', (_req, res) => {
+  cachePublic(res, 60);
+  res.json(getZenDailyPayload());
+});
+
+dailyZenRouter.get('/', (_req, res) => {
+  const payload = getZenDailyPayload();
+  const { date, board } = payload;
   const { salt, wordHashes } = solveBoard(board, date);
   cachePublic(res, 60);
   res.json({
-    date,
-    number,
-    seed,
-    board,
-    config,
+    ...payload,
     salt,
     wordHashes,
   });

--- a/server/routes/dailyZen.ts
+++ b/server/routes/dailyZen.ts
@@ -26,6 +26,8 @@ import { getDailyDatePST } from '../services/dailyConfig.js';
 
 export const dailyZenRouter = Router();
 
+const solvedBoardCache = new Map<string, { totalFindable: number; words: string[] }>();
+
 dailyZenRouter.get('/', (_req, res) => {
   const date = getDailyDatePST();
   const number = getDailyZenNumber(date);
@@ -53,11 +55,20 @@ function solveBoard(board: string[][], date: string): {
   salt: string;
   wordHashes: string[];
 } {
+  const key = `${date}:${board.flat().join('')}`;
   const minWordLength = getDailyZenConfig(date).minWordLength;
-  const all = findAllWords(board, dictionary, minWordLength);
+  let solved = solvedBoardCache.get(key);
+  if (!solved) {
+    const all = findAllWords(board, dictionary, minWordLength);
+    solved = {
+      totalFindable: all.length,
+      words: all.map((w) => w.word),
+    };
+    solvedBoardCache.set(key, solved);
+  }
   const salt = generateSalt();
-  const wordHashes = all.map((w) => hashWord(w.word, salt));
-  return { totalFindable: all.length, salt, wordHashes };
+  const wordHashes = solved.words.map((word) => hashWord(word, salt));
+  return { totalFindable: solved.totalFindable, salt, wordHashes };
 }
 
 // Returns the player's session for today (or whatever date they ask for).


### PR DESCRIPTION
## Summary
- Add `GET /api/daily/zen/meta` for landing startup: date, number, config, board only, no solver/hash work
- Keep `GET /api/daily/zen` as the full play validation payload with salt + word hashes
- Start public daily and zen meta fetches immediately instead of waiting for auth
- Split authenticated daily-result and zen-session fetches so startup work runs in parallel instead of in a waterfall
- Cache solved zen board word lists in-process so full zen validation/session fetches do not rerun DFS/prefix construction on every request

## Measurements
- Production curl from this workspace before the patch: `/api/daily` ~273ms, `/api/daily/zen` ~891ms TTFB
- Repeated prod `/api/daily/zen` samples were mostly ~540-600ms TTFB from here
- Local solver timing for today's 5x5 zen board: `findAllWords` ~67ms, hashing cached words ~0.4ms
- Expected first-paint impact: landing now uses the lightweight meta endpoint and no longer waits for the full zen solver/hash payload

## Verification
- npm run build --workspace=client
- npx tsc -p server/tsconfig.json --noEmit
- npm test

Note: client build still reports the existing Tailwind arbitrary-value CSS warning and Rollup chunk-size warning.