### PR TITLE
feat(landing): player feedback form at bottom of home screen

### DIFF
--- a/client/src/pages/landing/LandingPage.tsx
+++ b/client/src/pages/landing/LandingPage.tsx
@@ -1,6 +1,7 @@
 import {
   AppHeader,
   DailyCard,
+  FeedbackButton,
   FreePlayCard,
   NextDailyHeader,
   ThemeTogglePill,
@@ -95,6 +96,8 @@ export function LandingPage({
             unread={freePlayUnread}
           />
         </div>
+
+        <FeedbackButton />
       </div>
     </div>
   );

--- a/client/src/pages/landing/components/FeedbackButton.tsx
+++ b/client/src/pages/landing/components/FeedbackButton.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'react';
+import { submitFeedback } from '../../../shared/api/gameApi';
+
+const MAX_LENGTH = 2000;
+
+type Phase = 'idle' | 'submitting' | 'success' | 'error';
+
+export function FeedbackButton() {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (open && phase === 'idle') {
+      // Focus on next tick so the modal mount animation doesn't get
+      // interrupted by the keyboard popping on mobile.
+      const t = setTimeout(() => textareaRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open, phase]);
+
+  const handleOpen = () => {
+    setMessage('');
+    setPhase('idle');
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = message.trim();
+    if (trimmed.length === 0 || phase === 'submitting') return;
+    setPhase('submitting');
+    const result = await submitFeedback(trimmed);
+    setPhase(result.ok ? 'success' : 'error');
+  };
+
+  const canSubmit = message.trim().length > 0 && phase !== 'submitting';
+
+  return (
+    <>
+      <div className="flex justify-center mt-4">
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="flex items-center gap-1.5 bg-transparent border-none cursor-pointer text-caption uppercase tracking-[0.12em] text-[color:var(--ink-soft)] font-[family-name:var(--font-structure)] px-3 py-2"
+          style={{ fontWeight: 600, WebkitTapHighlightColor: 'transparent' }}
+        >
+          <FeedbackIcon />
+          Send feedback
+        </button>
+      </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[150] flex items-center justify-center p-6 bg-black/40 backdrop-blur-md font-[family-name:var(--font-ui)]"
+          onClick={handleClose}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Send feedback"
+        >
+          <div
+            className="w-full max-w-[340px] rounded-2xl bg-[var(--surface-card)] shadow-[var(--shadow-card)] flex flex-col overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <header className="flex flex-col items-center pt-6 pb-4 px-6 border-b border-[var(--ink-border-subtle)]">
+              <div
+                className="text-title italic leading-none tracking-[-0.01em] font-[family-name:var(--font-display)] text-[color:var(--ink)]"
+                style={{ fontWeight: 600 }}
+              >
+                {phase === 'success' ? 'Thanks!' : 'Send feedback'}
+                <span className="inline-block w-[5px] h-[5px] rounded-full bg-[var(--logo-dot)] ml-[2px] align-baseline mb-[3px]" />
+              </div>
+            </header>
+
+            {phase === 'success' ? (
+              <div className="px-6 py-6 flex flex-col items-center gap-2">
+                <p className="text-body text-[color:var(--ink-muted)] text-center leading-relaxed">
+                  Your feedback was sent, thank you!
+                </p>
+              </div>
+            ) : (
+              <div className="px-6 py-5 flex flex-col gap-3">
+                <p className="text-small text-[color:var(--ink-soft)] leading-relaxed">
+                  I'd love to hear your feedback! If you have ideas or issues (or compliments) leave 'em here!
+                </p>
+                <textarea
+                  ref={textareaRef}
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value.slice(0, MAX_LENGTH))}
+                  disabled={phase === 'submitting'}
+                  placeholder="What's on your mind?"
+                  rows={5}
+                  className="w-full resize-none rounded-xl border border-[var(--ink-border-subtle)] bg-[var(--surface-panel)] text-[color:var(--ink)] placeholder:text-[color:var(--ink-faint)] text-body px-3 py-2.5 outline-none focus:border-[color:var(--ink-border)]"
+                  style={{ fontWeight: 400 }}
+                />
+                {phase === 'error' && (
+                  <p className="text-caption text-[color:var(--rarity-legendary)] leading-relaxed">
+                    Couldn&apos;t send that — try again in a moment.
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="px-6 py-4 border-t border-[var(--ink-border-subtle)] flex gap-2">
+              {phase === 'success' ? (
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="flex-1 rounded-xl py-3 text-sm border-none cursor-pointer bg-[var(--ink)] text-[color:var(--ink-inverse)] shadow-[var(--shadow-btn-primary)]"
+                  style={{ fontWeight: 700, WebkitTapHighlightColor: 'transparent' }}
+                >
+                  Close
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    disabled={phase === 'submitting'}
+                    className="flex-1 rounded-xl py-3 text-sm border border-[var(--ink-border-subtle)] cursor-pointer bg-transparent text-[color:var(--ink-muted)] disabled:opacity-50"
+                    style={{ fontWeight: 600, WebkitTapHighlightColor: 'transparent' }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={!canSubmit}
+                    className="flex-1 rounded-xl py-3 text-sm border-none cursor-pointer bg-[var(--ink)] text-[color:var(--ink-inverse)] shadow-[var(--shadow-btn-primary)] disabled:opacity-50"
+                    style={{ fontWeight: 700, WebkitTapHighlightColor: 'transparent' }}
+                  >
+                    {phase === 'submitting' ? 'Sending…' : 'Send'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function FeedbackIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+    </svg>
+  );
+}

--- a/client/src/pages/landing/components/index.ts
+++ b/client/src/pages/landing/components/index.ts
@@ -2,6 +2,7 @@ export { AppHeader } from "./AppHeader";
 export { ChangelogControl } from "./ChangelogControl";
 export { DailyCard } from "./DailyCard";
 export { ZenDailyCard } from "./ZenDailyCard";
+export { FeedbackButton } from "./FeedbackButton";
 export { FreePlayCard } from "./FreePlayCard";
 export { NextDailyHeader } from "./NextDailyHeader";
 export { ProfileAvatar } from "./ProfileAvatar";

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -780,6 +780,19 @@ export type UpdateProfileResult =
   | { ok: false; reason: 'locked'; lockedUntil: string | null }
   | { ok: false; reason: 'unknown' };
 
+export const submitFeedback = async (message: string): Promise<{ ok: boolean }> => {
+  try {
+    const response = await fetch(`${API_URL}/feedback`, {
+      method: 'POST',
+      headers: await sessionHeaders(),
+      body: JSON.stringify({ message }),
+    });
+    return { ok: response.ok };
+  } catch {
+    return { ok: false };
+  }
+};
+
 export const updateProfile = async (displayName: string): Promise<UpdateProfileResult> => {
   const response = await fetch(`${API_URL}/user/profile`, {
     method: 'PUT',

--- a/client/src/shared/changelog/entries/2026-05-17-feedback.tsx
+++ b/client/src/shared/changelog/entries/2026-05-17-feedback.tsx
@@ -1,0 +1,16 @@
+import type { ChangelogEntry } from '../types';
+
+const entry: ChangelogEntry = {
+  id: 'feedback-2026-05-17',
+  date: '2026-05-17',
+  kind: 'minor',
+  title: 'Send us feedback',
+  body: (
+    <p>
+      A <strong>Send feedback</strong> button now lives at the bottom of the
+      home screen. Ideas, bugs, compliments — I'll do my best to read it all!
+    </p>
+  ),
+};
+
+export default entry;

--- a/client/src/shared/changelog/entries/2026-05-17-feedback.tsx
+++ b/client/src/shared/changelog/entries/2026-05-17-feedback.tsx
@@ -4,7 +4,7 @@ const entry: ChangelogEntry = {
   id: 'feedback-2026-05-17',
   date: '2026-05-17',
   kind: 'minor',
-  title: 'Send us feedback',
+  title: 'Send feedback',
   body: (
     <p>
       A <strong>Send feedback</strong> button now lives at the bottom of the

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -53,8 +53,16 @@ export interface FreePlaySessionsTable {
   last_viewed_at: Date | null;
 }
 
+export interface FeedbackTable {
+  id: Generated<string>;
+  user_id: string | null;
+  message: string;
+  created_at: Generated<Date>;
+}
+
 export interface Database {
   daily_results: DailyResultsTable;
   daily_zen_results: DailyZenResultsTable;
   free_play_sessions: FreePlaySessionsTable;
+  feedback: FeedbackTable;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { dailyRouter } from './routes/daily.js';
 import { dailyZenRouter } from './routes/dailyZen.js';
 import { leaderboardRouter } from './routes/leaderboard.js';
 import { freeplayRouter } from './routes/freeplay.js';
+import { feedbackRouter } from './routes/feedback.js';
 import { versionRouter } from './routes/version.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -45,6 +46,7 @@ app.use(
 app.use('/api/game', gameRouter);
 app.use('/api/user', userRouter);
 app.use('/api/freeplay', freeplayRouter);
+app.use('/api/feedback', feedbackRouter);
 app.use('/api/daily/leaderboard', leaderboardRouter);
 app.use('/api/daily/zen', dailyZenRouter);
 app.use('/api/daily', dailyRouter);

--- a/server/routes/feedback.ts
+++ b/server/routes/feedback.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { getDb } from '../db/index.js';
+import { noStore } from '../httpCache.js';
+
+export const feedbackRouter = Router();
+
+const MAX_LENGTH = 2000;
+
+feedbackRouter.post('/', async (req, res) => {
+  const { message } = req.body ?? {};
+
+  if (typeof message !== 'string') {
+    return res.status(400).json({ error: 'message must be a string' });
+  }
+
+  const trimmed = message.trim();
+  if (trimmed.length === 0) {
+    return res.status(400).json({ error: 'message must not be empty' });
+  }
+  if (trimmed.length > MAX_LENGTH) {
+    return res.status(400).json({ error: `message must be ${MAX_LENGTH} characters or fewer` });
+  }
+
+  try {
+    const db = getDb();
+    await db
+      .insertInto('feedback')
+      .values({
+        user_id: req.userId ?? null,
+        message: trimmed,
+      })
+      .execute();
+
+    noStore(res);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Failed to save feedback:', err);
+    res.status(500).json({ error: 'Failed to save feedback' });
+  }
+});

--- a/supabase/migrations/20260516000003_create_feedback.sql
+++ b/supabase/migrations/20260516000003_create_feedback.sql
@@ -1,0 +1,15 @@
+-- Player feedback messages submitted from the landing page.
+-- user_id is nullable so anonymous visitors can submit without an account;
+-- when present it's the Supabase auth user id of the signed-in player.
+
+create table public.feedback (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid,
+  message text not null,
+  created_at timestamptz not null default now(),
+  constraint feedback_message_length check (
+    char_length(message) between 1 and 2000
+  )
+);
+
+create index idx_feedback_created_at on public.feedback(created_at desc);


### PR DESCRIPTION
## What
A "Send feedback" pill at the bottom of the landing page opens a modal with a textarea and posts to a new `POST /api/feedback` route, backed by a `feedback` table (user_id nullable for anonymous, 1–2000 char check). After submit, the modal swaps to a "Thanks!" confirmation. Adds a changelog entry announcing the feature.

## Why
Lowest-friction way to collect bug reports, ideas, and reactions in-product. Storing rows in Supabase keeps the data queryable without a third-party form.

## Follow-ups
- Migration applied locally — needs to be pushed to staging/prod.
- No moderation/rate-limiting yet; reconsider if abuse appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)