### PR TITLE
feat(results): tint board preview cells with the word's rarity color

### DIFF
--- a/client/src/pages/results/ResultsRoute.tsx
+++ b/client/src/pages/results/ResultsRoute.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useGame } from '../../GameContext';
 import { ResultsView } from '../../shared/results/ResultsView';
 import type { ResultsRosterEntry } from '../../shared/results/types';
@@ -7,8 +7,18 @@ import { encodeGameLink } from '../../shared/utils/gameLink';
 import { createFreePlayChallenge } from '../../shared/api/gameApi';
 import { useShareText } from './hooks/useShareText';
 import { ActionButton } from '../../shared/results/components/ActionButton';
+import { RESULTS_FIXTURES } from './__fixtures__';
 
 export function ResultsRoute() {
+  const [searchParams] = useSearchParams();
+  const mock = searchParams.get('mock');
+  if (import.meta.env.DEV && mock && RESULTS_FIXTURES[mock]) {
+    return <>{RESULTS_FIXTURES[mock]()}</>;
+  }
+  return <RealResultsRoute />;
+}
+
+function RealResultsRoute() {
   const {
     game,
     results,

--- a/client/src/pages/results/__fixtures__/index.tsx
+++ b/client/src/pages/results/__fixtures__/index.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from 'react';
+import { ResultsView } from '../../../shared/results/ResultsView';
+import type {
+  LoadOpponentResult,
+  ResultsRosterEntry,
+} from '../../../shared/results/types';
+import type { ScoredWord } from '../../../shared/types';
+
+const BOARD_4x4: string[][] = [
+  ['T', 'R', 'A', 'P'],
+  ['E', 'S', 'O', 'L'],
+  ['N', 'I', 'D', 'E'],
+  ['G', 'H', 'A', 'M'],
+];
+
+// Mock words spanning every rarity tier so the board preview animation
+// exercises each rarity color when the cells are tapped.
+const ME_WORDS: ScoredWord[] = [
+  { word: 'TEAR', score: 2, path: [
+    { row: 0, col: 0 }, { row: 1, col: 0 }, { row: 0, col: 2 }, { row: 1, col: 1 },
+  ]},
+  { word: 'STORE', score: 3, path: [
+    { row: 1, col: 1 }, { row: 0, col: 1 }, { row: 0, col: 2 }, { row: 1, col: 2 }, { row: 1, col: 0 },
+  ]},
+  { word: 'STREAM', score: 5, path: [
+    { row: 1, col: 1 }, { row: 0, col: 1 }, { row: 0, col: 0 }, { row: 1, col: 0 }, { row: 0, col: 2 }, { row: 3, col: 3 },
+  ]},
+  { word: 'PARSED', score: 8, path: [
+    { row: 0, col: 3 }, { row: 0, col: 2 }, { row: 0, col: 1 }, { row: 1, col: 1 }, { row: 0, col: 0 }, { row: 2, col: 2 },
+  ]},
+  { word: 'MIDDLES', score: 13, path: [
+    { row: 3, col: 3 }, { row: 2, col: 1 }, { row: 2, col: 2 }, { row: 2, col: 2 }, { row: 1, col: 3 }, { row: 2, col: 3 }, { row: 1, col: 1 },
+  ]},
+  { word: 'NIT', score: 1, path: [
+    { row: 2, col: 0 }, { row: 2, col: 1 }, { row: 0, col: 0 },
+  ]},
+];
+
+const MISSED_WORDS: ScoredWord[] = [
+  { word: 'PRESIDED', score: 13, path: [] },
+];
+
+const ROSTER: ResultsRosterEntry[] = [
+  { id: 'you', rank: 1, displayName: 'You', points: 32, isYou: true },
+  { id: 'op-1', rank: 2, displayName: 'Pat', points: 22, isYou: false },
+];
+
+async function loadOpponent(id: string): Promise<LoadOpponentResult> {
+  if (id !== 'op-1') return { ok: false, error: 'opponent-missing' };
+  return {
+    ok: true,
+    opponent: {
+      id: 'op-1',
+      displayName: 'Pat',
+      points: 22,
+      wordCount: 3,
+      foundWords: [
+        { word: 'TEAR', score: 2 },
+        { word: 'STORE', score: 3 },
+        { word: 'MIDDLES', score: 13 },
+      ],
+    },
+  };
+}
+
+export const RESULTS_FIXTURES: Record<string, () => ReactNode> = {
+  rarity: () => (
+    <ResultsView
+      me={{
+        displayName: 'You',
+        points: ME_WORDS.reduce((s, w) => s + w.score, 0),
+        wordCount: ME_WORDS.length,
+        foundWords: ME_WORDS,
+        missedWords: MISSED_WORDS,
+      }}
+      board={BOARD_4x4}
+      config={{ boardSize: 4, minWordLength: 3, timeLimit: 90 }}
+      roster={ROSTER}
+      loadOpponent={loadOpponent}
+      topbarLabel="MOCK"
+      topbarOnClose={() => {}}
+      topbarOnShare={() => {}}
+      bottomActions={<div className="h-10" />}
+    />
+  ),
+};

--- a/client/src/shared/results/ResultsView.tsx
+++ b/client/src/shared/results/ResultsView.tsx
@@ -5,6 +5,7 @@ import { IconAction } from '../components/IconAction';
 import { findWordPath } from '../utils/findWordPath';
 import { WordsCard } from '../../pages/results/components/WordsCard';
 import { WordDefinitionPanel } from '../../pages/results/components/WordDefinitionPanel';
+import { RARITY_VAR, wordRarity } from '../../pages/results/utils/wordRarity';
 import { Board } from './components/Board';
 import { ResultsHero } from './components/ResultsHero';
 import { Standings } from './components/Standings';
@@ -158,6 +159,19 @@ export function ResultsView({
     return comparePathByWord.get(highlightedWord) ?? null;
   }, [opponent, comparePathByWord, highlightedWord, highlightPath]);
 
+  // Tint the board's animated cells with the rarity color of the word being
+  // replayed, so the preview matches the rarity stripe in the word list. In
+  // compare mode either side may own the word but not both, so look in both.
+  const highlightColor = useMemo(() => {
+    if (!highlightedWord) return null;
+    const score =
+      me.foundWords.find((w) => w.word.toUpperCase() === highlightedWord)?.score ??
+      opponent?.foundWords.find((w) => w.word.toUpperCase() === highlightedWord)
+        ?.score;
+    if (!score || score <= 0) return null;
+    return RARITY_VAR[wordRarity(score)];
+  }, [highlightedWord, me.foundWords, opponent]);
+
   const youCompareRows = useMemo(
     () => (opponent ? alignedRows(me, opponent, 'you', highlightedWord) : null),
     [opponent, me, highlightedWord],
@@ -243,6 +257,7 @@ export function ResultsView({
             <Board
               board={board}
               highlightPath={activeHighlightPath}
+              highlightColor={highlightColor}
               config={config}
               compact
             />

--- a/client/src/shared/results/components/Board.tsx
+++ b/client/src/shared/results/components/Board.tsx
@@ -5,13 +5,23 @@ import type { ResultsBoardConfig } from '../types';
 interface BoardProps {
   board: string[][];
   highlightPath: Position[] | null;
+  /** CSS color (typically `var(--rarity-*)`) used to tint lit cells so the
+   *  animation echoes the rarity stripe of the word being replayed. When
+   *  null, lit cells fall back to the neutral ink palette. */
+  highlightColor?: string | null;
   config: ResultsBoardConfig;
   compact?: boolean;
 }
 
 const STEP_MS = 70;
 
-export function Board({ board, highlightPath, config, compact = false }: BoardProps) {
+export function Board({
+  board,
+  highlightPath,
+  highlightColor = null,
+  config,
+  compact = false,
+}: BoardProps) {
   const size = board.length;
   const [animatedCells, setAnimatedCells] = useState<Set<string>>(new Set());
 
@@ -41,16 +51,20 @@ export function Board({ board, highlightPath, config, compact = false }: BoardPr
         {board.map((row, r) =>
           row.map((letter, c) => {
             const lit = animatedCells.has(`${r},${c}`);
+            const litBackground = highlightColor
+              ? `color-mix(in srgb, ${highlightColor} 28%, transparent)`
+              : 'var(--ink-trace)';
+            const litBorder = highlightColor ?? 'var(--ink-mid)';
             return (
               <div
                 key={`${r}-${c}`}
                 className={`${compact ? 'rounded-[4px] text-[13px]' : 'rounded-[4px] text-sm'} flex items-center justify-center tabular-nums font-[family-name:var(--font-structure)] transition-[background,border-color,color] duration-150`}
                 style={{
                   fontWeight: 700,
-                  background: lit ? 'var(--ink-trace)' : 'var(--surface-card)',
+                  background: lit ? litBackground : 'var(--surface-card)',
                   borderWidth: '1px',
                   borderStyle: 'solid',
-                  borderColor: lit ? 'var(--ink-mid)' : 'var(--ink-border-subtle)',
+                  borderColor: lit ? litBorder : 'var(--ink-border-subtle)',
                   color: lit ? 'var(--ink)' : 'var(--ink-muted)',
                 }}
               >


### PR DESCRIPTION
## What
When a word is tapped on the results page, the cells that light up during the board-preview animation now use the word's rarity color (the same palette as the rarity stripe in the word list) instead of the neutral ink fill.

## Why
The preview already echoes the word being replayed — adding rarity color makes the rarity tier visible at a glance and reinforces the existing rarity language used elsewhere in the results UI. The tint uses `color-mix(... 28%, transparent)` for the background and the full rarity color for the border, so the lit-cell weight stays close to the old design and text contrast (`var(--ink)`) holds across themes.

## Follow-ups
- Adds a dev-only `?mock=rarity` fixture under `client/src/pages/results/__fixtures__/` (the pattern referenced by `client/CLAUDE.md` that didn't yet exist) — useful for any future results-page tweaks.
- Dark-mode contrast for the highest-saturation tiers (uncommon yellow especially) wasn't verified live — the design should be safe but worth a glance next time you're in dark mode.