### PR TITLE
fix(daily): block timed-daily replay after mid-game exit

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,7 @@ import { ZenGameRoute, ZenResultsRoute, ZenLeaderboardRoute } from './pages/dail
 import './tailwind.css';
 
 function App() {
-  const { game, showHomeConfirm, setShowHomeConfirm, cancelGame, setDailyInfo } = useGame();
+  const { game, showHomeConfirm, setShowHomeConfirm, cancelGame, setDailyInfo, dailyInfo, abandonDaily } = useGame();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -28,6 +28,13 @@ function App() {
 
   const handleGoHome = async () => {
     setShowHomeConfirm(false);
+    // Bailing out of a daily mid-play has to leave behind a result row
+    // (with whatever was found so far), otherwise the confirm page sees
+    // no result and re-offers Start — letting the player replay today's
+    // puzzle from scratch.
+    if (dailyInfo && game?.status === GameState.InProgress) {
+      await abandonDaily();
+    }
     setDailyInfo(null);
     if (game) await cancelGame();
     navigate('/');

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -56,6 +56,7 @@ interface GameContextValue {
   cachedDailyResult: { found_words: string[]; board: string[][] } | null;
   dailyResultLoaded: boolean;
   refreshDaily: () => Promise<DailyInfo>;
+  abandonDaily: () => Promise<void>;
 
   // Zen Daily
   cachedDailyZen: DailyZenMeta | null;
@@ -479,10 +480,31 @@ export function GameProvider({ children }: { children: ReactNode }) {
     return info;
   };
 
+  // Finalize the current daily attempt without ending the in-progress game
+  // normally — used when the player navigates home mid-daily. Writes the
+  // words found so far so the confirm page can't re-offer Start on the
+  // same date. Cache is set optimistically so the gate flips before the
+  // server round-trip resolves.
+  const abandonDaily = useCallback(async () => {
+    if (!dailyInfo || cachedDailyResult) return;
+    const wordStrings = words.map((w) => w.word);
+    setCachedDailyResult({ found_words: wordStrings, board: dailyInfo.board });
+    try {
+      await recordDailyResultToServer(
+        dailyInfo.date,
+        wordStrings,
+        dailyInfo.board,
+        dailyInfo.config,
+      );
+    } catch (err) {
+      console.warn('Failed to record abandoned daily result:', err);
+    }
+  }, [dailyInfo, cachedDailyResult, words]);
+
   return (
     <GameContext.Provider value={{
       game, words, results, gameSeed, feedback, timeRemaining,
-      dailyInfo, setDailyInfo, cachedDaily, cachedDailyResult, dailyResultLoaded, refreshDaily,
+      dailyInfo, setDailyInfo, cachedDaily, cachedDailyResult, dailyResultLoaded, refreshDaily, abandonDaily,
       cachedDailyZen, cachedDailyZenSession, dailyZenLoaded,
       setCachedDailyZenSession, refreshDailyZenSession,
       lastZenModeChoice, setLastZenModeChoice,

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -84,7 +84,6 @@ interface GameContextValue {
   toggleMute: () => void;
 
   // Actions
-  createGame: () => Promise<void>;
   startGame: (timeLimit: number, boardSize: number, minWordLength: number, board?: string[][], seed?: number) => Promise<any>;
   cancelGame: () => Promise<void>;
   endGame: () => Promise<void>;
@@ -119,7 +118,7 @@ export function useGame() {
 }
 
 export function GameProvider({ children }: { children: ReactNode }) {
-  const { game, words, results, gameSeed, createGame, startGame, cancelGame, endGame, fetchGameState, submitWord } = useGameApi();
+  const { game, words, results, gameSeed, startGame, cancelGame, endGame, fetchGameState, submitWord } = useGameApi();
   const [feedback, setFeedback] = useState<{ type: FeedbackType; path: Position[] } | null>(null);
   const [muted, setMuted] = useState(loadMuted);
   const [dailyInfo, setDailyInfo] = useState<DailyInfo | null>(null);
@@ -490,7 +489,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       boardCode, setBoardCode, sharedSeed, handleCodeChange,
       lastConfig, setLastConfig,
       muted, toggleMute,
-      createGame, startGame, cancelGame, endGame, submitWord, handleSubmitWord, handleSubmitZenWord,
+      startGame, cancelGame, endGame, submitWord, handleSubmitWord, handleSubmitZenWord,
       showHomeConfirm, setShowHomeConfirm,
       theme, toggleTheme,
       session, authReady,

--- a/client/src/hooks/useGameApi.ts
+++ b/client/src/hooks/useGameApi.ts
@@ -13,20 +13,9 @@ export const useGameApi = () => {
   const saltRef = useRef<string>('');
   const submittedWordsRef = useRef<Set<string>>(new Set());
 
-  const createGame = async () => {
-    const data = await gameApi.createGame();
-    setGame(data.game);
-    setWords([]);
-    setResults(null);
-    fetchingResults.current = false;
-    wordHashesRef.current = new Set();
-    saltRef.current = '';
-    submittedWordsRef.current = new Set();
-  };
-
   const startGame = async (
-    durationSeconds: number = 180, 
-    boardSize: number = 4, 
+    durationSeconds: number = 180,
+    boardSize: number = 4,
     minWordLength: number = 3,
     predefinedBoard?: string[][],
     seed?: number
@@ -34,7 +23,9 @@ export const useGameApi = () => {
     const data = await gameApi.startGame(durationSeconds, boardSize, minWordLength, predefinedBoard, seed);
     setGame(data.game);
     setWords([]);
+    setResults(null);
     setGameSeed(data.seed);
+    fetchingResults.current = false;
     wordHashesRef.current = new Set(data.wordHashes);
     saltRef.current = data.salt;
     submittedWordsRef.current = new Set();
@@ -114,7 +105,6 @@ export const useGameApi = () => {
     words,
     results,
     gameSeed,
-    createGame,
     startGame,
     cancelGame,
     endGame,

--- a/client/src/pages/config/ConfigRoute.tsx
+++ b/client/src/pages/config/ConfigRoute.tsx
@@ -7,14 +7,17 @@ import { decodeGameParams } from '../../shared/utils/gameLink';
 import { fetchDaily } from '../../shared/api/gameApi';
 
 export function ConfigRoute({ mode }: { mode: 'freeplay' | 'daily' }) {
-  const { game, dailyInfo, cachedDailyResult, startGame, cancelGame, createGame, sharedSeed, boardCode, handleCodeChange, setBoardCode, lastConfig, setLastConfig, setDailyInfo } = useGame();
+  const { dailyInfo, cachedDailyResult, startGame, sharedSeed, boardCode, handleCodeChange, setBoardCode, lastConfig, setLastConfig, setDailyInfo } = useGame();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isDaily = mode === 'daily';
   const [ready, setReady] = useState(false);
   const initRef = useRef(false);
 
-  // Handle direct navigation: create game session and fetch daily info if needed
+  // Handle direct navigation: fetch daily info if needed. The server
+  // session is now created lazily by /api/game/start, so the config page
+  // no longer pre-allocates one — there's nothing to clean up if the
+  // player navigates away before clicking Start.
   useEffect(() => {
     if (initRef.current) return;
     initRef.current = true;
@@ -31,10 +34,6 @@ export function ConfigRoute({ mode }: { mode: 'freeplay' | 'daily' }) {
         setDailyInfo(info);
       }
 
-      if (!game) {
-        await createGame();
-      }
-
       setReady(true);
     };
 
@@ -49,8 +48,10 @@ export function ConfigRoute({ mode }: { mode: 'freeplay' | 'daily' }) {
 
   const isSharedGame = sharedGame !== null;
 
-  // Don't render until initialization is complete
-  if (!ready && (isDaily || !game)) return null;
+  // Daily redirects to /daily/results if the player has already played,
+  // so we wait for the init effect to settle before rendering. Free play
+  // has no async init step and can render immediately.
+  if (isDaily && !ready) return null;
 
   const dailyDefaults = isDaily && dailyInfo ? {
     boardSize: dailyInfo.config.boardSize as 4 | 5 | 6,
@@ -82,10 +83,9 @@ export function ConfigRoute({ mode }: { mode: 'freeplay' | 'daily' }) {
     navigate('/game');
   };
 
-  const handleBack = async () => {
+  const handleBack = () => {
     setBoardCode('');
     setDailyInfo(null);
-    await cancelGame();
     navigate('/');
   };
 

--- a/client/src/pages/daily/DailyConfirmRoute.tsx
+++ b/client/src/pages/daily/DailyConfirmRoute.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { GameState } from 'models';
 import { useGame } from '../../GameContext';
 import { DailyConfirmPage } from './DailyConfirmPage';
-import { fetchDailyStats } from '../../shared/api/gameApi';
+import { fetchDailyStats, startDailyAttemptOnServer } from '../../shared/api/gameApi';
 
 function formatLongDate(dateIso: string): string {
   const d = new Date(dateIso + 'T12:00:00');
@@ -47,7 +48,11 @@ export function DailyConfirmRoute() {
     dailyResultLoaded,
     authReady,
     startGame,
+    cancelGame,
+    game,
+    dailyInfo,
     setDailyInfo,
+    abandonDaily,
   } = useGame();
   const [playersCount, setPlayersCount] = useState<number | null>(null);
 
@@ -75,6 +80,32 @@ export function DailyConfirmRoute() {
     };
   }, [authReady, mockFixture]);
 
+  // Re-entering /daily while a daily game is still in progress (browser
+  // back from /game, history nav, etc.) is treated the same as a Froggle-
+  // title cancel: finalize the attempt with whatever was found so far and
+  // tear down the server session. Without this, the confirm page would
+  // still see cachedDailyResult=null and re-offer Start.
+  //
+  // The ref keeps the effect from firing during handleStart's own state
+  // changes — startGame flips game.status to InProgress before navigate
+  // unmounts us, which would otherwise trip the same condition.
+  const startingRef = useRef(false);
+  useEffect(() => {
+    if (mockFixture || startingRef.current) return;
+    if (!dailyInfo) return;
+    if (cachedDailyResult) return;
+    if (game?.status !== GameState.InProgress) return;
+    let cancelled = false;
+    (async () => {
+      await abandonDaily();
+      if (cancelled) return;
+      await cancelGame();
+    })().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [mockFixture, dailyInfo, cachedDailyResult, game?.status, abandonDaily, cancelGame]);
+
   const handleBack = () => {
     setDailyInfo(null);
     navigate('/');
@@ -90,7 +121,21 @@ export function DailyConfirmRoute() {
       navigate('/daily/results');
       return;
     }
+    startingRef.current = true;
     setDailyInfo(cachedDaily);
+    // Best-effort: write an empty daily_results row before the game starts
+    // so closing the tab mid-play still leaves an attempt on the server.
+    // Non-fatal — if this fails the only regression is the original
+    // tab-close replay bug, which we don't want to gate the game on.
+    try {
+      await startDailyAttemptOnServer(
+        cachedDaily.date,
+        cachedDaily.board,
+        cachedDaily.config,
+      );
+    } catch (err) {
+      console.warn('Failed to mark daily attempt as started:', err);
+    }
     await startGame(
       cachedDaily.config.timeLimit,
       cachedDaily.config.boardSize,

--- a/client/src/pages/daily/DailyConfirmRoute.tsx
+++ b/client/src/pages/daily/DailyConfirmRoute.tsx
@@ -46,9 +46,7 @@ export function DailyConfirmRoute() {
     cachedDailyResult,
     dailyResultLoaded,
     authReady,
-    createGame,
     startGame,
-    game,
     setDailyInfo,
   } = useGame();
   const [playersCount, setPlayersCount] = useState<number | null>(null);
@@ -93,7 +91,6 @@ export function DailyConfirmRoute() {
       return;
     }
     setDailyInfo(cachedDaily);
-    if (!game) await createGame();
     await startGame(
       cachedDaily.config.timeLimit,
       cachedDaily.config.boardSize,

--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -29,7 +29,6 @@ export function LandingRoute() {
     cachedDailyZenSession,
     dailyZenLoaded,
     authReady,
-    createGame,
     setDailyInfo,
     displayName,
     nameProfile,
@@ -103,9 +102,8 @@ export function LandingRoute() {
     };
   }, [authReady, cachedDailyZen?.date, cachedDailyZenSession?.date, cachedDailyZenSession?.ended_at, cachedDailyZenSession?.is_competitive]);
 
-  const handleFreePlay = async () => {
+  const handleFreePlay = () => {
     setDailyInfo(null);
-    await createGame();
     navigate('/play');
   };
 

--- a/client/src/pages/results/ResultsRoute.tsx
+++ b/client/src/pages/results/ResultsRoute.tsx
@@ -5,7 +5,7 @@ import { ResultsPage } from './ResultsPage';
 import { getResultsFixture } from './__fixtures__';
 
 export function ResultsRoute() {
-  const { game, results, gameSeed, dailyInfo, setDailyInfo, createGame, cancelGame } = useGame();
+  const { game, results, gameSeed, dailyInfo, setDailyInfo, cancelGame } = useGame();
   const navigate = useNavigate();
   const navigatingRef = useRef(false);
   const [searchParams] = useSearchParams();
@@ -35,7 +35,6 @@ export function ResultsRoute() {
       navigate('/');
     } else {
       navigate('/play');
-      await createGame();
     }
   };
 

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -55,22 +55,9 @@ async function getJson<T>(
   return pending;
 }
 
-export const createGame = async (): Promise<{
-  game: Game;
-  sessionId: string;
-}> => {
-  const response = await fetch(`${API_URL}/game/create`, {
-    method: 'POST',
-    headers: await sessionHeaders(),
-  });
-  const data = await response.json();
-  sessionId = data.sessionId;
-  return data;
-};
-
 export const startGame = async (
-  durationSeconds: number = 180, 
-  boardSize: number = 4, 
+  durationSeconds: number = 180,
+  boardSize: number = 4,
   minWordLength: number = 3,
   predefinedBoard?: string[][],
   seed?: number
@@ -79,13 +66,16 @@ export const startGame = async (
   wordHashes: string[];
   salt: string;
   seed: number;
+  sessionId: string;
 }> => {
   const response = await fetch(`${API_URL}/game/start`, {
     method: 'POST',
     headers: await sessionHeaders(),
     body: JSON.stringify({ durationSeconds, boardSize, minWordLength, board: predefinedBoard, seed }),
   });
-  return response.json();
+  const data = await response.json();
+  sessionId = data.sessionId;
+  return data;
 };
 
 export const cancelGame = async (): Promise<{ success: boolean }> => {

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -221,6 +221,26 @@ export const recordDailyResultToServer = async (
   return response.json();
 };
 
+// Writes a placeholder daily_results row so the player has been "counted"
+// as having attempted today before they've found a single word — this is
+// what stops a tab-close from looking like an unplayed day next visit.
+export const startDailyAttemptOnServer = async (
+  date: string,
+  board: string[][],
+  config: DailyConfig,
+): Promise<{ success: boolean }> => {
+  const response = await fetch(`${API_URL}/daily/results/start`, {
+    method: 'POST',
+    headers: await sessionHeaders(),
+    body: JSON.stringify({ date, board, config }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`startDailyAttemptOnServer ${response.status}: ${body}`);
+  }
+  return response.json();
+};
+
 export interface DailyResultMissedWord {
   word: string;
   path: { row: number; col: number }[];

--- a/models/index.ts
+++ b/models/index.ts
@@ -37,7 +37,6 @@ export interface Room {
 }
 
 export enum GameState {
-  Config = 'Config',
   InProgress = 'InProgress',
   Finished = 'Finished'
 }

--- a/server/GameController.ts
+++ b/server/GameController.ts
@@ -28,31 +28,12 @@ export class GameController {
     this.dictionary = loadDictionary(dictionaryPath);
   }
 
-  createGame(): Game {
-    // Clear any existing game
+  startGame(durationSeconds: number, boardSize: number = 4, minWordLength: number = 3, predefinedBoard?: string[][], seed?: number): { game: Game; wordHashes: string[]; salt: string; seed: number } {
+    // Tear down any prior timer — a stale session that gets reused must
+    // not keep counting toward an old game's deadline.
     if (this.timer) {
       clearTimeout(this.timer);
-    }
-
-    // Create a game in Config state with empty board
-    this.game = {
-      board: [],
-      startedAt: 0,
-      status: GameState.Config,
-      config: {
-        durationSeconds: 180,
-        boardSize: 4,
-        minWordLength: 3,
-      },
-    };
-    this.words = [];
-
-    return this.game;
-  }
-
-  startGame(durationSeconds: number, boardSize: number = 4, minWordLength: number = 3, predefinedBoard?: string[][], seed?: number): { game: Game; wordHashes: string[]; salt: string; seed: number } {
-    if (!this.game || this.game.status !== GameState.Config) {
-      throw new Error('Cannot start game: game not in Config state');
+      this.timer = null;
     }
 
     // Always have a seed — use provided one or generate a new one

--- a/server/routes/daily.ts
+++ b/server/routes/daily.ts
@@ -7,7 +7,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { getDb } from '../db/index.js';
 import { cachePrivate, cachePublic, noStore } from '../httpCache.js';
 import { dictionary } from '../services/dictionary.js';
-import { scoreResult, scoreWords, getDailyStats } from '../services/DailyService.js';
+import { scoreResult, scoreWords, getDailyStats, startDailyAttempt } from '../services/DailyService.js';
 import { getTimedDailyWordPercents } from '../services/dailyWordStats.js';
 import { getDisplayNames } from '../services/displayNames.js';
 import {
@@ -60,6 +60,32 @@ if (process.env.NODE_ENV !== 'production') {
     res.json({ seed, config, board });
   });
 }
+
+// Mark today's daily as in-progress for the player. Idempotent: a second
+// call for an already-finalized day is a no-op (see startDailyAttempt's
+// onConflict). Called from the Start button so abandoning the tab still
+// counts as an attempt and the player can't replay from scratch.
+dailyRouter.post('/results/start', requireAuth, async (req, res) => {
+  const { date, board, config } = req.body;
+
+  if (!date || !board || !config) {
+    return res.status(400).json({ error: 'Missing required fields: date, board, config' });
+  }
+
+  try {
+    await startDailyAttempt(getDb(), {
+      userId: req.userId!,
+      date,
+      board,
+      config,
+    });
+    noStore(res);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to start daily attempt:', err);
+    res.status(500).json({ error: 'Failed to start attempt' });
+  }
+});
 
 dailyRouter.post('/results', requireAuth, async (req, res) => {
   const { date, found_words, board, config } = req.body;

--- a/server/routes/game.ts
+++ b/server/routes/game.ts
@@ -28,26 +28,22 @@ function recordIfFinishedOnce(session: Session, userId: string | null): void {
   });
 }
 
-gameRouter.post('/create', (_req, res) => {
-  const { sessionId, controller } = createSession();
-  const game = controller.createGame();
-  res.json({ game, sessionId });
-});
-
+// One-shot game start: allocates a fresh session and runs the controller
+// past the old Config → InProgress hop in a single call. Returns the new
+// sessionId so the client can set it as X-Session-Id for subsequent
+// /submit, /end, /cancel calls.
 gameRouter.post('/start', (req, res) => {
-  const session = getSession(getRequestSessionId(req));
-  if (!session) return res.status(401).json({ error: 'Invalid session' });
-
+  const { sessionId, controller } = createSession();
   const { durationSeconds, boardSize, minWordLength, board, seed } = req.body;
   try {
-    const result = session.controller.startGame(
+    const result = controller.startGame(
       durationSeconds || 180,
       boardSize || 4,
       minWordLength || 3,
       board,
       seed,
     );
-    res.json(result);
+    res.json({ ...result, sessionId });
   } catch (error) {
     res.status(400).json({ error: (error as Error).message });
   }

--- a/server/services/DailyService.test.ts
+++ b/server/services/DailyService.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DummyDriver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+} from 'kysely';
+import type { Database } from '../db/types.js';
+import {
+  buildStartDailyAttemptQuery,
+  buildStartDailyAttemptRow,
+} from './DailyService.js';
+
+const PARAMS = {
+  userId: 'user-1',
+  date: '2026-05-12',
+  board: [
+    ['A', 'B'],
+    ['C', 'D'],
+  ],
+  config: { boardSize: 2, minWordLength: 3, timeLimit: 120 },
+};
+
+function dummyDb(): Kysely<Database> {
+  return new Kysely<Database>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+}
+
+describe('buildStartDailyAttemptRow', () => {
+  it('produces an empty result row with the player config', () => {
+    expect(buildStartDailyAttemptRow(PARAMS)).toEqual({
+      user_id: 'user-1',
+      date: '2026-05-12',
+      found_words: '[]',
+      board: '[["A","B"],["C","D"]]',
+      board_size: 2,
+      min_word_length: 3,
+      time_limit: 120,
+    });
+  });
+});
+
+describe('buildStartDailyAttemptQuery', () => {
+  it('compiles to INSERT … ON CONFLICT DO NOTHING — never DO UPDATE — so a finalized row is never clobbered', () => {
+    const compiled = buildStartDailyAttemptQuery(dummyDb(), PARAMS).compile();
+    const sql = compiled.sql.toLowerCase();
+    expect(sql).toContain('insert into "daily_results"');
+    expect(sql).toContain('on conflict ("user_id", "date") do nothing');
+    expect(sql).not.toContain('do update');
+    expect(compiled.parameters).toEqual([
+      'user-1',
+      '2026-05-12',
+      '[]',
+      '[["A","B"],["C","D"]]',
+      2,
+      3,
+      120,
+    ]);
+  });
+
+  it('targets the same unique constraint as the finalize write so the two paths upsert against each other', () => {
+    // Mirrors POST /api/daily/results's onConflict columns. If that route's
+    // conflict target ever drifts, this test should drift with it.
+    const compiled = buildStartDailyAttemptQuery(dummyDb(), PARAMS).compile();
+    expect(compiled.sql.toLowerCase()).toContain('("user_id", "date")');
+  });
+});

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -9,6 +9,49 @@ export interface ScoredResult {
   longestWord: string;
 }
 
+export interface StartDailyAttemptParams {
+  userId: string;
+  date: string;
+  board: string[][];
+  config: DailyConfig;
+}
+
+// Empty row written on /start so a player who closes the tab (or otherwise
+// abandons mid-play) can't re-enter today's daily as if it were unplayed.
+// The end-of-game write path upserts over this with the full result.
+export function buildStartDailyAttemptRow(params: StartDailyAttemptParams) {
+  return {
+    user_id: params.userId,
+    date: params.date,
+    found_words: '[]',
+    board: JSON.stringify(params.board),
+    board_size: params.config.boardSize,
+    min_word_length: params.config.minWordLength,
+    time_limit: params.config.timeLimit,
+  };
+}
+
+// `do nothing` (not `do update`) is the load-bearing detail: a second call
+// for the same (user_id, date) must not blow away the finalized row a
+// previous /results write may have placed there. Split into builder + run
+// so the conflict shape is verifiable from a unit test without a live DB.
+export function buildStartDailyAttemptQuery(
+  db: Kysely<Database>,
+  params: StartDailyAttemptParams,
+) {
+  return db
+    .insertInto('daily_results')
+    .values(buildStartDailyAttemptRow(params))
+    .onConflict((oc) => oc.columns(['user_id', 'date']).doNothing());
+}
+
+export async function startDailyAttempt(
+  db: Kysely<Database>,
+  params: StartDailyAttemptParams,
+): Promise<void> {
+  await buildStartDailyAttemptQuery(db, params).execute();
+}
+
 // Sums the per-word scores of a word list. Callers that only need the point
 // total share this helper instead of reimplementing the reduce inline.
 export function scoreWords(foundWords: string[]): number {


### PR DESCRIPTION
## What

Players who started today's timed daily and exited mid-play (Froggle title → "Return home", tab close, or browser back from /game) could re-enter /daily and replay from scratch, because none of those paths wrote a `daily_results` row.

## Why this approach

Server is the only durable gate — once a `daily_results` row exists, the existing `cachedDailyResult !== null` check on `DailyConfirmRoute` flips Start → See result on every future visit. The fix has two layers: a `POST /daily/results/start` endpoint that writes a placeholder row at Start-click time (covers tab close and any crash path) using `ON CONFLICT (user_id, date) DO NOTHING` so it never clobbers a finalized row, and an `abandonDaily()` helper that records partial progress on in-app exit paths (Froggle title, browser-back to /daily) so "See result" shows what the player actually found instead of an empty row.

Commit 1 is a precursor refactor: the old two-step `POST /game/create` + `POST /game/start` was a relic of an earlier multiplayer-room design. Collapsing it into a single endpoint removes the `GameState.Config` state, saves a round-trip on every game launch, and untangles the DailyConfirmRoute auto-abandon logic. The bugfix itself rides on top in commit 2.

## Follow-ups

- The auto-abandon-on-mount effect in `DailyConfirmRoute` uses a `startingRef` to avoid abandoning the brand-new game `startGame()` just created; a cleaner fix would be to navigate away from /daily before `startGame()`'s state lands, but that's a bigger restructure.
- Could add React Testing Library to cover the auto-abandon effect — currently only the server-side `ON CONFLICT DO NOTHING` invariant is unit-tested.

## Test plan

- [ ] Start daily, click Froggle title → "Return home" → /daily shows See result with the words you found
- [ ] Start daily, close tab, reopen → /daily shows See result (0 words)
- [ ] Start daily, browser-back to /daily → page auto-flips to See result with partial progress
- [ ] Free play: Start, play, Play Again → goes to /play, configure, Start works
- [ ] Daily completion via timer expiry: results recorded, See result shows full found-word list