### PR TITLE
fix(results): portal word definition sheet out of transformed ancestor

### DIFF
--- a/client/src/pages/results/components/WordDefinitionSheet.tsx
+++ b/client/src/pages/results/components/WordDefinitionSheet.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import type { WordDefinition } from '../hooks/useDefinition';
 import { abbreviatePartOfSpeech } from '../utils/partOfSpeech';
 
@@ -32,7 +33,12 @@ export function WordDefinitionSheet({
     return () => document.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  return (
+  // Portal to document.body so the sheet's `position: fixed` is
+  // viewport-relative. Otherwise the .results-region-fade-in animation on
+  // an ancestor sets a transform, which creates a containing block and
+  // pins the sheet to the right column (where it leaks out over the
+  // bottom action bar even when closed).
+  return createPortal(
     <>
       <div
         aria-hidden
@@ -143,6 +149,7 @@ export function WordDefinitionSheet({
           )}
         </div>
       </div>
-    </>
+    </>,
+    document.body,
   );
 }


### PR DESCRIPTION
## What
Render `WordDefinitionSheet` through a `createPortal` to `document.body`.

## Why
The right-column wrapper in `ResultsView` carries the `results-region-fade-in` animation, which holds a non-identity `transform` via `animation-fill-mode: both`. A transformed ancestor becomes the containing block for `position: fixed` descendants, so the bottom sheet was pinned to the ~160px right column and its closed-state `translate-y-full` only translated it down by its own short height — leaving the header strip visible over the Play Again button after selecting a word.

## Follow-ups
None.