### PR TITLE
fix(freshness): reload stale clients on tab focus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,12 @@ COPY tsconfig.json .
 # Build the client (VITE_ env vars are available via ARG → ENV)
 ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
 ENV VITE_SUPABASE_PUBLISHABLE_KEY=$VITE_SUPABASE_PUBLISHABLE_KEY
-RUN npm run build --workspace=client
+
+# Stamp a build ID so the running client can detect when a newer image has
+# shipped and force a reload on tab focus. Written to /app/BUILD_ID, which the
+# server reads at startup.
+RUN date -u +%Y%m%d%H%M%S > /app/BUILD_ID && \
+    npm run build --workspace=client
 
 # Expose the port
 EXPOSE 3000

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -253,6 +253,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     if (!authReady || !cachedDaily) return;
     let cancelled = false;
     setDailyResultLoaded(false);
+    setCachedDailyResult(null);
 
     (async () => {
       try {

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useState, useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import type { Position, Game, Word } from 'models';
+import { GameState } from 'models';
 import type { Session } from '@supabase/supabase-js';
 import { supabase } from './shared/supabase';
 import { useGameApi } from './hooks/useGameApi';
@@ -326,6 +327,62 @@ export function GameProvider({ children }: { children: ReactNode }) {
       cancelled = true;
     };
   }, [authReady, cachedDailyZen]);
+
+  // Mobile browsers freeze backgrounded tabs (bfcache) and resume them with
+  // their old in-memory state — yesterday's daily, an outdated JS bundle, etc.
+  // On tab focus or pageshow, refetch the public puzzles so the board matches
+  // today, and compare the server's build ID against the one we booted with so
+  // a stale bundle reloads instead of silently lingering.
+  const baselineBuildIdRef = useRef<string | null>(null);
+  const gameStatusRef = useRef<GameState | null>(null);
+  useEffect(() => {
+    gameStatusRef.current = game?.status ?? null;
+  }, [game]);
+
+  useEffect(() => {
+    fetch('/api/version')
+      .then((r) => r.json())
+      .then((d) => {
+        if (typeof d?.buildId === 'string') baselineBuildIdRef.current = d.buildId;
+      })
+      .catch(() => {});
+
+    const checkFreshness = () => {
+      if (document.hidden) return;
+
+      fetchDaily()
+        .then((info) => setCachedDaily(info))
+        .catch(() => {});
+      fetchDailyZenMeta()
+        .then((info) => setCachedDailyZen(info))
+        .catch(() => {});
+
+      if (gameStatusRef.current === GameState.InProgress) return;
+      fetch('/api/version')
+        .then((r) => r.json())
+        .then((d) => {
+          const next = typeof d?.buildId === 'string' ? d.buildId : null;
+          const baseline = baselineBuildIdRef.current;
+          if (baseline && next && next !== baseline) {
+            window.location.reload();
+          }
+        })
+        .catch(() => {});
+    };
+
+    const onVisibility = () => {
+      if (!document.hidden) checkFreshness();
+    };
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) checkFreshness();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pageshow', onPageShow);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pageshow', onPageShow);
+    };
+  }, []);
 
   // Record daily results when a daily game is completed in the current session.
   // Skips if the result for this date has already been cached (either from a prior

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import { userRouter } from './routes/user.js';
 import { dailyRouter } from './routes/daily.js';
 import { dailyZenRouter } from './routes/dailyZen.js';
 import { leaderboardRouter } from './routes/leaderboard.js';
+import { versionRouter } from './routes/version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,16 +25,32 @@ app.use('/api', authMiddleware);
 app.use('/api', sessionMiddleware);
 
 const clientDistPath = path.join(__dirname, '../client/dist');
-app.use(express.static(clientDistPath));
+const assetsSegment = `${path.sep}assets${path.sep}`;
+app.use(
+  express.static(clientDistPath, {
+    setHeaders: (res, filepath) => {
+      // Vite emits content-hashed filenames under /assets/, so they're safe to
+      // cache forever. Everything else (index.html, favicon, etc.) must
+      // revalidate or stale clients keep loading old bundle references.
+      if (filepath.includes(assetsSegment)) {
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+      } else {
+        res.setHeader('Cache-Control', 'no-cache');
+      }
+    },
+  }),
+);
 
 app.use('/api/game', gameRouter);
 app.use('/api/user', userRouter);
 app.use('/api/daily/leaderboard', leaderboardRouter);
 app.use('/api/daily/zen', dailyZenRouter);
 app.use('/api/daily', dailyRouter);
+app.use('/api/version', versionRouter);
 
 // SPA fallback for non-API routes
 app.get('*', (_req, res) => {
+  res.set('Cache-Control', 'no-cache');
   res.sendFile(path.join(clientDistPath, 'index.html'));
 });
 

--- a/server/routes/version.ts
+++ b/server/routes/version.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { noStore } from '../httpCache.js';
+
+// The Dockerfile writes a fresh BUILD_ID per image. In local dev the file is
+// absent, so we fall back to a constant — the client only reloads on a real
+// mismatch, and `'dev'` keeps matching `'dev'`.
+const BUILD_ID = (() => {
+  try {
+    return readFileSync(path.join(process.cwd(), 'BUILD_ID'), 'utf-8').trim();
+  } catch {
+    return 'dev';
+  }
+})();
+
+export const versionRouter = Router();
+
+versionRouter.get('/', (_req, res) => {
+  noStore(res);
+  res.json({ buildId: BUILD_ID });
+});


### PR DESCRIPTION
## What
On `visibilitychange` / `pageshow` (including bfcache restore), the client refetches the public daily + zen meta and checks `/api/version` against a baseline captured at boot. If the build ID differs and no game is in progress, it forces a `location.reload()`. Static serving now stamps `/assets/*` as `immutable, max-age=1y` and everything else as `no-cache`, and each Docker image writes a fresh `BUILD_ID` that the new `/api/version` route reads.

## Why
Mobile Safari/Chrome were resuming long-lived tabs from bfcache, showing yesterday's daily and sometimes an outdated bundle from a prior deploy. Refetching daily data on focus fixes the "stale puzzle" symptom; the build-ID + cache-header pair fixes the "older app version" symptom by ensuring a reload actually pulls the new `index.html` and its new asset hashes.

## Follow-ups
- No interval poll — a tab that never backgrounds won't pick up a deploy. Fine for the reported case; revisit if it bites.
- Reload is suppressed mid-game; the next focus after the game ends will pick up the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)