### PR TITLE
feat(landing): compact split-row daily cards

### DIFF
--- a/client/src/pages/landing/LandingPage.tsx
+++ b/client/src/pages/landing/LandingPage.tsx
@@ -1,4 +1,11 @@
-import { AppHeader, DailyCard, FreePlayCard, ZenDailyCard, ThemeTogglePill } from "./components";
+import {
+  AppHeader,
+  DailyCard,
+  FreePlayCard,
+  NextDailyHeader,
+  ThemeTogglePill,
+  ZenDailyCard,
+} from "./components";
 import type { DailyResults } from "./types";
 import type { DailyZenSession } from "../../shared/api/gameApi";
 
@@ -6,7 +13,6 @@ interface LandingPageProps {
   dateLabel: string;
   streak: number;
   dailyConfig: { boardSize: number; timeLimit: number; minWordLength: number };
-  zenConfig: { boardSize: number; minWordLength: number };
   dailyResults: DailyResults | null;
   dailyRank: number | null;
   zenSession: DailyZenSession | null;
@@ -29,7 +35,6 @@ export function LandingPage({
   dateLabel,
   streak,
   dailyConfig,
-  zenConfig,
   dailyResults,
   dailyRank,
   zenSession,
@@ -58,9 +63,10 @@ export function LandingPage({
           onDisplayNameChange={onDisplayNameChange}
         />
 
-        <div className="flex-1 flex flex-col justify-center gap-[14px]">
+        <div className="flex-1 flex flex-col justify-center gap-[10px]">
+          <NextDailyHeader streak={streak} />
+
           <DailyCard
-            streak={streak}
             config={dailyConfig}
             results={dailyResults}
             rank={dailyRank}
@@ -70,7 +76,6 @@ export function LandingPage({
           />
           <ZenDailyCard
             session={zenSession}
-            config={zenConfig}
             rank={zenRank}
             onPlay={onZenPlay}
             onResume={onZenResume}

--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -149,7 +149,6 @@ export function LandingRoute() {
         dateLabel={mockFixture.dateLabel}
         streak={mockFixture.streak}
         dailyConfig={mockFixture.dailyConfig}
-        zenConfig={mockFixture.zenConfig}
         dailyResults={mockFixture.dailyResults}
         dailyRank={null}
         zenSession={mockFixture.zenSession ?? null}
@@ -201,7 +200,6 @@ export function LandingRoute() {
       dateLabel={formatToday(cachedDaily.date)}
       streak={stats?.currentStreak ?? 0}
       dailyConfig={cachedDaily.config}
-      zenConfig={cachedDailyZen.config}
       dailyResults={dailyResultsData}
       dailyRank={dailyRank}
       zenSession={cachedDailyZenSession}

--- a/client/src/pages/landing/components/DailyCard.tsx
+++ b/client/src/pages/landing/components/DailyCard.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from "react";
-import { StatusIcon } from "../../../shared/components/StatusIcon";
-import { InkButton } from "../../../shared/components/InkButton";
-import { RankBadge, type PodiumRank } from "./RankBadge";
+import { DailyRow } from "./DailyRow";
+import type { PodiumRank } from "./RankBadge";
 import type { DailyResults } from "../types";
 
 interface DailyCardProps {
-  streak: number;
   config: { boardSize: number; timeLimit: number; minWordLength: number };
   results: DailyResults | null;
   /** Player's rank for today's puzzle. Only the top-3 are surfaced as a badge. */
@@ -16,7 +13,6 @@ interface DailyCardProps {
 }
 
 export function DailyCard({
-  streak,
   config,
   results,
   rank,
@@ -25,242 +21,32 @@ export function DailyCard({
   onSeeLeaderboard,
 }: DailyCardProps) {
   const completed = results !== null;
-  const podiumRank: PodiumRank | null =
+  const podium: PodiumRank | null =
     completed && (rank === 1 || rank === 2 || rank === 3) ? rank : null;
 
   return (
-    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] flex flex-col overflow-hidden">
-      <div className="flex justify-between items-center px-5 pt-[18px]">
-        <div className="flex items-center gap-1.5">
-          <StatusIcon state={completed ? 'completed' : 'unplayed'} />
-          <span
-            className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] leading-none font-[family-name:var(--font-structure)]"
-            style={{ fontWeight: 700 }}
-          >
-            Timed Daily
-          </span>
-          {podiumRank && <RankBadge rank={podiumRank} />}
-        </div>
-        <StreakBadge streak={streak} />
-      </div>
-
-      <div className="px-5 py-3 flex flex-col gap-[10px]">
-        {completed && results ? (
-          <>
-            <ScoreBlock points={results.points} words={results.words} longestWord={results.longestWord} />
-            <div className="grid grid-cols-2 gap-2">
-              <SecondaryButton onClick={onSeeResult}>See result</SecondaryButton>
-              <SecondaryButton onClick={onSeeLeaderboard}>Leaderboard</SecondaryButton>
-            </div>
-            <NextDailyCountdown />
-          </>
-        ) : (
-          <>
-            <PrimaryPlayButton onClick={onPlay} />
-            <LeaderboardLink onClick={onSeeLeaderboard} />
-          </>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function StreakBadge({ streak }: { streak: number }) {
-  const active = streak > 0;
-  return (
-    <span
-      className={
-        'inline-flex items-center gap-1 rounded-full px-2 py-[3px] leading-none ' +
-        (active
-          ? 'bg-[var(--streak-green)] text-white'
-          : 'bg-[var(--ink-trace)] text-[color:var(--ink-soft)]')
+    <DailyRow
+      mode="timed"
+      label="Timed Daily"
+      state={completed ? "completed" : "unplayed"}
+      podium={podium}
+      results={
+        results
+          ? { points: results.points, words: results.words }
+          : null
       }
-      style={{ fontWeight: 600 }}
-    >
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        aria-hidden
-      >
-        <path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.7 7L12 17.8 5.7 21.2l1.7-7L2 9.5l7.1-.6L12 2z" />
-      </svg>
-      <span className="text-caption tabular-nums">{streak} day streak</span>
-    </span>
+      unplayedHint={formatTimedHint(config)}
+      onPrimary={completed ? onSeeResult : onPlay}
+      onLeaderboard={onSeeLeaderboard}
+    />
   );
 }
 
-function formatTimer(seconds: number): string {
-  if (!isFinite(seconds) || seconds <= 0) return '∞';
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return s === 0 ? `${m}:00` : `${m}:${String(s).padStart(2, '0')}`;
-}
-
-function ScoreBlock({
-  points,
-  words,
-  longestWord,
-}: {
-  points: number;
-  words: number;
-  longestWord?: string;
-}) {
-  return (
-    <div
-      className="flex items-end justify-between py-0.5"
-      style={{ animation: "v2-fade-in-up 0.5s cubic-bezier(0.22, 1, 0.36, 1)" }}
-    >
-      <div className="flex items-baseline gap-[5px]">
-        <span
-          className="text-display-lg leading-none font-[family-name:var(--font-structure)] tracking-[-0.03em] tabular-nums"
-          style={{ fontWeight: 800 }}
-        >
-          {points}
-        </span>
-        <span className="text-small text-[color:var(--ink-muted)]" style={{ fontWeight: 600 }}>
-          pts
-        </span>
-      </div>
-      <div className="flex flex-col items-end gap-0.5 leading-tight min-w-0">
-        <span
-          className="text-small text-[color:var(--ink-muted)] tabular-nums"
-          style={{ fontWeight: 500 }}
-        >
-          {words} {words === 1 ? "word" : "words"}
-        </span>
-        {longestWord && (
-          <span
-            className="text-small uppercase tracking-[0.04em] text-[color:var(--ink)] truncate max-w-[140px] font-[family-name:var(--font-structure)]"
-            style={{ fontWeight: 700 }}
-            title={longestWord}
-          >
-            {longestWord}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function NextDailyCountdown() {
-  const [msLeft, setMsLeft] = useState(msUntilNextDailyPST);
-  useEffect(() => {
-    const id = setInterval(() => setMsLeft(msUntilNextDailyPST()), 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  return (
-    <div
-      className="flex items-center justify-center gap-[5px] text-[11px] text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-ui)] -mt-0.5"
-      style={{ fontWeight: 500 }}
-    >
-      <svg
-        width="11"
-        height="11"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden
-        className="opacity-80"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <polyline points="12 6 12 12 16 14" />
-      </svg>
-      Next daily in {formatCountdown(msLeft)}
-    </div>
-  );
-}
-
-function msUntilNextDailyPST(): number {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Los_Angeles',
-    hour: 'numeric',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).formatToParts(new Date());
-  const h = Number(parts.find((p) => p.type === 'hour')!.value) % 24;
-  const m = Number(parts.find((p) => p.type === 'minute')!.value);
-  const s = Number(parts.find((p) => p.type === 'second')!.value);
-  return Math.max(0, (24 * 3600 - (h * 3600 + m * 60 + s)) * 1000);
-}
-
-function formatCountdown(ms: number): string {
-  const totalS = Math.max(0, Math.floor(ms / 1000));
-  const h = Math.floor(totalS / 3600);
-  const m = Math.floor((totalS % 3600) / 60);
-  const s = totalS % 60;
-  if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m`;
-  return `${m}m ${String(s).padStart(2, '0')}s`;
-}
-
-function PrimaryPlayButton({ onClick }: { onClick: () => void }) {
-  return (
-    <InkButton onClick={onClick}>
-      Play daily
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="transition-transform duration-200 group-hover:translate-x-[3px]"
-      >
-        <path d="M5 12h14M13 5l7 7-7 7" />
-      </svg>
-    </InkButton>
-  );
-}
-
-function SecondaryButton({
-  children,
-  onClick,
-}: {
-  children: React.ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex items-center justify-center gap-2 rounded-xl py-3 px-3 text-small text-[color:var(--ink)] bg-transparent border border-[var(--ink-border)] cursor-pointer select-none hover:bg-[var(--ink-whisper)] hover:border-[var(--ink-muted)] active:scale-[0.98] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] font-[family-name:var(--font-ui)]"
-      style={{ fontWeight: 600, WebkitTapHighlightColor: "transparent" }}
-    >
-      {children}
-    </button>
-  );
-}
-
-function LeaderboardLink({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group flex items-center justify-center gap-1.5 text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] bg-transparent border-none cursor-pointer font-[family-name:var(--font-ui)] transition-colors duration-200"
-      style={{ fontWeight: 500 }}
-    >
-      See today's leaderboard
-      <svg
-        width="11"
-        height="11"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="transition-transform duration-200 group-hover:translate-x-[2px]"
-      >
-        <path d="M9 18l6-6-6-6" />
-      </svg>
-    </button>
-  );
+function formatTimedHint(config: { boardSize: number; timeLimit: number }) {
+  const { boardSize, timeLimit } = config;
+  if (!isFinite(timeLimit) || timeLimit <= 0) {
+    return `No timer · ${boardSize}×${boardSize}`;
+  }
+  const minutes = Math.floor(timeLimit / 60);
+  return `${minutes}-minute timer · ${boardSize}×${boardSize}`;
 }

--- a/client/src/pages/landing/components/DailyRow.tsx
+++ b/client/src/pages/landing/components/DailyRow.tsx
@@ -1,0 +1,160 @@
+import { ModeAvatar, TrophyIcon } from "./ModeAvatar";
+import { RankBadge, type PodiumRank } from "./RankBadge";
+import { StatusIcon } from "../../../shared/components/StatusIcon";
+
+export type DailyMode = "timed" | "zen";
+export type DailyState = "unplayed" | "in-progress" | "completed";
+
+export interface DailyRowResults {
+  points: number;
+  words: number;
+  /** When set, the words count renders as `words/totalWords`. */
+  totalWords?: number;
+}
+
+interface DailyRowProps {
+  mode: DailyMode;
+  label: string;
+  state: DailyState;
+  /** Top-3 finish badge. Only rendered when results are present. */
+  podium: PodiumRank | null;
+  results: DailyRowResults | null;
+  /** Mode-specific copy shown when the row is unplayed. e.g.
+   *  "2-minute timer · 5×5". Ignored when there's a result or in-progress
+   *  session — those states have their own line. */
+  unplayedHint: string;
+  onPrimary: () => void;
+  onLeaderboard: () => void;
+}
+
+// Compact split-row for one daily mode. Left half is the primary tap
+// (Play / Resume / See result), right half is the per-mode leaderboard.
+// The inner divider is short and centered so the trophy column doesn't
+// read as its own outlined sub-card when the parent's rounded corners
+// "clip" the perceived rectangle around it.
+export function DailyRow({
+  mode,
+  label,
+  state,
+  podium,
+  results,
+  unplayedHint,
+  onPrimary,
+  onLeaderboard,
+}: DailyRowProps) {
+  return (
+    <div className="flex items-stretch w-full rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden font-[family-name:var(--font-ui)]">
+      <button
+        type="button"
+        onClick={onPrimary}
+        className="group flex-1 flex items-center gap-3 px-4 py-[12px] bg-transparent border-none cursor-pointer select-none text-left hover:bg-[var(--ink-whisper)] active:scale-[0.99] transition-colors duration-150 min-w-0"
+        style={{ WebkitTapHighlightColor: "transparent", minHeight: 60 }}
+      >
+        <ModeAvatar mode={mode} size={32} />
+        <div className="flex-1 flex flex-col gap-[3px] min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span
+              className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] leading-none font-[family-name:var(--font-structure)] truncate"
+              style={{ fontWeight: 700 }}
+            >
+              {label}
+            </span>
+            {podium && <RankBadge rank={podium} />}
+            {state !== "unplayed" && <StatusIcon state={state} />}
+          </div>
+          {results ? (
+            <ScoreLine results={results} />
+          ) : (
+            <SubtleHint state={state} unplayedHint={unplayedHint} />
+          )}
+        </div>
+        <Chevron className="shrink-0 text-[color:var(--ink-faint)] group-hover:text-[color:var(--ink-muted)] group-hover:translate-x-[2px] transition-[transform,color] duration-200" />
+      </button>
+
+      {/* Inset divider — short and centered so the trophy column doesn't
+          read as its own outlined sub-card under the parent's rounded
+          corners. */}
+      <div
+        aria-hidden
+        className="self-center w-px h-8 bg-[var(--ink-border-subtle)] shrink-0"
+      />
+      <button
+        type="button"
+        onClick={onLeaderboard}
+        aria-label="Leaderboard"
+        className="inline-flex items-center justify-center px-4 text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] hover:bg-[var(--ink-whisper)] cursor-pointer bg-transparent border-none transition-colors duration-150"
+        style={{ WebkitTapHighlightColor: "transparent", minWidth: 52 }}
+      >
+        <TrophyIcon size={16} />
+      </button>
+    </div>
+  );
+}
+
+function ScoreLine({ results }: { results: DailyRowResults }) {
+  return (
+    <div
+      className="flex items-baseline gap-1.5 min-w-0"
+      style={{ animation: "v2-fade-in-up 0.5s cubic-bezier(0.22, 1, 0.36, 1)" }}
+    >
+      <span
+        className="text-xl leading-none font-[family-name:var(--font-structure)] tracking-[-0.03em] tabular-nums text-[color:var(--ink)]"
+        style={{ fontWeight: 800 }}
+      >
+        {results.points}
+      </span>
+      <span
+        className="text-caption text-[color:var(--ink-muted)]"
+        style={{ fontWeight: 600 }}
+      >
+        pts
+      </span>
+      <span
+        className="text-caption text-[color:var(--ink-muted)] tabular-nums"
+        style={{ fontWeight: 500 }}
+      >
+        · {results.words}
+        {results.totalWords !== undefined ? `/${results.totalWords}` : ""}{" "}
+        {results.words === 1 ? "word" : "words"}
+      </span>
+    </div>
+  );
+}
+
+function SubtleHint({
+  state,
+  unplayedHint,
+}: {
+  state: DailyState;
+  unplayedHint: string;
+}) {
+  const text =
+    state === "in-progress" ? "Pick up where you left off" : unplayedHint;
+  return (
+    <span
+      className="text-xs text-[color:var(--ink-soft)] truncate"
+      style={{ fontWeight: 500 }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function Chevron({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={className}
+    >
+      <path d="M9 18l6-6-6-6" />
+    </svg>
+  );
+}

--- a/client/src/pages/landing/components/FreePlayCard.tsx
+++ b/client/src/pages/landing/components/FreePlayCard.tsx
@@ -2,43 +2,91 @@ interface FreePlayCardProps {
   onClick: () => void;
 }
 
+// Free Play sits below the dailies as a visually distinct option — same
+// solid card structure as the dailies (so it looks like a real, completed
+// feature, not a placeholder), but flatter (no shadow, ink-whisper fill)
+// and led by a sliders glyph instead of a mode avatar so it reads as a
+// customisation tool, not a daily puzzle. A thin rule above it makes the
+// grouping break with the dailies explicit.
 export function FreePlayCard({ onClick }: FreePlayCardProps) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Free play"
-      className="group flex items-center justify-between gap-3 w-full rounded-2xl px-5 py-4 bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] cursor-pointer select-none text-left hover:-translate-y-px hover:shadow-[var(--shadow-card-hover)] active:scale-[0.99] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] font-[family-name:var(--font-ui)]"
-      style={{ WebkitTapHighlightColor: "transparent" }}
+    <>
+      <div
+        className="h-px bg-[var(--ink-border-subtle)] mt-1 mx-1"
+        aria-hidden
+      />
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label="Free play"
+        className="group flex items-center gap-3 w-full rounded-2xl px-4 py-[12px] bg-[var(--ink-whisper)] border border-[var(--ink-border-subtle)] cursor-pointer select-none text-left hover:bg-[var(--ink-trace)] hover:border-[var(--ink-border)] active:scale-[0.99] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] font-[family-name:var(--font-ui)]"
+        style={{ WebkitTapHighlightColor: "transparent", minHeight: 56 }}
+      >
+        <SlidersGlyph />
+        <span className="flex flex-col gap-[2px] flex-1 min-w-0">
+          <span
+            className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] leading-none font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 700 }}
+          >
+            Free Play
+          </span>
+          <span
+            className="text-xs leading-[1.3] text-[color:var(--ink-soft)]"
+            style={{ fontWeight: 500 }}
+          >
+            Custom board, time, and letters
+          </span>
+        </span>
+        <Chevron />
+      </button>
+    </>
+  );
+}
+
+function SlidersGlyph() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-center justify-center rounded-full shrink-0 bg-[var(--ink-trace)] text-[color:var(--ink-muted)]"
+      style={{ width: 32, height: 32 }}
     >
-      <span className="flex flex-col gap-[3px]">
-        <span
-          className="text-body-lg leading-none tracking-[-0.01em] text-[color:var(--ink)] font-[family-name:var(--font-structure)]"
-          style={{ fontWeight: 700 }}
-        >
-          Free play
-        </span>
-        <span
-          className="text-xs leading-[1.3] text-[color:var(--ink-soft)]"
-          style={{ fontWeight: 500 }}
-        >
-          Custom board, time, and letters
-        </span>
-      </span>
       <svg
         width="16"
         height="16"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
-        strokeWidth="2.2"
+        strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
         aria-hidden
-        className="shrink-0 text-[color:var(--ink-faint)] group-hover:text-[color:var(--ink-muted)] group-hover:translate-x-[3px] transition-[transform,color] duration-200"
       >
-        <path d="M9 18l6-6-6-6" />
+        <line x1="4" y1="7" x2="20" y2="7" />
+        <line x1="4" y1="12" x2="20" y2="12" />
+        <line x1="4" y1="17" x2="20" y2="17" />
+        <circle cx="9" cy="7" r="2" fill="var(--ink-whisper)" />
+        <circle cx="15" cy="12" r="2" fill="var(--ink-whisper)" />
+        <circle cx="7" cy="17" r="2" fill="var(--ink-whisper)" />
       </svg>
-    </button>
+    </span>
+  );
+}
+
+function Chevron() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="shrink-0 text-[color:var(--ink-faint)] group-hover:text-[color:var(--ink-muted)] group-hover:translate-x-[2px] transition-[transform,color] duration-200"
+    >
+      <path d="M9 18l6-6-6-6" />
+    </svg>
   );
 }

--- a/client/src/pages/landing/components/ModeAvatar.tsx
+++ b/client/src/pages/landing/components/ModeAvatar.tsx
@@ -1,0 +1,79 @@
+import type { DailyMode } from "./DailyRow";
+
+// Per-mode visual identity. Each daily renders with a distinct glyph and
+// accent tint so the lineup reads as different things at a glance — not
+// just three rectangles with different labels. Backed by existing palette
+// tokens so we don't introduce mode colors as new design knobs.
+
+const MODE_TINT: Record<DailyMode, { bg: string; stroke: string }> = {
+  timed: { bg: "var(--podium-gold-bg)", stroke: "var(--podium-gold)" },
+  zen: { bg: "var(--streak-green-glow)", stroke: "var(--streak-green)" },
+};
+
+export function ModeAvatar({
+  mode,
+  size = 32,
+}: {
+  mode: DailyMode;
+  size?: number;
+}) {
+  const { bg, stroke } = MODE_TINT[mode];
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-center justify-center rounded-full shrink-0"
+      style={{ width: size, height: size, background: bg, color: stroke }}
+    >
+      <ModeGlyph mode={mode} size={Math.round(size * 0.55)} />
+    </span>
+  );
+}
+
+function ModeGlyph({ mode, size }: { mode: DailyMode; size: number }) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: "0 0 24 24" as const,
+    fill: "none" as const,
+    stroke: "currentColor" as const,
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+  };
+  if (mode === "timed") {
+    return (
+      <svg {...common}>
+        <circle cx="12" cy="13" r="8" />
+        <path d="M12 9v4l2.5 2.5M9 2h6M12 5V2" />
+      </svg>
+    );
+  }
+  // zen
+  return (
+    <svg {...common}>
+      <path d="M5 21c0-9 7-16 16-16-1 9-7 16-16 16z" />
+      <path d="M5 21c4-4 8-8 16-16" />
+    </svg>
+  );
+}
+
+export function TrophyIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M8 21h8M12 17v4" />
+      <path d="M7 4h10v5a5 5 0 0 1-10 0V4z" />
+      <path d="M17 5h3v3a3 3 0 0 1-3 3M7 5H4v3a3 3 0 0 0 3 3" />
+    </svg>
+  );
+}

--- a/client/src/pages/landing/components/NextDailyHeader.tsx
+++ b/client/src/pages/landing/components/NextDailyHeader.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { StreakBadge } from "./StreakBadge";
+
+// Single shared "next daily reset" indicator + streak chip. The reset is
+// the same wall-clock event for every daily mode, so it surfaces once
+// above the row of daily cards instead of repeating per-card.
+
+interface NextDailyHeaderProps {
+  streak: number;
+}
+
+export function NextDailyHeader({ streak }: NextDailyHeaderProps) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      <Countdown />
+      <span aria-hidden className="text-[color:var(--ink-faint)] text-[10px]">
+        ·
+      </span>
+      <StreakBadge streak={streak} />
+    </div>
+  );
+}
+
+function Countdown() {
+  const [msLeft, setMsLeft] = useState(msUntilNextDailyPST);
+  useEffect(() => {
+    const id = setInterval(() => setMsLeft(msUntilNextDailyPST()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div
+      className="flex items-center gap-[5px] text-[11px] text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-ui)]"
+      style={{ fontWeight: 500 }}
+    >
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className="opacity-80"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+      Next puzzle in {formatCountdown(msLeft)}
+    </div>
+  );
+}
+
+function msUntilNextDailyPST(): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Los_Angeles",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date());
+  const h = Number(parts.find((p) => p.type === "hour")!.value) % 24;
+  const m = Number(parts.find((p) => p.type === "minute")!.value);
+  const s = Number(parts.find((p) => p.type === "second")!.value);
+  return Math.max(0, (24 * 3600 - (h * 3600 + m * 60 + s)) * 1000);
+}
+
+function formatCountdown(ms: number): string {
+  const totalS = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalS / 3600);
+  const m = Math.floor((totalS % 3600) / 60);
+  const s = totalS % 60;
+  if (h > 0) return `${h}h ${String(m).padStart(2, "0")}m`;
+  return `${m}m ${String(s).padStart(2, "0")}s`;
+}

--- a/client/src/pages/landing/components/StreakBadge.tsx
+++ b/client/src/pages/landing/components/StreakBadge.tsx
@@ -1,0 +1,23 @@
+interface StreakBadgeProps {
+  streak: number;
+}
+
+export function StreakBadge({ streak }: StreakBadgeProps) {
+  const active = streak > 0;
+  return (
+    <span
+      className={
+        "inline-flex items-center gap-1 rounded-full px-2 py-[3px] leading-none " +
+        (active
+          ? "bg-[var(--streak-green)] text-white"
+          : "bg-[var(--ink-trace)] text-[color:var(--ink-soft)]")
+      }
+      style={{ fontWeight: 600 }}
+    >
+      <svg width="10" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+        <path d="M13.5 1.5c.4 4 3.6 4.7 4.5 8.5 1.2 5-2.4 9-6 10 3-3 .5-6-.5-7.5C9 16 7.5 17.5 7.5 20.5c0 .8.2 1.4.5 2-3-1-6-4-6-9 0-4 2.5-6 4-9 .9 2 2.5 3 4 3.5C12 6.5 13.5 5 13.5 1.5z" />
+      </svg>
+      <span className="text-caption tabular-nums">{streak}-day streak</span>
+    </span>
+  );
+}

--- a/client/src/pages/landing/components/ZenDailyCard.tsx
+++ b/client/src/pages/landing/components/ZenDailyCard.tsx
@@ -1,13 +1,9 @@
-import { useEffect, useState } from "react";
-import { InkButton } from "../../../shared/components/InkButton";
-import { StatusIcon } from "../../../shared/components/StatusIcon";
-import { RankBadge, type PodiumRank } from "./RankBadge";
-import { ZenModeBadge } from "../../dailyZen/components/ZenModeBadge";
+import { DailyRow, type DailyState } from "./DailyRow";
+import type { PodiumRank } from "./RankBadge";
 import type { DailyZenSession } from "../../../shared/api/gameApi";
 
 interface ZenDailyCardProps {
   session: DailyZenSession | null;
-  config: { boardSize: number; minWordLength: number };
   /** Player's rank on today's zen leaderboard. Only the top-3 are surfaced as a badge. */
   rank?: number | null;
   onPlay: () => void;
@@ -16,17 +12,8 @@ interface ZenDailyCardProps {
   onSeeLeaderboard: () => void;
 }
 
-type CardState = 'unplayed' | 'in-progress' | 'ended';
-
-function deriveState(session: DailyZenSession | null): CardState {
-  if (!session) return 'unplayed';
-  if (session.ended_at) return 'ended';
-  return 'in-progress';
-}
-
 export function ZenDailyCard({
   session,
-  config,
   rank,
   onPlay,
   onResume,
@@ -34,236 +21,49 @@ export function ZenDailyCard({
   onSeeLeaderboard,
 }: ZenDailyCardProps) {
   const state = deriveState(session);
+
   // Casual players opt out of the leaderboard for the day, so the rank
   // badge would be misleading — gate it on competitive mode. For
-  // competitive players the badge appears as soon as a session exists and
-  // tracks live as the session evolves (in-progress sessions are on the
-  // zen leaderboard too).
+  // competitive players the badge appears as soon as a session exists
+  // and tracks live as the session evolves (in-progress sessions are on
+  // the zen leaderboard too).
   const isCompetitive = session?.is_competitive ?? false;
-  const podiumRank: PodiumRank | null =
-    state !== 'unplayed' && isCompetitive && (rank === 1 || rank === 2 || rank === 3)
+  const podium: PodiumRank | null =
+    state !== "unplayed" && isCompetitive && (rank === 1 || rank === 2 || rank === 3)
       ? rank
       : null;
 
   return (
-    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] flex flex-col overflow-hidden">
-      <div className="flex justify-between items-center px-5 pt-[18px]">
-        <div className="flex items-center gap-1.5">
-          <StatusIcon state={state === 'ended' ? 'completed' : state} />
-          <span
-            className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] leading-none font-[family-name:var(--font-structure)]"
-            style={{ fontWeight: 700 }}
-          >
-            Zen Daily
-          </span>
-          {podiumRank && <RankBadge rank={podiumRank} />}
-        </div>
-        {session && <ZenModeBadge isCompetitive={session.is_competitive} />}
-      </div>
-
-      <div className="px-5 py-3 flex flex-col gap-[10px]">
-        {state === 'ended' && session && (
-          <>
-            <ScoreBlock
-              words={session.word_count}
-              totalWords={session.total_findable}
-              points={session.points}
-              longestWord={session.longest_word}
-            />
-            <div className="grid grid-cols-2 gap-2">
-              <SecondaryButton onClick={onSeeResult}>See result</SecondaryButton>
-              <SecondaryButton onClick={onSeeLeaderboard}>Leaderboard</SecondaryButton>
-            </div>
-            <NextDailyCountdown />
-          </>
-        )}
-
-        {state === 'in-progress' && session && (
-          <>
-            <ScoreBlock
-              words={session.word_count}
-              points={session.points}
-              longestWord={session.longest_word}
-            />
-            <PrimaryButton onClick={onResume} label="Resume" />
-            <LeaderboardLink onClick={onSeeLeaderboard} />
-          </>
-        )}
-
-        {state === 'unplayed' && (
-          <>
-            <PrimaryButton onClick={onPlay} label="Play zen" />
-            <LeaderboardLink onClick={onSeeLeaderboard} />
-          </>
-        )}
-      </div>
-    </div>
+    <DailyRow
+      mode="zen"
+      label="Zen Daily"
+      state={state}
+      podium={podium}
+      results={
+        session
+          ? {
+              points: session.points,
+              words: session.word_count,
+              totalWords:
+                state === "completed" ? session.total_findable : undefined,
+            }
+          : null
+      }
+      unplayedHint="No timer · find them all"
+      onPrimary={
+        state === "completed"
+          ? onSeeResult
+          : state === "in-progress"
+            ? onResume
+            : onPlay
+      }
+      onLeaderboard={onSeeLeaderboard}
+    />
   );
 }
 
-function ScoreBlock({
-  words,
-  totalWords,
-  points,
-  longestWord,
-}: {
-  words: number;
-  totalWords?: number;
-  points: number;
-  longestWord?: string;
-}) {
-  return (
-    <div className="flex items-end justify-between py-0.5" style={{ animation: "v2-fade-in-up 0.5s cubic-bezier(0.22, 1, 0.36, 1)" }}>
-      <div className="flex items-baseline gap-[5px]">
-        <span
-          className="text-display-lg leading-none font-[family-name:var(--font-structure)] tracking-[-0.03em] tabular-nums"
-          style={{ fontWeight: 800 }}
-        >
-          {points}
-        </span>
-        <span className="text-small text-[color:var(--ink-muted)]" style={{ fontWeight: 600 }}>
-          {points === 1 ? "pt" : "pts"}
-        </span>
-      </div>
-      <div className="flex flex-col items-end gap-0.5 leading-tight min-w-0">
-        <span
-          className="text-small text-[color:var(--ink-muted)] tabular-nums"
-          style={{ fontWeight: 500 }}
-        >
-          {words}
-          {totalWords !== undefined && `/${totalWords}`} {words === 1 ? "word" : "words"}
-        </span>
-        {longestWord && (
-          <span
-            className="text-small uppercase tracking-[0.04em] text-[color:var(--ink)] truncate max-w-[140px] font-[family-name:var(--font-structure)]"
-            style={{ fontWeight: 700 }}
-            title={longestWord}
-          >
-            {longestWord}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function NextDailyCountdown() {
-  const [msLeft, setMsLeft] = useState(msUntilNextDailyPST);
-  useEffect(() => {
-    const id = setInterval(() => setMsLeft(msUntilNextDailyPST()), 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  return (
-    <div
-      className="flex items-center justify-center gap-[5px] text-[11px] text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-ui)] -mt-0.5"
-      style={{ fontWeight: 500 }}
-    >
-      <svg
-        width="11"
-        height="11"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden
-        className="opacity-80"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <polyline points="12 6 12 12 16 14" />
-      </svg>
-      Next daily in {formatCountdown(msLeft)}
-    </div>
-  );
-}
-
-function msUntilNextDailyPST(): number {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Los_Angeles',
-    hour: 'numeric',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).formatToParts(new Date());
-  const h = Number(parts.find((p) => p.type === 'hour')!.value) % 24;
-  const m = Number(parts.find((p) => p.type === 'minute')!.value);
-  const s = Number(parts.find((p) => p.type === 'second')!.value);
-  return Math.max(0, (24 * 3600 - (h * 3600 + m * 60 + s)) * 1000);
-}
-
-function formatCountdown(ms: number): string {
-  const totalS = Math.max(0, Math.floor(ms / 1000));
-  const h = Math.floor(totalS / 3600);
-  const m = Math.floor((totalS % 3600) / 60);
-  const s = totalS % 60;
-  if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m`;
-  return `${m}m ${String(s).padStart(2, '0')}s`;
-}
-
-function PrimaryButton({ onClick, label }: { onClick: () => void; label: string }) {
-  return (
-    <InkButton onClick={onClick}>
-      {label}
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="transition-transform duration-200 group-hover:translate-x-[3px]"
-      >
-        <path d="M5 12h14M13 5l7 7-7 7" />
-      </svg>
-    </InkButton>
-  );
-}
-
-function SecondaryButton({
-  children,
-  onClick,
-}: {
-  children: React.ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex items-center justify-center gap-2 rounded-xl py-3 px-3 text-small text-[color:var(--ink)] bg-transparent border border-[var(--ink-border)] cursor-pointer select-none hover:bg-[var(--ink-whisper)] hover:border-[var(--ink-muted)] active:scale-[0.98] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] font-[family-name:var(--font-ui)]"
-      style={{ fontWeight: 600, WebkitTapHighlightColor: "transparent" }}
-    >
-      {children}
-    </button>
-  );
-}
-
-function LeaderboardLink({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group flex items-center justify-center gap-1.5 text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] bg-transparent border-none cursor-pointer font-[family-name:var(--font-ui)] transition-colors duration-200"
-      style={{ fontWeight: 500 }}
-    >
-      See today's leaderboard
-      <svg
-        width="11"
-        height="11"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="transition-transform duration-200 group-hover:translate-x-[2px]"
-      >
-        <path d="M9 18l6-6-6-6" />
-      </svg>
-    </button>
-  );
+function deriveState(session: DailyZenSession | null): DailyState {
+  if (!session) return "unplayed";
+  if (session.ended_at) return "completed";
+  return "in-progress";
 }

--- a/client/src/pages/landing/components/index.ts
+++ b/client/src/pages/landing/components/index.ts
@@ -3,5 +3,6 @@ export { ChangelogControl } from "./ChangelogControl";
 export { DailyCard } from "./DailyCard";
 export { ZenDailyCard } from "./ZenDailyCard";
 export { FreePlayCard } from "./FreePlayCard";
+export { NextDailyHeader } from "./NextDailyHeader";
 export { ProfileAvatar } from "./ProfileAvatar";
 export { ThemeTogglePill } from "./ThemeTogglePill";

--- a/client/src/stories/Cards.stories.tsx
+++ b/client/src/stories/Cards.stories.tsx
@@ -39,7 +39,6 @@ function DailyStory({ completed }: { completed: boolean }) {
     <div className="flex gap-8">
       <PaperFrame theme="light">
         <DailyCard
-          streak={9}
           config={{ boardSize: 5, timeLimit: 120, minWordLength: 3 }}
           results={completed ? dailyResults : null}
           onPlay={fn()}
@@ -51,7 +50,6 @@ function DailyStory({ completed }: { completed: boolean }) {
       </PaperFrame>
       <PaperFrame theme="dark">
         <DailyCard
-          streak={9}
           config={{ boardSize: 5, timeLimit: 120, minWordLength: 3 }}
           results={completed ? dailyResults : null}
           onPlay={fn()}

--- a/client/src/stories/ProfileCard.stories.tsx
+++ b/client/src/stories/ProfileCard.stories.tsx
@@ -51,7 +51,6 @@ function InContextWrapper({ completed }: { completed: boolean }) {
         dateLabel="Tue · Apr 21"
         streak={9}
         dailyConfig={{ boardSize: 5, timeLimit: 120, minWordLength: 3 }}
-        zenConfig={{ boardSize: 5, minWordLength: 3 }}
         dailyResults={results}
         dailyRank={null}
         zenSession={null}


### PR DESCRIPTION
## What

Reworks the landing page so a third or fourth daily mode can be added without forcing the page to scroll. Each daily becomes a compact split row: left half is the primary tap (Play / Resume / See result), right half is the per-mode leaderboard, with a short inset divider between them.

- New shared primitive `DailyRow` powers both Timed and Zen cards.
- Per-mode `ModeAvatar` (tinted gold / green glyphs from the existing palette) gives each row a distinct identity at a glance.
- Streak chip moves to a shared `NextDailyHeader` alongside the next-puzzle countdown — it's a player stat, not a per-mode stat — and now reads "9-day streak" with a flame icon instead of an ambiguous star + number.
- Free Play is demoted to a flat `ink-whisper` row with a sliders glyph below a thin rule, so it reads as a customisation tool rather than another daily.

## Why

The previous stack of full-size cards already filled the viewport at three items (Timed, Zen, Free Play). Adding a fourth daily mode would require scrolling, and the cards' shared shape made them hard to tell apart at a glance. The compact split-row pattern reclaims the vertical space, gives each daily its own visual identity, and keeps both the primary action and the per-mode leaderboard one tap away.

## Follow-ups

- The `__mockups__` directory of variant explorations was deleted with this PR; if we want to revisit a different direction (carousel, grid, etc.), recover from this branch's history.
- When the third daily mode lands, extend `DailyMode` with the new key, add an entry to `MODE_TINT` in `ModeAvatar.tsx`, and drop another `DailyRow` into `LandingPage`.
- No changelog entry added — let me know if this should ship with one.

## Test plan

- [ ] Visit `/` on dev — verify Timed + Zen rows, Free Play flat row, header countdown + streak chip render.
- [ ] `?mock=unplayed` — both rows show their unplayed hints.
- [ ] `?mock=zen-progress` — Zen row shows live score line + half-circle in-progress icon.
- [ ] `?mock=zen-ended` — both completed; scores render inline; checkmarks visible.
- [ ] Tap each daily's left side → primary action; tap trophy → leaderboard.
- [ ] Light + dark themes look correct.
- [ ] Storybook `Components/DailyCard` and `Components/Profile/InContext` stories still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)