### PR TITLE
feat(daily): show find percentage per word in All words view

### DIFF
--- a/client/src/pages/dailyZen/ZenResultsRoute.tsx
+++ b/client/src/pages/dailyZen/ZenResultsRoute.tsx
@@ -226,6 +226,8 @@ export function ZenResultsRoute() {
             showMissedTab={result.missed_words.length > 0}
             highlightedWord={highlightedWord}
             onHighlightWord={handleHighlight}
+            findPercents={result.find_percents}
+            popularityStyle={result.find_percents ? 'inline' : undefined}
           />
         </div>
 

--- a/client/src/pages/results/DailyResultsRoute.tsx
+++ b/client/src/pages/results/DailyResultsRoute.tsx
@@ -234,6 +234,8 @@ export function DailyResultsRoute() {
       onClose={handleClose}
       onPlayAgain={handlePlayAgain}
       daily={daily}
+      findPercents={serverResult?.find_percents}
+      popularityStyle={serverResult?.find_percents ? 'inline' : undefined}
     />
   );
 }

--- a/client/src/pages/results/ResultsPage.tsx
+++ b/client/src/pages/results/ResultsPage.tsx
@@ -39,6 +39,10 @@ interface ResultsPageProps {
   /** Present only on daily results; swaps the Play again button for the
    *  leaderboard teaser and the center label for the date chip. */
   daily?: DailyResultsExtras;
+  /** Per-word popularity (% of daily players who found the word). Threaded
+   *  into WordsCard for the popularity affordance. */
+  findPercents?: Record<string, number>;
+  popularityStyle?: 'inline';
 }
 
 export function ResultsPage({
@@ -48,6 +52,8 @@ export function ResultsPage({
   onClose,
   onPlayAgain,
   daily,
+  findPercents,
+  popularityStyle,
 }: ResultsPageProps) {
   const [highlightedWord, setHighlightedWord] = useState<string | null>(null);
   const [highlightPath, setHighlightPath] = useState<Position[] | null>(null);
@@ -126,6 +132,8 @@ export function ResultsPage({
             showMissedTab={results.missedWords.length > 0}
             highlightedWord={highlightedWord}
             onHighlightWord={handleHighlight}
+            findPercents={findPercents}
+            popularityStyle={popularityStyle}
           />
         </div>
 

--- a/client/src/pages/results/ResultsRoute.tsx
+++ b/client/src/pages/results/ResultsRoute.tsx
@@ -63,6 +63,8 @@ export function ResultsRoute() {
       onClose={handleClose}
       onPlayAgain={handlePlayAgain}
       daily={mockFixture?.daily}
+      findPercents={mockFixture?.findPercents}
+      popularityStyle={mockFixture?.popularityStyle}
     />
   );
 }

--- a/client/src/pages/results/__fixtures__/daily.ts
+++ b/client/src/pages/results/__fixtures__/daily.ts
@@ -35,7 +35,22 @@ export const dailyDefaultFixture: GameResults = {
     { word: 'ATE', score: 1, path: [] },
     { word: 'TAN', score: 1, path: [] },
   ],
-  missedWords: [],
+  missedWords: [
+    { word: 'CAPTAINS', score: 13, path: [] },
+    { word: 'PARTITION', score: 13, path: [] },
+    { word: 'ATTAIN', score: 5, path: [] },
+    { word: 'CARTON', score: 5, path: [] },
+    { word: 'ACTION', score: 5, path: [] },
+    { word: 'NATION', score: 5, path: [] },
+    { word: 'PLAIT', score: 3, path: [] },
+    { word: 'CAIRN', score: 3, path: [] },
+    { word: 'CLAIM', score: 3, path: [] },
+    { word: 'PITA', score: 2, path: [] },
+    { word: 'ICAP', score: 2, path: [] },
+    { word: 'ANT', score: 1, path: [] },
+    { word: 'NIP', score: 1, path: [] },
+    { word: 'OAR', score: 1, path: [] },
+  ],
 };
 
 export const dailyDefaultGame: Game = {
@@ -129,6 +144,41 @@ const pickerEntries: DailyEntry[] = [
     config: stubConfig,
   },
 ];
+
+// Stand-in popularity numbers — calibrated so the spread is plausible:
+// short common words near 90%+, mid-tier in the 30–60% range, the long
+// rare finds in the single digits or below 1%.
+export const dailyFindPercents: Record<string, number> = {
+  CAPTIONS: 0.4,
+  CAPTION: 4,
+  PATRON: 11,
+  TRAINS: 38,
+  STRAIN: 22,
+  TRAIN: 71,
+  STARE: 64,
+  PAINT: 58,
+  IRATE: 9,
+  TACIT: 2,
+  TRIO: 81,
+  RATE: 92,
+  ATE: 97,
+  TAN: 89,
+  // missed
+  CAPTAINS: 0.2,
+  PARTITION: 1,
+  ATTAIN: 14,
+  CARTON: 27,
+  ACTION: 49,
+  NATION: 36,
+  PLAIT: 6,
+  CAIRN: 3,
+  CLAIM: 31,
+  PITA: 44,
+  ICAP: 0.4,
+  ANT: 78,
+  NIP: 52,
+  OAR: 41,
+};
 
 export const dailyDefaultExtras: DailyResultsExtras = {
   dateLabel: 'Timed Daily · Tue, Apr 21',

--- a/client/src/pages/results/__fixtures__/index.ts
+++ b/client/src/pages/results/__fixtures__/index.ts
@@ -2,7 +2,12 @@ import type { Game } from 'models';
 import type { GameResults } from '../../../shared/types';
 import type { DailyResultsExtras } from '../ResultsPage';
 import { defaultFixture, defaultGame } from './default';
-import { dailyDefaultFixture, dailyDefaultGame, dailyDefaultExtras } from './daily';
+import {
+  dailyDefaultFixture,
+  dailyDefaultGame,
+  dailyDefaultExtras,
+  dailyFindPercents,
+} from './daily';
 
 export interface ResultsFixture {
   results: GameResults;
@@ -10,6 +15,8 @@ export interface ResultsFixture {
   /** When present, ResultsRoute renders the page in daily mode
    *  (date chip + leaderboard teaser). */
   daily?: DailyResultsExtras;
+  findPercents?: Record<string, number>;
+  popularityStyle?: 'inline';
 }
 
 const FIXTURES: Record<string, ResultsFixture> = {
@@ -18,6 +25,13 @@ const FIXTURES: Record<string, ResultsFixture> = {
     results: dailyDefaultFixture,
     game: dailyDefaultGame,
     daily: dailyDefaultExtras,
+  },
+  'daily-popularity': {
+    results: dailyDefaultFixture,
+    game: dailyDefaultGame,
+    daily: dailyDefaultExtras,
+    findPercents: dailyFindPercents,
+    popularityStyle: 'inline',
   },
 };
 

--- a/client/src/pages/results/components/WordsCard.tsx
+++ b/client/src/pages/results/components/WordsCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Position } from 'models';
 import type { ScoredWord } from '../../../shared/types';
 import { RARITY_VAR, wordRarity } from '../utils/wordRarity';
+import { formatPercent } from '../utils/formatPercent';
 
 interface WordsCardProps {
   foundWords: ScoredWord[];
@@ -12,6 +13,13 @@ interface WordsCardProps {
   showMissedTab?: boolean;
   highlightedWord?: string | null;
   onHighlightWord?: (word: string | null, path: Position[] | null) => void;
+  /** Per-word percentage of daily players who found it (0-100, uppercased
+   *  word as key). Rendered as an inline % in the All-words view when
+   *  popularityStyle is set. */
+  findPercents?: Record<string, number>;
+  /** Opt-in for the inline popularity column. Only takes effect in the
+   *  All-words view; the Found view stays uncluttered. */
+  popularityStyle?: 'inline';
 }
 
 type Mode = 'found' | 'missed';
@@ -22,6 +30,8 @@ export function WordsCard({
   showMissedTab = true,
   highlightedWord,
   onHighlightWord,
+  findPercents,
+  popularityStyle,
 }: WordsCardProps) {
   const [mode, setMode] = useState<Mode>('found');
   const listRef = useRef<HTMLDivElement>(null);
@@ -108,6 +118,8 @@ export function WordsCard({
             found={w.found}
             highlighted={highlightedWord === w.word}
             onTap={() => tapWord(w.word, w.path)}
+            findPercent={findPercents?.[w.word]}
+            popularityStyle={mode === 'missed' ? popularityStyle : undefined}
           />
         ))}
       </div>
@@ -159,6 +171,8 @@ function WordRow({
   found,
   highlighted,
   onTap,
+  findPercent,
+  popularityStyle,
 }: {
   word: string;
   score: number;
@@ -166,8 +180,11 @@ function WordRow({
   found: boolean;
   highlighted: boolean;
   onTap: () => void;
+  findPercent?: number;
+  popularityStyle?: 'inline';
 }) {
   const rarity = wordRarity(score);
+  const showInline = popularityStyle === 'inline' && findPercent !== undefined;
   return (
     <div
       onClick={onTap}
@@ -185,14 +202,24 @@ function WordRow({
         style={{ background: RARITY_VAR[rarity], opacity: found ? 1 : 0.45 }}
       />
       <span className="tabular-nums">{word}</span>
-      <span
-        className={[
-          'text-[11px] tabular-nums font-[family-name:var(--font-structure)]',
-          found ? 'text-[color:var(--ink-soft)]' : 'text-[color:var(--ink-faint)]',
-        ].join(' ')}
-        style={{ fontWeight: 700 }}
-      >
-        +{score}
+      <span className="flex items-baseline gap-1.5">
+        {showInline && (
+          <span
+            className="text-[10px] tabular-nums text-[color:var(--ink-faint)] font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 600 }}
+          >
+            {formatPercent(findPercent!)}
+          </span>
+        )}
+        <span
+          className={[
+            'text-[11px] tabular-nums font-[family-name:var(--font-structure)]',
+            found ? 'text-[color:var(--ink-soft)]' : 'text-[color:var(--ink-faint)]',
+          ].join(' ')}
+          style={{ fontWeight: 700 }}
+        >
+          +{score}
+        </span>
       </span>
     </div>
   );

--- a/client/src/pages/results/utils/formatPercent.test.ts
+++ b/client/src/pages/results/utils/formatPercent.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { formatPercent } from './formatPercent';
+
+describe('formatPercent', () => {
+  it('shows <1% for sub-1 values so rare finds never read as zero', () => {
+    expect(formatPercent(0)).toBe('<1%');
+    expect(formatPercent(0.4)).toBe('<1%');
+    expect(formatPercent(0.999)).toBe('<1%');
+  });
+
+  it('shows 100% for ≥99.5 so universal finds never read as 99%', () => {
+    expect(formatPercent(99.5)).toBe('100%');
+    expect(formatPercent(99.9)).toBe('100%');
+    expect(formatPercent(100)).toBe('100%');
+  });
+
+  it('rounds to the nearest integer in the middle band', () => {
+    expect(formatPercent(1)).toBe('1%');
+    expect(formatPercent(11.4)).toBe('11%');
+    expect(formatPercent(11.5)).toBe('12%');
+    expect(formatPercent(50)).toBe('50%');
+    expect(formatPercent(99.4)).toBe('99%');
+  });
+});

--- a/client/src/pages/results/utils/formatPercent.ts
+++ b/client/src/pages/results/utils/formatPercent.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats a 0–100 percentage for the All-words popularity column.
+ *
+ * Boundary handling matters here:
+ *   - Sub-1% finds get `<1%` instead of `0%` so a rare-but-real find
+ *     never reads as "nobody got this".
+ *   - Anything ≥99.5 rounds to `100%` so the column never shows a
+ *     misleading `99%` for a word every player got.
+ *   - Everything in between rounds to the nearest integer.
+ */
+export function formatPercent(pct: number): string {
+  if (pct < 1) return '<1%';
+  if (pct >= 99.5) return '100%';
+  return `${Math.round(pct)}%`;
+}

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -244,6 +244,9 @@ export interface DailyResultResponse {
    *  but always present from the current endpoint. */
   missed_words?: DailyResultMissedWord[];
   config: DailyConfig;
+  /** Per-word percentage of today's daily players who found this word
+   *  (uppercase keys, 0–100). Drives the All-words popularity column. */
+  find_percents?: Record<string, number>;
 }
 
 export const fetchDailyResult = async (date: string): Promise<DailyResultResponse | null> => {
@@ -463,6 +466,9 @@ export interface DailyZenResultResponse {
   /** Sum of every findable word's score on this board, locked at session
    *  start. Null on legacy rows that predate the column. */
   theoretical_max_score: number | null;
+  /** Per-word percentage of finalized zen players who found this word
+   *  (uppercase keys, 0–100). Drives the All-words popularity column. */
+  find_percents?: Record<string, number>;
 }
 
 export const fetchDailyZenResult = async (

--- a/client/src/shared/changelog/entries/2026-05-07-word-popularity.tsx
+++ b/client/src/shared/changelog/entries/2026-05-07-word-popularity.tsx
@@ -1,0 +1,22 @@
+import type { ChangelogEntry } from '../types';
+
+const entry: ChangelogEntry = {
+  id: 'word-popularity-2026-05-07',
+  date: '2026-05-07',
+  kind: 'minor',
+  title: 'See how rare your finds were',
+  body: (
+    <>
+      <p>
+        Switch to <strong>All words</strong> on a daily results page to see
+        what percentage of today's players found each word — both the ones
+        you got and the ones you missed.
+      </p>
+      <p>
+        Works on timed and zen dailies. The Found view stays uncluttered.
+      </p>
+    </>
+  ),
+};
+
+export default entry;

--- a/server/routes/daily.ts
+++ b/server/routes/daily.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/index.js';
 import { cachePrivate, cachePublic, noStore } from '../httpCache.js';
 import { dictionary } from '../services/dictionary.js';
 import { scoreResult, scoreWords, getDailyStats } from '../services/DailyService.js';
+import { getTimedDailyWordPercents } from '../services/dailyWordStats.js';
 import { getDisplayNames } from '../services/displayNames.js';
 import {
   DAILY_LAUNCH_DATE,
@@ -145,6 +146,12 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
       .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }))
       .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
 
+    const findPercents = await getTimedDailyWordPercents(
+      db,
+      result.date,
+      getDailyDatePST(),
+    );
+
     cachePrivate(res, 60);
     res.json({
       result: {
@@ -154,6 +161,7 @@ dailyRouter.get('/results/:date', requireAuth, async (req, res) => {
         missed_words: missedWords,
         completed_at: result.completed_at,
         config,
+        find_percents: findPercents,
       },
     });
   } catch (err) {

--- a/server/routes/dailyZen.ts
+++ b/server/routes/dailyZen.ts
@@ -23,6 +23,7 @@ import {
   getDailyZenNumber,
 } from '../services/dailyZenConfig.js';
 import { getDailyDatePST } from '../services/dailyConfig.js';
+import { getZenDailyWordPercents } from '../services/dailyWordStats.js';
 
 export const dailyZenRouter = Router();
 
@@ -185,6 +186,12 @@ dailyZenRouter.get('/results/:date', requireAuth, async (req, res) => {
       .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }))
       .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
 
+    const findPercents = await getZenDailyWordPercents(
+      getDb(),
+      session.date,
+      getDailyDatePST(),
+    );
+
     cachePrivate(res, 60);
     res.json({
       result: {
@@ -196,6 +203,7 @@ dailyZenRouter.get('/results/:date', requireAuth, async (req, res) => {
         ended_by_player: session.ended_by_player,
         is_competitive: session.is_competitive,
         theoretical_max_score: session.theoretical_max_score,
+        find_percents: findPercents,
       },
     });
   } catch (err) {

--- a/server/services/dailyWordStats.test.ts
+++ b/server/services/dailyWordStats.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  TODAY_TTL_MS,
+  getCachedWordPercents,
+  type CacheRef,
+} from './dailyWordStats.js';
+
+const TODAY = '2026-05-07';
+const YESTERDAY = '2026-05-06';
+const PERCENTS = { CAPTION: 4, RATE: 92 };
+
+function mkRef(): CacheRef {
+  return { value: null };
+}
+
+describe('getCachedWordPercents', () => {
+  it('caches today\'s result so a second call within TTL skips recompute', async () => {
+    const ref = mkRef();
+    const aggregate = vi.fn().mockResolvedValue(PERCENTS);
+    const first = await getCachedWordPercents(ref, aggregate, TODAY, TODAY, 1_000);
+    const second = await getCachedWordPercents(ref, aggregate, TODAY, TODAY, 1_001);
+    expect(first).toEqual(PERCENTS);
+    expect(second).toEqual(PERCENTS);
+    expect(aggregate).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes after the TTL window expires', async () => {
+    const ref = mkRef();
+    const aggregate = vi.fn().mockResolvedValue(PERCENTS);
+    await getCachedWordPercents(ref, aggregate, TODAY, TODAY, 1_000);
+    await getCachedWordPercents(ref, aggregate, TODAY, TODAY, 1_000 + TODAY_TTL_MS + 1);
+    expect(aggregate).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache historic dates so the slot stays free for today', async () => {
+    const ref = mkRef();
+    const aggregate = vi.fn().mockResolvedValue(PERCENTS);
+    await getCachedWordPercents(ref, aggregate, YESTERDAY, TODAY, 1_000);
+    await getCachedWordPercents(ref, aggregate, YESTERDAY, TODAY, 1_001);
+    expect(ref.value).toBeNull();
+    expect(aggregate).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not serve a stale today entry from a previous day', async () => {
+    const ref = mkRef();
+    const stale = vi.fn().mockResolvedValue({ STALE: 99 });
+    const fresh = vi.fn().mockResolvedValue(PERCENTS);
+    // Yesterday's run cached its result while the date was still "today".
+    await getCachedWordPercents(ref, stale, YESTERDAY, YESTERDAY, 1_000);
+    expect(ref.value?.date).toBe(YESTERDAY);
+    // The clock rolled over; the same ref must not return yesterday's
+    // cache when the caller asks for today's date.
+    const result = await getCachedWordPercents(ref, fresh, TODAY, TODAY, 2_000);
+    expect(result).toEqual(PERCENTS);
+    expect(fresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/dailyWordStats.ts
+++ b/server/services/dailyWordStats.ts
@@ -1,0 +1,122 @@
+import { sql, type Kysely } from 'kysely';
+import type { Database } from '../db/types.js';
+
+export type WordPercents = Record<string, number>;
+
+export interface CacheEntry {
+  date: string;
+  percents: WordPercents;
+  expiresAt: number;
+}
+
+export interface CacheRef {
+  value: CacheEntry | null;
+}
+
+export const TODAY_TTL_MS = 60_000;
+
+interface AggregateRow {
+  word: string;
+  finders: number | string;
+}
+
+async function aggregateTimed(db: Kysely<Database>, date: string): Promise<WordPercents> {
+  // Single pass: total players for the date plus per-word find counts.
+  // jsonb_array_elements_text unnests the found_words array; the upper()
+  // normalization protects against any historical lower-cased entries.
+  const totalsQuery = sql<{ total: number | string }>`
+    select count(*)::int as total from daily_results where date = ${date}
+  `;
+  const findsQuery = sql<AggregateRow>`
+    select upper(w::text) as word, count(distinct r.user_id)::int as finders
+    from daily_results r,
+         lateral jsonb_array_elements_text(r.found_words) as w
+    where r.date = ${date}
+    group by upper(w::text)
+  `;
+  const [totalsResult, findsResult] = await Promise.all([
+    totalsQuery.execute(db),
+    findsQuery.execute(db),
+  ]);
+  const total = Number(totalsResult.rows[0]?.total ?? 0);
+  if (total === 0) return {};
+  const out: WordPercents = {};
+  for (const row of findsResult.rows) {
+    out[row.word] = (Number(row.finders) / total) * 100;
+  }
+  return out;
+}
+
+async function aggregateZen(db: Kysely<Database>, date: string): Promise<WordPercents> {
+  // Only finalized zen sessions count toward popularity. In-progress
+  // players would otherwise drag every word's percentage downward — the
+  // denominator must match "people who had a fair shot at finding it".
+  const totalsQuery = sql<{ total: number | string }>`
+    select count(*)::int as total
+    from daily_zen_results
+    where date = ${date} and ended_at is not null
+  `;
+  const findsQuery = sql<AggregateRow>`
+    select upper(w::text) as word, count(distinct r.user_id)::int as finders
+    from daily_zen_results r,
+         lateral jsonb_array_elements_text(r.found_words) as w
+    where r.date = ${date} and r.ended_at is not null
+    group by upper(w::text)
+  `;
+  const [totalsResult, findsResult] = await Promise.all([
+    totalsQuery.execute(db),
+    findsQuery.execute(db),
+  ]);
+  const total = Number(totalsResult.rows[0]?.total ?? 0);
+  if (total === 0) return {};
+  const out: WordPercents = {};
+  for (const row of findsResult.rows) {
+    out[row.word] = (Number(row.finders) / total) * 100;
+  }
+  return out;
+}
+
+/** Read-through cache that only memoizes today's date. Historic dates
+ *  always recompute (their popularity is final, but we accept the small
+ *  per-request cost rather than retaining unbounded state). The cache ref
+ *  is mutated in place so each pair of (cacheRef, aggregate) shares one
+ *  slot regardless of how many concurrent callers there are.
+ *
+ *  Exported so the cache decision can be unit tested without a database
+ *  connection. */
+export async function getCachedWordPercents(
+  cacheRef: CacheRef,
+  aggregate: (date: string) => Promise<WordPercents>,
+  date: string,
+  today: string,
+  now: number = Date.now(),
+): Promise<WordPercents> {
+  const cached = cacheRef.value;
+  if (date === today && cached?.date === today && cached.expiresAt > now) {
+    return cached.percents;
+  }
+  const percents = await aggregate(date);
+  if (date === today) {
+    cacheRef.value = { date, percents, expiresAt: now + TODAY_TTL_MS };
+  }
+  return percents;
+}
+
+const timedCacheRef: CacheRef = { value: null };
+const zenCacheRef: CacheRef = { value: null };
+
+export function getTimedDailyWordPercents(
+  db: Kysely<Database>,
+  date: string,
+  today: string,
+): Promise<WordPercents> {
+  return getCachedWordPercents(timedCacheRef, (d) => aggregateTimed(db, d), date, today);
+}
+
+export function getZenDailyWordPercents(
+  db: Kysely<Database>,
+  date: string,
+  today: string,
+): Promise<WordPercents> {
+  return getCachedWordPercents(zenCacheRef, (d) => aggregateZen(db, d), date, today);
+}


### PR DESCRIPTION
## What
Daily results pages (timed + zen) now display the % of today's players who found each word, inline next to the score in the **All words** view. The Found view stays uncluttered.

![All words view with popularity percentages on iPhone SE](https://github.com/user-attachments/assets/placeholder)

## Why
- **Communicates rarity beyond the score-tier rarity stripe.** A player can see whether their finds were common or genuine bragging rights, and whether their misses were obvious to everyone or also rare.
- **Inline column over a background fill bar.** Explored both during design; inline reads precisely (`71%` vs `64%`), while a fill bar conveyed gestalt but lost short-percentage detail.
- **Cache scoped to today's date with a 60s TTL.** Avoids the hot-path cost on every results-page load while keeping the consistency story simple. Historic dates compute on demand — they load less often and the percentages are already final. Per-instance cache is safe since 60s of staleness across Fly instances is acceptable; no cross-instance coordination needed.
- **Zen aggregation only counts finalized sessions** (`ended_at IS NOT NULL`) so in-progress players don't drag every word's percentage downward.

## How
- New service `server/services/dailyWordStats.ts` does the aggregation via `jsonb_array_elements_text` over `found_words` (one query for totals, one for per-word find counts). Cache logic extracted into a testable `getCachedWordPercents` helper.
- Both `GET /api/daily/results/:date` and `GET /api/daily/zen/results/:date` now include `find_percents: Record<string, number>` in their response.
- `WordsCard` renders the inline `%` only when `mode === 'missed'` (the All words tab) so the default Found view stays clean. Format: `<1%` for sub-1, `100%` for ≥99.5, rounded otherwise.
- Dev preview behind `?mock=daily-popularity` on the `/results` route.

## Tests
- `formatPercent.test.ts` — boundary handling (`<1%` floor, `100%` ceiling so a universal find never reads as `99%`, rounding in the middle).
- `dailyWordStats.test.ts` — cache TTL: caches today within window, recomputes after expiry, never caches historic dates, rejects a stale today entry whose date no longer matches "today".
- Skipped: SQL aggregation (no test-DB infra in this repo) and `WordsCard` render (no React testing library set up).

## Follow-ups
- No header label hinting at the popularity column yet (`ALL WORDS · % FOUND`); keeps the header lean for now. Easy to add if discoverability proves an issue.
- If daily volume grows past where on-demand aggregation feels expensive, the next step is a denormalized `daily_word_counts` table updated at submission time.

## Test plan
- [ ] Play a daily (timed and zen), open results, switch to All words, confirm percentages appear and look reasonable
- [ ] Open a historic daily's results, confirm percentages still load
- [ ] Verify Found view shows no percentages
- [ ] Sanity-check `<1%` and `100%` formatting against actual data
- [ ] iPhone SE viewport: confirm no horizontal/vertical scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)