### PR TITLE
feat(results): smooth solo↔compare transition with region fade-in

### DIFF
--- a/client/src/shared/results/ResultsView.tsx
+++ b/client/src/shared/results/ResultsView.tsx
@@ -183,39 +183,44 @@ export function ResultsView({
           />
         )}
 
-        {opponent && meRow && opponentRosterRow ? (
-          <ResultsHero
-            me={{
-              displayName: 'You',
-              points: me.points,
-              wordCount: me.wordCount,
-            }}
-            myRank={meRow.rank}
-            totalPlayers={roster.length}
-            opponent={{
-              displayName: opponent.displayName,
-              points: opponent.points,
-              wordCount: opponent.wordCount,
-            }}
-            oppRank={opponentRosterRow.rank}
-            compact
-          />
-        ) : (
-          soloHero ?? (
+        <div
+          key={opponent ? 'hero-versus' : 'hero-solo'}
+          className="shrink-0 results-region-fade-in"
+        >
+          {opponent && meRow && opponentRosterRow ? (
             <ResultsHero
               me={{
-                displayName: me.displayName,
+                displayName: 'You',
                 points: me.points,
                 wordCount: me.wordCount,
               }}
-              myRank={meRow?.rank ?? 1}
+              myRank={meRow.rank}
               totalPlayers={roster.length}
-              opponent={null}
-              oppRank={null}
+              opponent={{
+                displayName: opponent.displayName,
+                points: opponent.points,
+                wordCount: opponent.wordCount,
+              }}
+              oppRank={opponentRosterRow.rank}
               compact
             />
-          )
-        )}
+          ) : (
+            soloHero ?? (
+              <ResultsHero
+                me={{
+                  displayName: me.displayName,
+                  points: me.points,
+                  wordCount: me.wordCount,
+                }}
+                myRank={meRow?.rank ?? 1}
+                totalPlayers={roster.length}
+                opponent={null}
+                oppRank={null}
+                compact
+              />
+            )
+          )}
+        </div>
 
         <section className="flex items-stretch gap-2 shrink-0 box-border">
           {isMulti && (
@@ -239,7 +244,10 @@ export function ResultsView({
         </section>
 
         <section className="flex justify-between items-stretch gap-2 flex-1 min-h-0 box-border">
-          <div className="w-1/2 flex flex-col min-h-0">
+          <div
+            key={opponent ? 'left-compare' : 'left-solo'}
+            className="w-1/2 flex flex-col min-h-0 results-region-fade-in"
+          >
             {opponent && youCompareRows ? (
               <WordList
                 side="you"
@@ -268,7 +276,10 @@ export function ResultsView({
               />
             )}
           </div>
-          <div className="w-1/2 flex flex-col min-h-0">
+          <div
+            key={opponent ? 'right-compare' : 'right-solo'}
+            className="w-1/2 flex flex-col min-h-0 results-region-fade-in"
+          >
             {opponent && oppCompareRows ? (
               <WordList
                 side="opp"

--- a/client/src/tailwind-v2.css
+++ b/client/src/tailwind-v2.css
@@ -256,3 +256,19 @@
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+/* Results page: smooth the transition between solo and compare modes by
+   fading newly-mounted regions in. The hero, left word list, and right
+   word list each remount when the user taps a leaderboard name (or hits
+   "Stop"); without this the layout context-switches in a single frame
+   and reads as jarring. Skipped under prefers-reduced-motion. */
+@keyframes results-region-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.results-region-fade-in {
+  animation: results-region-fade-in 450ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .results-region-fade-in { animation: none; }
+}


### PR DESCRIPTION
## What
Wraps the hero and both word-list columns in keyed containers that remount on compare-mode toggle, firing a 450ms cubic-bezier fade-in (opacity + 4px translateY). Keyframes live in \`tailwind-v2.css\` next to the other v2 fade.

## Why
Tapping a leaderboard name (or hitting Stop) used to swap three regions — hero, left list, right list — in a single frame, which read as jarring. A short fade softens the layout context-switch without adding a motion library or touching component internals.

## Follow-ups
- \`prefers-reduced-motion\` skips the animation.
- Could add a loading skeleton/dim on the solo content during \`opponentLoading\` so the wait before swap is also signalled — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)