### PR TITLE
fix(results): smoother compare scroll sync + first-to-finish placeholder

### DIFF
--- a/client/src/pages/dailyZen/ZenResultsRoute.tsx
+++ b/client/src/pages/dailyZen/ZenResultsRoute.tsx
@@ -197,6 +197,7 @@ export function ZenResultsRoute() {
         compareSourceLabel="leaderboard"
         findPercents={result.find_percents}
         popularityStyle={result.find_percents ? 'inline' : undefined}
+        soloPlaceholderVariant="wait"
         soloHero={
           <div className="shrink-0 pt-2 pb-1 h-[82px] box-border flex items-center justify-center">
             <HeroScore

--- a/client/src/pages/results/DailyResultsRoute.tsx
+++ b/client/src/pages/results/DailyResultsRoute.tsx
@@ -232,6 +232,7 @@ export function DailyResultsRoute() {
         compareSourceLabel="leaderboard"
         findPercents={serverResult?.find_percents}
         popularityStyle={serverResult?.find_percents ? 'inline' : undefined}
+        soloPlaceholderVariant="wait"
         topbar={
           <DailyTopbar
             label={dateLabel}

--- a/client/src/shared/results/ResultsView.tsx
+++ b/client/src/shared/results/ResultsView.tsx
@@ -53,6 +53,11 @@ interface ResultsViewProps {
   topbarOnLabelClick?: () => void;
   /** Bottom CTA row (Home/Leaderboard, or Play again). */
   bottomActions: ReactNode;
+  /** Right-column placeholder when the viewer is the only player in the
+   *  roster. Free-play defaults to a Share nudge; daily/zen pass 'wait'
+   *  since there's nothing to share — comparisons surface as other
+   *  players finish today's puzzle. */
+  soloPlaceholderVariant?: 'share' | 'wait';
   /** Optional solo-state hero override (e.g. daily/zen want HeroScore
    *  with a mode badge / rank crown). Defaults to the unified
    *  ResultsHero in solo mode. */
@@ -78,6 +83,7 @@ export function ResultsView({
   topbarOnLabelClick,
   bottomActions,
   soloHero,
+  soloPlaceholderVariant = 'share',
 }: ResultsViewProps) {
   const [highlightedWord, setHighlightedWord] = useState<string | null>(null);
   const [highlightPath, setHighlightPath] = useState<Position[] | null>(null);
@@ -288,8 +294,8 @@ export function ResultsView({
               />
             ) : (
               <Placeholders
-                variant={isMulti ? 'compare' : 'share'}
-                onShare={!isMulti ? topbarOnShare : undefined}
+                variant={isMulti ? 'compare' : soloPlaceholderVariant}
+                onShare={!isMulti && soloPlaceholderVariant === 'share' ? topbarOnShare : undefined}
                 compact
                 compareSourceLabel={compareSourceLabel}
                 definitionSlot={
@@ -440,18 +446,26 @@ function alignedRows(
 function useScrollSync(active: boolean) {
   const leftRef = useRef<HTMLDivElement | null>(null);
   const rightRef = useRef<HTMLDivElement | null>(null);
-  const syncingRef = useRef(false);
+  // Per-side "ignore the next scroll event" flags. When we programmatically
+  // set scrollTop on the other side, that write queues a scroll event we
+  // must drop so it doesn't echo back. A single shared flag would also
+  // swallow legitimate follow-up scrolls from the active side that fire
+  // before rAF clears it — which is what made momentum scrolling stutter.
+  const ignoreNextRef = useRef({ left: false, right: false });
 
   const sync = (source: 'left' | 'right') => {
-    if (!active || syncingRef.current) return;
+    if (!active) return;
+    if (ignoreNextRef.current[source]) {
+      ignoreNextRef.current[source] = false;
+      return;
+    }
     const from = source === 'left' ? leftRef.current : rightRef.current;
     const to = source === 'left' ? rightRef.current : leftRef.current;
     if (!from || !to) return;
-    syncingRef.current = true;
-    to.scrollTop = from.scrollTop;
-    requestAnimationFrame(() => {
-      syncingRef.current = false;
-    });
+    if (to.scrollTop !== from.scrollTop) {
+      ignoreNextRef.current[source === 'left' ? 'right' : 'left'] = true;
+      to.scrollTop = from.scrollTop;
+    }
   };
 
   return {

--- a/client/src/shared/results/components/Placeholders.tsx
+++ b/client/src/shared/results/components/Placeholders.tsx
@@ -8,9 +8,12 @@ interface PlaceholdersProps {
    *  the definition first. */
   definitionSlot?: ReactNode;
   /** "compare" — used when there are other players to compare against.
-   *  "share" — used in solo mode to nudge the player to share the board
-   *  so someone else can play it. */
-  variant?: 'compare' | 'share';
+   *  "share" — used in free-play solo to nudge the player to share the
+   *  board so someone else can play it.
+   *  "wait" — used in daily/zen solo (first to finish today's puzzle);
+   *  there's nothing to share, just a heads-up that comparisons appear
+   *  as others play. */
+  variant?: 'compare' | 'share' | 'wait';
   /** Fired when the user taps the share-prompt's Share button. */
   onShare?: () => void;
   compact?: boolean;
@@ -45,6 +48,8 @@ export function Placeholders({
     <div className="flex flex-col gap-2 h-full min-h-0">
       {variant === 'share' ? (
         <SharePrompt onShare={onShare} compact={compact} />
+      ) : variant === 'wait' ? (
+        <WaitPrompt compact={compact} />
       ) : (
         <ComparePrompt compact={compact} sourceLabel={compareSourceLabel} />
       )}
@@ -90,6 +95,36 @@ function ComparePrompt({
       </div>
       <div className={`${compact ? 'mt-1 px-0 text-[11px] leading-[1.25]' : 'mt-1.5 px-1 text-xs leading-[1.35]'} italic font-[family-name:var(--font-display)] text-[color:var(--ink-muted)]`}>
         Tap any name in the {sourceLabel} to see their words side-by-side with yours
+      </div>
+    </div>
+  );
+}
+
+function WaitPrompt({ compact = false }: { compact?: boolean }) {
+  return (
+    <div
+      className={`w-full flex flex-col items-center justify-center text-center rounded-xl text-[color:var(--ink-muted)] min-h-0 ${compact ? 'px-2 py-2' : 'px-3 py-3'}`}
+      style={{
+        flex: '2 1 0',
+        border: '1.5px dashed var(--opp-accent)',
+        background: 'var(--opp-accent-soft)',
+      }}
+    >
+      <div className="flex items-center gap-1 mb-1.5" aria-hidden>
+        <PlaceholderInitial char="Y" accent="var(--you-accent)" />
+        <span className="italic font-[family-name:var(--font-display)] text-label-xs text-[color:var(--ink-soft)]">
+          vs
+        </span>
+        <PlaceholderInitial char="?" accent="var(--opp-accent)" />
+      </div>
+      <div
+        className="uppercase font-[family-name:var(--font-structure)] text-label-xs tracking-[0.1em] text-[color:var(--ink)] leading-[1.2]"
+        style={{ fontWeight: 700 }}
+      >
+        First to finish
+      </div>
+      <div className={`${compact ? 'mt-1 px-0 text-[11px] leading-[1.25]' : 'mt-1.5 px-1 text-xs leading-[1.35]'} italic font-[family-name:var(--font-display)] text-[color:var(--ink-muted)]`}>
+        Check back as others play to compare your words side-by-side
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Two small polishes on the results page compare view:

1. **Smoother scroll-sync between aligned word lists.** `useScrollSync` previously used a single shared flag (cleared in `requestAnimationFrame`) to break the feedback loop between the two lists. During fast trackpad/momentum scrolling the same flag was also swallowing subsequent scroll events from the active side that fired before the rAF tick, so the follower lurched in stutters of dropped frames. Replaced with per-side "ignore next scroll" flags so only the single echo from the programmatic `scrollTop` write on the follower is dropped — never the active side's own follow-up events.

2. **"First to finish" placeholder for daily/zen solo state.** When the viewer is the only player on the leaderboard (daily/zen first finisher), the right column previously showed the free-play "Share this board" CTA, which doesn't fit — daily/zen puzzles aren't shareable in that sense. Added a `'wait'` `Placeholders` variant ("First to finish — Check back as others play to compare your words side-by-side") and a `soloPlaceholderVariant` prop on `ResultsView`. `DailyResultsRoute` and `ZenResultsRoute` pass `'wait'`; free-play (`ResultsRoute`) keeps the existing `'share'` default.

## Why

- The sync bug was the visible reason the compare view felt "off" compared to the solo word list. Fixing the flag scope eliminates dropped frames without any wider restructuring; the two lists still scroll natively.
- The share CTA in daily/zen first-place state was misleading — there's nothing to share to invite competition because the puzzle is the same for everyone that day. The wait copy reframes the empty state as "comparisons will appear" rather than nudging the user toward an action that doesn't do what they'd expect.

## Follow-ups

- The scroll sync still uses two DOM scroll containers driven by JS. A future cleanup could merge them into a single grid-based scroll container, eliminating the sync code entirely — discussed but deferred since the per-side card framing would need to merge into one rounded card.

## Test plan

- [ ] Open results in compare mode (free-play challenge or daily comparison) and flick-scroll one side with a trackpad — both lists track together without lurching.
- [ ] Land on daily results as the first/only finisher — right column shows the "First to finish" wait copy in the dashed `vs ?` frame, not the share button.
- [ ] Land on daily results with other players present — right column still shows the existing "Compare players" prompt.
- [ ] Free-play solo results still show the existing "Share this board" prompt with the Share button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)