### PR TITLE
refactor(results): anchor "you" on the right; unify placeholder order

### DIFF
--- a/client/src/shared/results/ResultsView.tsx
+++ b/client/src/shared/results/ResultsView.tsx
@@ -251,39 +251,7 @@ export function ResultsView({
 
         <section className="flex justify-between items-stretch gap-2 flex-1 min-h-0 box-border">
           <div
-            key={opponent ? 'left-compare' : 'left-solo'}
-            className="w-1/2 flex flex-col min-h-0 results-region-fade-in"
-          >
-            {opponent && youCompareRows ? (
-              <WordList
-                side="you"
-                headerLabel={`You · ${me.wordCount}`}
-                headerTrail={String(me.points)}
-                rows={youCompareRows}
-                onWordTap={(w) => {
-                  const normalized = w.toUpperCase();
-                  setHighlightedWord((prev) =>
-                    prev === normalized ? null : normalized,
-                  );
-                  setHighlightPath(null);
-                }}
-                scrollSync={scrollSync.left}
-                compact
-              />
-            ) : (
-              <WordsCard
-                foundWords={me.foundWords}
-                missedWords={me.missedWords}
-                showMissedTab={me.missedWords.length > 0}
-                highlightedWord={highlightedWord}
-                onHighlightWord={handleHighlight}
-                findPercents={findPercents}
-                popularityStyle={popularityStyle}
-              />
-            )}
-          </div>
-          <div
-            key={opponent ? 'right-compare' : 'right-solo'}
+            key={opponent ? 'opp-compare' : 'placeholders-solo'}
             className="w-1/2 flex flex-col min-h-0 results-region-fade-in"
           >
             {opponent && oppCompareRows ? (
@@ -300,7 +268,7 @@ export function ResultsView({
                   );
                   setHighlightPath(null);
                 }}
-                scrollSync={scrollSync.right}
+                scrollSync={scrollSync.left}
                 compact
               />
             ) : (
@@ -318,6 +286,38 @@ export function ResultsView({
                     <WordDefinitionPanel word={highlightedWord} fitContainer />
                   ) : undefined
                 }
+              />
+            )}
+          </div>
+          <div
+            key={opponent ? 'you-compare' : 'words-solo'}
+            className="w-1/2 flex flex-col min-h-0 results-region-fade-in"
+          >
+            {opponent && youCompareRows ? (
+              <WordList
+                side="you"
+                headerLabel={`You · ${me.wordCount}`}
+                headerTrail={String(me.points)}
+                rows={youCompareRows}
+                onWordTap={(w) => {
+                  const normalized = w.toUpperCase();
+                  setHighlightedWord((prev) =>
+                    prev === normalized ? null : normalized,
+                  );
+                  setHighlightPath(null);
+                }}
+                scrollSync={scrollSync.right}
+                compact
+              />
+            ) : (
+              <WordsCard
+                foundWords={me.foundWords}
+                missedWords={me.missedWords}
+                showMissedTab={me.missedWords.length > 0}
+                highlightedWord={highlightedWord}
+                onHighlightWord={handleHighlight}
+                findPercents={findPercents}
+                popularityStyle={popularityStyle}
               />
             )}
           </div>

--- a/client/src/shared/results/components/Placeholders.tsx
+++ b/client/src/shared/results/components/Placeholders.tsx
@@ -30,22 +30,14 @@ export function Placeholders({
   compact = false,
   compareSourceLabel = 'standings',
 }: PlaceholdersProps = {}) {
-  if (compact && variant === 'share') {
-    return (
-      <div className="flex flex-col gap-2 h-full min-h-0">
-        <div
-          className="w-full min-h-0"
-          style={{ flex: '1 1 0' }}
-        >
-          {definitionSlot ?? <DefinitionsPlaceholder />}
-        </div>
-        <SharePrompt onShare={onShare} compact />
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-2 h-full min-h-0">
+      <div
+        className="w-full min-h-0"
+        style={{ flex: '1 1 0' }}
+      >
+        {definitionSlot ?? <DefinitionsPlaceholder />}
+      </div>
       {variant === 'share' ? (
         <SharePrompt onShare={onShare} compact={compact} />
       ) : variant === 'wait' ? (
@@ -53,13 +45,6 @@ export function Placeholders({
       ) : (
         <ComparePrompt compact={compact} sourceLabel={compareSourceLabel} />
       )}
-
-      <div
-        className="w-full min-h-0"
-        style={{ flex: '1 1 0' }}
-      >
-        {definitionSlot ?? <DefinitionsPlaceholder />}
-      </div>
     </div>
   );
 }
@@ -76,8 +61,8 @@ function ComparePrompt({
       className={`w-full flex flex-col items-center justify-center text-center rounded-xl text-[color:var(--ink-muted)] min-h-0 ${compact ? 'px-2 py-2' : 'px-3 py-3'}`}
       style={{
         flex: '2 1 0',
-        border: '1.5px dashed var(--opp-accent)',
-        background: 'var(--opp-accent-soft)',
+        border: compact ? '1.5px dashed var(--ink-faint)' : '1.5px dashed var(--opp-accent)',
+        background: compact ? 'transparent' : 'var(--opp-accent-soft)',
       }}
     >
       <div className="flex items-center gap-1 mb-1.5" aria-hidden>
@@ -106,8 +91,8 @@ function WaitPrompt({ compact = false }: { compact?: boolean }) {
       className={`w-full flex flex-col items-center justify-center text-center rounded-xl text-[color:var(--ink-muted)] min-h-0 ${compact ? 'px-2 py-2' : 'px-3 py-3'}`}
       style={{
         flex: '2 1 0',
-        border: '1.5px dashed var(--opp-accent)',
-        background: 'var(--opp-accent-soft)',
+        border: compact ? '1.5px dashed var(--ink-faint)' : '1.5px dashed var(--opp-accent)',
+        background: compact ? 'transparent' : 'var(--opp-accent-soft)',
       }}
     >
       <div className="flex items-center gap-1 mb-1.5" aria-hidden>

--- a/client/src/shared/results/components/ResultsHero.tsx
+++ b/client/src/shared/results/components/ResultsHero.tsx
@@ -117,12 +117,13 @@ function VersusHero({
       style={{ gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)' }}
     >
       <VersusCard
-        side="you"
-        name="You"
-        score={me.points}
-        wordCount={me.wordCount}
-        rank={myRank}
-        isWinner={youWins}
+        side="opp"
+        name={opponent.displayName}
+        initial={oppInitial}
+        score={opponent.points}
+        wordCount={opponent.wordCount}
+        rank={oppRank}
+        isWinner={oppWins}
         align="left"
         compact={compact}
       />
@@ -141,13 +142,12 @@ function VersusHero({
         </span>
       </div>
       <VersusCard
-        side="opp"
-        name={opponent.displayName}
-        initial={oppInitial}
-        score={opponent.points}
-        wordCount={opponent.wordCount}
-        rank={oppRank}
-        isWinner={oppWins}
+        side="you"
+        name="You"
+        score={me.points}
+        wordCount={me.wordCount}
+        rank={myRank}
+        isWinner={youWins}
         align="right"
         compact={compact}
       />
@@ -177,7 +177,6 @@ function VersusCard({
   compact: boolean;
 }) {
   const accent = side === 'you' ? 'var(--you-accent)' : 'var(--opp-accent)';
-  const showInitial = initial !== undefined;
   const initialChar = side === 'you' ? 'Y' : initial ?? '?';
   // Two distinct winner palettes — viewer-side wins use a blue tint so
   // the highlight never collides with the opponent's tan accent on the
@@ -229,9 +228,7 @@ function VersusCard({
           {name}
         </span>
         {align === 'left' && <RankBadge rank={rank} />}
-        {align === 'right' && showInitial && (
-          <Initial char={initialChar} accent={accent} />
-        )}
+        {align === 'right' && <Initial char={initialChar} accent={accent} />}
       </div>
       <div className="inline-flex items-baseline gap-1 mt-1 leading-none">
         <span


### PR DESCRIPTION
## What
Mirror the unified results view so the viewer's content is always on the right column — `WordsCard` in solo, the You `WordList` in compare — with the opponent / share / compare / wait placeholder on the left. `VersusHero` swaps to match (opponent left, you right). `Placeholders` now always renders the Definitions slot on top with the prompt below, and `ComparePrompt`/`WaitPrompt` pick up the same softened compact treatment (`--ink-faint` dashed border, transparent background) that `SharePrompt` already used.

## Why
The old layout put the word list on the left half in solo, which felt cramped and was harder to scroll with the right thumb. Anchoring "you" on the right keeps the column you scan most under your thumb and keeps it positionally stable when toggling an opponent in. Unifying the placeholder order removes a visual inconsistency between solo and compare states.

## Follow-ups
No results-page fixture exists yet, so this was verified by `tsc` only. Worth eyeballing solo (free play + daily first-to-finish), compare from a free-play challenge, and compare from the daily leaderboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)