### PR TITLE
fix(results): keep standings panel from outgrowing the board

### DIFF
--- a/client/src/shared/results/ResultsView.tsx
+++ b/client/src/shared/results/ResultsView.tsx
@@ -236,7 +236,7 @@ export function ResultsView({
               onSelect={handleSelectOpponent}
               header={standingsHeader}
               compact
-              maxHeight="190px"
+              maxHeight="160px"
             />
           )}
           <div className={isMulti ? '' : 'flex-1 flex justify-center'}>

--- a/client/src/shared/results/components/Standings.tsx
+++ b/client/src/shared/results/components/Standings.tsx
@@ -8,7 +8,9 @@ interface StandingsProps {
    *  for daily/zen. The right-hand counter always shows row count. */
   header: string;
   compact?: boolean;
-  /** Cap the visible height; rest scrolls behind a soft mask. */
+  /** Cap the visible height; rest scrolls behind a soft mask. Sized so the
+   *  Standings panel doesn't outgrow the Board next to it (Board ≈ 180px,
+   *  header ≈ 20px → inner ≤ 160px). */
   maxHeight?: string;
 }
 
@@ -18,7 +20,7 @@ export function Standings({
   onSelect,
   header,
   compact = false,
-  maxHeight = '190px',
+  maxHeight = '160px',
 }: StandingsProps) {
   return (
     <div className="flex-1 min-w-0 flex flex-col min-h-0">


### PR DESCRIPTION
## What
Lower the Standings inner `maxHeight` from `190px` → `160px` so the panel's outer height stays at the Board's natural ~180px.

## Why
On today's timed daily (26 players), the standings cap meant the panel ran ~30px taller than the adjacent Board, which is sized by `flex items-stretch`. That pushed the whole section taller and squeezed the word lists below. The new cap keeps the Board as the section's height anchor regardless of roster size; verified visually with 26 and 3 mock players.

## Follow-ups
None — the cap is documented inline in `Standings.tsx` so future Board sizing changes have a pointer to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)