### PR TITLE
Add three-round daily gauntlet mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,13 @@ import { ResultsRoute, DailyResultsRoute } from './pages/results';
 import { LeaderboardRoute } from './pages/leaderboard';
 import { DailyConfirmRoute } from './pages/daily';
 import { ZenGameRoute, ZenResultsRoute, ZenLeaderboardRoute } from './pages/dailyZen';
+import {
+  GauntletHubRoute,
+  GauntletConfirmRoute,
+  GauntletPlayRoute,
+  GauntletRoundResultsRoute,
+  GauntletResultsRoute,
+} from './pages/dailyGauntlet';
 import { HistoryRoute, HistoricResultsRoute } from './pages/history';
 import { ChallengeRoute } from './pages/challenge';
 import './tailwind.css';
@@ -80,6 +87,11 @@ function App() {
         <Route path="/daily/zen/play" element={<ZenGameRoute />} />
         <Route path="/daily/zen/results" element={<ZenResultsRoute />} />
         <Route path="/daily/zen/leaderboard" element={<ZenLeaderboardRoute />} />
+        <Route path="/daily/gauntlet" element={<GauntletHubRoute />} />
+        <Route path="/daily/gauntlet/results" element={<GauntletResultsRoute />} />
+        <Route path="/daily/gauntlet/round/:round" element={<GauntletConfirmRoute />} />
+        <Route path="/daily/gauntlet/round/:round/play" element={<GauntletPlayRoute />} />
+        <Route path="/daily/gauntlet/round/:round/results" element={<GauntletRoundResultsRoute />} />
         <Route path="/history" element={<HistoryRoute />} />
         <Route path="/freeplay/results/:id" element={<HistoricResultsRoute />} />
         <Route path="/freeplay/challenge/:id" element={<ChallengeRoute />} />

--- a/client/src/pages/dailyGauntlet/GauntletConfirmPage.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletConfirmPage.tsx
@@ -38,7 +38,7 @@ export function GauntletConfirmPage({
 }: GauntletConfirmPageProps) {
   return (
     <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
-      <div className="w-full max-w-[380px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px]">
+      <div className="w-full max-w-[360px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px]">
         <div className="flex items-center pt-[18px]">
           <BackButton onClick={onBack} />
         </div>

--- a/client/src/pages/dailyGauntlet/GauntletConfirmPage.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletConfirmPage.tsx
@@ -1,6 +1,13 @@
 import type { GauntletRoundConfig } from 'models/gauntlet';
 import { InkButton } from '../../shared/components/InkButton';
 import { modifierBadge, modifierDescription, roundTitle } from './modifierDisplay';
+import {
+  BackButton,
+  BonusLetterCard,
+  ConfigCard,
+  ModifierCard,
+  ProgressDots,
+} from './components';
 
 interface GauntletConfirmPageProps {
   dateLabel: string;
@@ -15,13 +22,6 @@ interface GauntletConfirmPageProps {
   onSeeResult: () => void;
   onViewRoundResult: (index: number) => void;
   onBack: () => void;
-}
-
-function formatTimer(seconds: number): string {
-  if (!isFinite(seconds)) return '∞';
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}:${String(s).padStart(2, '0')}`;
 }
 
 export function GauntletConfirmPage({
@@ -71,16 +71,20 @@ export function GauntletConfirmPage({
             </div>
           </div>
 
-          <ModifierCard description={modifierDescription(config.modifier)} badge={modifierBadge(config.modifier)} />
+          <ModifierCard
+            description={modifierDescription(config.modifier)}
+            badge={modifierBadge(config.modifier)}
+          />
 
           {config.modifier.kind === 'hotLetter' && (
-            <BonusLetterCard
-              letter={config.modifier.letter}
-              multiplier={config.modifier.multiplier}
-            />
+            <BonusLetterCard letter={config.modifier.letter} />
           )}
 
-          <ConfigCard boardSize={config.boardSize} timeLimit={config.timeLimit} minWordLength={config.minWordLength} />
+          <ConfigCard
+            boardSize={config.boardSize}
+            timeLimit={config.timeLimit}
+            minWordLength={config.minWordLength}
+          />
 
           <p className="text-small text-[color:var(--ink-muted)] text-center leading-[1.5]">
             {alreadyEnded
@@ -98,189 +102,5 @@ export function GauntletConfirmPage({
         </div>
       </div>
     </div>
-  );
-}
-
-function ProgressDots({
-  current,
-  total,
-  completedRounds,
-  onViewRoundResult,
-}: {
-  current: number;
-  total: number;
-  completedRounds: number[];
-  onViewRoundResult: (index: number) => void;
-}) {
-  const doneSet = new Set(completedRounds);
-  return (
-    <div
-      className="flex items-center justify-center gap-2"
-      aria-label={`Round ${current + 1} of ${total}`}
-    >
-      {Array.from({ length: total }, (_, i) => {
-        const done = doneSet.has(i);
-        const active = i === current;
-        // Past rounds are tappable — they go to that round's result page so
-        // the player can revisit their words without aborting the run.
-        if (done && !active) {
-          return (
-            <button
-              key={`r${i}`}
-              type="button"
-              onClick={() => onViewRoundResult(i)}
-              aria-label={`See round ${i + 1} result`}
-              className="block h-1.5 w-4 rounded-full bg-[var(--ink)] transition-transform duration-150 hover:scale-y-150 cursor-pointer border-none p-0"
-              style={{ WebkitTapHighlightColor: 'transparent' }}
-            />
-          );
-        }
-        return (
-          <span
-            key={`r${i}`}
-            className={`block h-1.5 rounded-full transition-colors duration-200 ${
-              active ? 'w-8 bg-[var(--accent)]' : 'w-4 bg-[var(--track)]'
-            }`}
-            aria-hidden
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-// Today's-specifics for the bonus round. The card itself uses the
-// neutral surface tokens (so it contrasts cleanly in both light and dark
-// themes), and the tile inside renders in the full hot-letter palette —
-// same lavender backdrop + edges the player sees on the in-game board.
-// That way the tile here is the visual anchor: "this is what to hunt
-// for, and this is exactly how it'll look".
-function BonusLetterCard({ letter, multiplier }: { letter: string; multiplier: number }) {
-  return (
-    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-4 flex items-center justify-between gap-3">
-      <div className="flex flex-col">
-        <span
-          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
-          style={{ fontWeight: 700 }}
-        >
-          Today's bonus letter
-        </span>
-        <span
-          className="text-base mt-0.5 text-[color:var(--ink)]"
-          style={{ fontWeight: 700 }}
-        >
-          Words with it score {multiplier}×
-        </span>
-      </div>
-      <div
-        className="flex items-center justify-center rounded-xl"
-        style={{
-          width: 56,
-          height: 56,
-          backgroundColor: 'var(--hot-letter-bg)',
-          color: 'var(--hot-letter-fg)',
-          fontFamily: 'var(--font-cell)',
-          fontWeight: 800,
-          fontSize: '2rem',
-          boxShadow:
-            '0 3px 0 0 var(--hot-letter-edge), 0 4px 0 0 var(--hot-letter-edge-deep), 0 6px 10px var(--hot-letter-glow)',
-        }}
-        aria-label={`Bonus letter ${letter}`}
-      >
-        {letter}
-      </div>
-    </div>
-  );
-}
-
-function ModifierCard({ description, badge }: { description: string; badge: string }) {
-  return (
-    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-4">
-      <div className="flex items-center justify-between mb-2">
-        <span
-          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
-          style={{ fontWeight: 700 }}
-        >
-          Scoring rule
-        </span>
-        <span
-          className="text-caption text-[color:var(--accent)] font-[family-name:var(--font-structure)]"
-          style={{ fontWeight: 700 }}
-        >
-          {badge}
-        </span>
-      </div>
-      <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0">{description}</p>
-    </div>
-  );
-}
-
-function ConfigCard({
-  boardSize,
-  timeLimit,
-  minWordLength,
-}: {
-  boardSize: number;
-  timeLimit: number;
-  minWordLength: number;
-}) {
-  return (
-    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
-      <div className="grid grid-cols-3 px-3 py-3">
-        <ConfigItem label="Board" value={`${boardSize}×${boardSize}`} divider />
-        <ConfigItem label="Time" value={formatTimer(timeLimit)} divider />
-        <ConfigItem label="Letters" value={String(minWordLength)} />
-      </div>
-    </div>
-  );
-}
-
-function ConfigItem({ label, value, divider }: { label: string; value: string; divider?: boolean }) {
-  return (
-    <div className="relative text-center py-1 px-2">
-      <div
-        className="text-label-xs uppercase tracking-[0.06em] text-[color:var(--ink-soft)] leading-none mb-1.5"
-        style={{ fontWeight: 600 }}
-      >
-        {label}
-      </div>
-      <div
-        className="text-xl leading-none tabular-nums tracking-[-0.01em] text-[color:var(--ink)]"
-        style={{ fontWeight: 700 }}
-      >
-        {value}
-      </div>
-      {divider && (
-        <span
-          aria-hidden
-          className="absolute right-0 top-[15%] bottom-[15%] w-px bg-[var(--ink-border-subtle)]"
-        />
-      )}
-    </div>
-  );
-}
-
-function BackButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group flex items-center gap-1.5 bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
-      style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
-    >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M15 18l-6-6 6-6" />
-      </svg>
-      Back
-    </button>
   );
 }

--- a/client/src/pages/dailyGauntlet/GauntletConfirmPage.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletConfirmPage.tsx
@@ -1,0 +1,286 @@
+import type { GauntletRoundConfig } from 'models/gauntlet';
+import { InkButton } from '../../shared/components/InkButton';
+import { modifierBadge, modifierDescription, roundTitle } from './modifierDisplay';
+
+interface GauntletConfirmPageProps {
+  dateLabel: string;
+  puzzleNumber: number;
+  totalRounds: number;
+  config: GauntletRoundConfig;
+  /** Indices of rounds already finished. Used to make their progress
+   *  dots tappable so mid-gauntlet players can revisit prior results. */
+  completedRounds: number[];
+  alreadyEnded: boolean;
+  onStart: () => void;
+  onSeeResult: () => void;
+  onViewRoundResult: (index: number) => void;
+  onBack: () => void;
+}
+
+function formatTimer(seconds: number): string {
+  if (!isFinite(seconds)) return '∞';
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export function GauntletConfirmPage({
+  dateLabel,
+  puzzleNumber,
+  totalRounds,
+  config,
+  completedRounds,
+  alreadyEnded,
+  onStart,
+  onSeeResult,
+  onViewRoundResult,
+  onBack,
+}: GauntletConfirmPageProps) {
+  return (
+    <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
+      <div className="w-full max-w-[380px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px]">
+        <div className="flex items-center pt-[18px]">
+          <BackButton onClick={onBack} />
+        </div>
+
+        <div className="flex-1 flex flex-col justify-center gap-[24px] px-1 mt-2">
+          <div className="text-center">
+            <div
+              className="text-caption uppercase tracking-[0.08em] text-[color:var(--ink-soft)] leading-none mb-3 font-[family-name:var(--font-structure)]"
+              style={{ fontWeight: 700 }}
+            >
+              {dateLabel} · Gauntlet #{puzzleNumber}
+            </div>
+            <ProgressDots
+              current={config.index}
+              total={totalRounds}
+              completedRounds={completedRounds}
+              onViewRoundResult={onViewRoundResult}
+            />
+            <div
+              className="text-display-sm italic leading-[1.1] tracking-[-0.015em] font-[family-name:var(--font-display)] mt-3"
+              style={{ fontWeight: 500 }}
+            >
+              {roundTitle(config.kind)}
+            </div>
+            <div
+              className="mt-1 text-caption uppercase tracking-[0.08em] text-[color:var(--ink-soft)] font-[family-name:var(--font-structure)]"
+              style={{ fontWeight: 700 }}
+            >
+              Round {config.index + 1} of {totalRounds}
+            </div>
+          </div>
+
+          <ModifierCard description={modifierDescription(config.modifier)} badge={modifierBadge(config.modifier)} />
+
+          {config.modifier.kind === 'hotLetter' && (
+            <BonusLetterCard
+              letter={config.modifier.letter}
+              multiplier={config.modifier.multiplier}
+            />
+          )}
+
+          <ConfigCard boardSize={config.boardSize} timeLimit={config.timeLimit} minWordLength={config.minWordLength} />
+
+          <p className="text-small text-[color:var(--ink-muted)] text-center leading-[1.5]">
+            {alreadyEnded
+              ? "You've already finished this round."
+              : 'One attempt. The timer starts when you tap start.'}
+          </p>
+
+          <div className="flex flex-col gap-1">
+            {alreadyEnded ? (
+              <InkButton onClick={onSeeResult}>Results</InkButton>
+            ) : (
+              <InkButton onClick={onStart}>Start</InkButton>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProgressDots({
+  current,
+  total,
+  completedRounds,
+  onViewRoundResult,
+}: {
+  current: number;
+  total: number;
+  completedRounds: number[];
+  onViewRoundResult: (index: number) => void;
+}) {
+  const doneSet = new Set(completedRounds);
+  return (
+    <div
+      className="flex items-center justify-center gap-2"
+      aria-label={`Round ${current + 1} of ${total}`}
+    >
+      {Array.from({ length: total }, (_, i) => {
+        const done = doneSet.has(i);
+        const active = i === current;
+        // Past rounds are tappable — they go to that round's result page so
+        // the player can revisit their words without aborting the run.
+        if (done && !active) {
+          return (
+            <button
+              key={`r${i}`}
+              type="button"
+              onClick={() => onViewRoundResult(i)}
+              aria-label={`See round ${i + 1} result`}
+              className="block h-1.5 w-4 rounded-full bg-[var(--ink)] transition-transform duration-150 hover:scale-y-150 cursor-pointer border-none p-0"
+              style={{ WebkitTapHighlightColor: 'transparent' }}
+            />
+          );
+        }
+        return (
+          <span
+            key={`r${i}`}
+            className={`block h-1.5 rounded-full transition-colors duration-200 ${
+              active ? 'w-8 bg-[var(--accent)]' : 'w-4 bg-[var(--track)]'
+            }`}
+            aria-hidden
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// Today's-specifics for the bonus round. The card itself uses the
+// neutral surface tokens (so it contrasts cleanly in both light and dark
+// themes), and the tile inside renders in the full hot-letter palette —
+// same lavender backdrop + edges the player sees on the in-game board.
+// That way the tile here is the visual anchor: "this is what to hunt
+// for, and this is exactly how it'll look".
+function BonusLetterCard({ letter, multiplier }: { letter: string; multiplier: number }) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-4 flex items-center justify-between gap-3">
+      <div className="flex flex-col">
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          Today's bonus letter
+        </span>
+        <span
+          className="text-base mt-0.5 text-[color:var(--ink)]"
+          style={{ fontWeight: 700 }}
+        >
+          Words with it score {multiplier}×
+        </span>
+      </div>
+      <div
+        className="flex items-center justify-center rounded-xl"
+        style={{
+          width: 56,
+          height: 56,
+          backgroundColor: 'var(--hot-letter-bg)',
+          color: 'var(--hot-letter-fg)',
+          fontFamily: 'var(--font-cell)',
+          fontWeight: 800,
+          fontSize: '2rem',
+          boxShadow:
+            '0 3px 0 0 var(--hot-letter-edge), 0 4px 0 0 var(--hot-letter-edge-deep), 0 6px 10px var(--hot-letter-glow)',
+        }}
+        aria-label={`Bonus letter ${letter}`}
+      >
+        {letter}
+      </div>
+    </div>
+  );
+}
+
+function ModifierCard({ description, badge }: { description: string; badge: string }) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-4">
+      <div className="flex items-center justify-between mb-2">
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          Scoring rule
+        </span>
+        <span
+          className="text-caption text-[color:var(--accent)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          {badge}
+        </span>
+      </div>
+      <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0">{description}</p>
+    </div>
+  );
+}
+
+function ConfigCard({
+  boardSize,
+  timeLimit,
+  minWordLength,
+}: {
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+}) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
+      <div className="grid grid-cols-3 px-3 py-3">
+        <ConfigItem label="Board" value={`${boardSize}×${boardSize}`} divider />
+        <ConfigItem label="Time" value={formatTimer(timeLimit)} divider />
+        <ConfigItem label="Letters" value={String(minWordLength)} />
+      </div>
+    </div>
+  );
+}
+
+function ConfigItem({ label, value, divider }: { label: string; value: string; divider?: boolean }) {
+  return (
+    <div className="relative text-center py-1 px-2">
+      <div
+        className="text-label-xs uppercase tracking-[0.06em] text-[color:var(--ink-soft)] leading-none mb-1.5"
+        style={{ fontWeight: 600 }}
+      >
+        {label}
+      </div>
+      <div
+        className="text-xl leading-none tabular-nums tracking-[-0.01em] text-[color:var(--ink)]"
+        style={{ fontWeight: 700 }}
+      >
+        {value}
+      </div>
+      {divider && (
+        <span
+          aria-hidden
+          className="absolute right-0 top-[15%] bottom-[15%] w-px bg-[var(--ink-border-subtle)]"
+        />
+      )}
+    </div>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex items-center gap-1.5 bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
+      style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 18l-6-6 6-6" />
+      </svg>
+      Back
+    </button>
+  );
+}

--- a/client/src/pages/dailyGauntlet/GauntletConfirmRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletConfirmRoute.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { GauntletRoundConfig } from 'models/gauntlet';
+import { GAUNTLET_ROUND_COUNT } from 'models/gauntlet';
+import { useGame } from '../../GameContext';
+import { GauntletConfirmPage } from './GauntletConfirmPage';
+import {
+  fetchGauntletStatus,
+  fetchGauntletPreview,
+  startGauntletRound,
+} from '../../shared/api/gauntletApi';
+
+function formatLongDate(dateIso: string): string {
+  const d = new Date(dateIso + 'T12:00:00');
+  const weekday = d.toLocaleString('en-US', { weekday: 'long' });
+  const month = d.toLocaleString('en-US', { month: 'long' });
+  return `${weekday} · ${month} ${d.getDate()}`;
+}
+
+export function GauntletConfirmRoute() {
+  const { round } = useParams<{ round: string }>();
+  const navigate = useNavigate();
+  const { authReady } = useGame();
+  const roundIndex = Number(round);
+  const [config, setConfig] = useState<GauntletRoundConfig | null>(null);
+  const [date, setDate] = useState<string | null>(null);
+  const [puzzleNumber, setPuzzleNumber] = useState<number>(0);
+  const [alreadyEnded, setAlreadyEnded] = useState(false);
+  const [locked, setLocked] = useState(false);
+  const [completedRounds, setCompletedRounds] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!authReady || !Number.isFinite(roundIndex)) return;
+    let cancelled = false;
+    (async () => {
+      const status = await fetchGauntletStatus();
+      if (cancelled) return;
+      setDate(status.date);
+      setPuzzleNumber(status.puzzleNumber);
+      setCompletedRounds(
+        status.entry.rounds
+          .map((r, i) => (r?.endedAt ? i : -1))
+          .filter((i) => i >= 0),
+      );
+
+      const summary = status.entry.rounds[roundIndex];
+      if (summary?.endedAt) {
+        setAlreadyEnded(true);
+      }
+
+      // Round is playable if it's the next round (or already in progress).
+      // Otherwise it's locked behind earlier rounds.
+      if (status.nextRoundIndex !== null && status.nextRoundIndex < roundIndex && !summary) {
+        setLocked(true);
+      }
+
+      // Prefer the live modifier from the user's started round (it carries
+      // the picked hot letter and any chosen values). Fall back to the
+      // upcoming-config from the hub, then to a fresh preview if neither
+      // is available (deep-link without prior status fetch).
+      if (summary) {
+        setConfig({
+          index: summary.index,
+          kind: summary.kind,
+          boardSize: summary.boardSize,
+          timeLimit: summary.timeLimit,
+          minWordLength: summary.minWordLength,
+          modifier: summary.modifier,
+        });
+        return;
+      }
+      const upcoming = status.upcomingConfigs[roundIndex];
+      if (upcoming) {
+        setConfig(upcoming);
+        return;
+      }
+      try {
+        const preview = await fetchGauntletPreview(status.date);
+        if (!cancelled) setConfig(preview.rounds[roundIndex]?.config ?? null);
+      } catch {
+        // leave config null; loading state stays
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, roundIndex]);
+
+  if (locked) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] text-small text-[color:var(--ink-muted)] p-6 text-center">
+        Finish the earlier rounds first.
+      </div>
+    );
+  }
+
+  if (!config || !date) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]" />
+    );
+  }
+
+  const handleStart = async () => {
+    const result = await startGauntletRound(date, roundIndex);
+    if ('error' in result) {
+      // Server-side gate caught a stale UI state. Bounce to hub so the
+      // user can see why.
+      navigate('/daily/gauntlet');
+      return;
+    }
+    navigate(`/daily/gauntlet/round/${roundIndex}/play`);
+  };
+
+  return (
+    <GauntletConfirmPage
+      dateLabel={formatLongDate(date)}
+      puzzleNumber={puzzleNumber}
+      totalRounds={GAUNTLET_ROUND_COUNT}
+      config={config}
+      completedRounds={completedRounds}
+      alreadyEnded={alreadyEnded}
+      onStart={handleStart}
+      onSeeResult={() => navigate(`/daily/gauntlet/round/${roundIndex}/results`)}
+      onViewRoundResult={(index) =>
+        navigate(`/daily/gauntlet/round/${index}/results`)
+      }
+      onBack={() => navigate('/')}
+    />
+  );
+}

--- a/client/src/pages/dailyGauntlet/GauntletHubPage.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletHubPage.tsx
@@ -1,0 +1,120 @@
+import type { GauntletRoundKind } from 'models/gauntlet';
+import { InkButton } from '../../shared/components/InkButton';
+import { roundTitle } from './modifierDisplay';
+
+interface GauntletHubPageProps {
+  dateLabel: string;
+  puzzleNumber: number;
+  roundKinds: GauntletRoundKind[];
+  onStart: () => void;
+  onBack: () => void;
+}
+
+// Intro screen for an unplayed gauntlet. Shows the three rounds the player
+// is about to face so the chain is legible up front, then hands off to
+// the first round's confirm page. Once the player has started any round,
+// they never see this screen again that day — the route auto-redirects.
+export function GauntletHubPage({
+  dateLabel,
+  puzzleNumber,
+  roundKinds,
+  onStart,
+  onBack,
+}: GauntletHubPageProps) {
+  return (
+    <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
+      <div className="w-full max-w-[420px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px]">
+        <div className="flex items-center pt-[18px]">
+          <BackButton onClick={onBack} />
+        </div>
+
+        <div className="flex-1 flex flex-col justify-center gap-6">
+          <div className="text-center">
+            <div
+              className="text-caption uppercase tracking-[0.08em] text-[color:var(--ink-soft)] leading-none mb-3 font-[family-name:var(--font-structure)]"
+              style={{ fontWeight: 700 }}
+            >
+              {dateLabel} · Gauntlet #{puzzleNumber}
+            </div>
+            <div
+              className="text-display-sm italic leading-[1.1] tracking-[-0.015em] font-[family-name:var(--font-display)]"
+              style={{ fontWeight: 500 }}
+            >
+              Three rounds. One chain.
+            </div>
+            <p className="mt-3 text-small text-[color:var(--ink-muted)] leading-[1.5] mx-auto max-w-[300px]">
+              Each round has its own board, timer, and scoring twist. Play them in
+              order — your standing is the sum of your three ranks.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            {roundKinds.map((kind, index) => (
+              <RoundRow key={`r${index}`} index={index} kind={kind} />
+            ))}
+          </div>
+
+          <InkButton onClick={onStart}>Start gauntlet</InkButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoundRow({ index, kind }: { index: number; kind: GauntletRoundKind }) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-3 flex items-center gap-3">
+      <div
+        className="w-8 h-8 rounded-full flex items-center justify-center text-sm bg-[var(--track)] text-[color:var(--ink-soft)] flex-shrink-0 font-[family-name:var(--font-structure)]"
+        style={{ fontWeight: 700 }}
+      >
+        {index + 1}
+      </div>
+      <div className="min-w-0">
+        <div
+          className="text-base leading-tight font-[family-name:var(--font-structure)] text-[color:var(--ink)]"
+          style={{ fontWeight: 700 }}
+        >
+          {roundTitle(kind)}
+        </div>
+        <div className="text-caption text-[color:var(--ink-soft)]">{kindHint(kind)}</div>
+      </div>
+    </div>
+  );
+}
+
+function kindHint(kind: GauntletRoundKind): string {
+  switch (kind) {
+    case 'regular':
+      return 'Standard scoring, no twist';
+    case 'hotLetter':
+      return 'One letter scores 2×';
+    case 'rareLetters':
+      return 'Letters score by their value';
+  }
+}
+
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex items-center gap-1.5 bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
+      style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 18l-6-6 6-6" />
+      </svg>
+      Back
+    </button>
+  );
+}

--- a/client/src/pages/dailyGauntlet/GauntletHubPage.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletHubPage.tsx
@@ -24,7 +24,7 @@ export function GauntletHubPage({
 }: GauntletHubPageProps) {
   return (
     <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
-      <div className="w-full max-w-[420px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px]">
+      <div className="w-full max-w-[360px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px]">
         <div className="flex items-center pt-[18px]">
           <BackButton onClick={onBack} />
         </div>

--- a/client/src/pages/dailyGauntlet/GauntletHubPage.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletHubPage.tsx
@@ -1,6 +1,7 @@
 import type { GauntletRoundKind } from 'models/gauntlet';
 import { InkButton } from '../../shared/components/InkButton';
 import { roundTitle } from './modifierDisplay';
+import { BackButton } from './components';
 
 interface GauntletHubPageProps {
   dateLabel: string;
@@ -94,27 +95,3 @@ function kindHint(kind: GauntletRoundKind): string {
   }
 }
 
-function BackButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group flex items-center gap-1.5 bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
-      style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
-    >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M15 18l-6-6 6-6" />
-      </svg>
-      Back
-    </button>
-  );
-}

--- a/client/src/pages/dailyGauntlet/GauntletHubRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletHubRoute.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGame } from '../../GameContext';
+import { GauntletHubPage } from './GauntletHubPage';
+import {
+  fetchGauntletStatus,
+  type GauntletStatusResponse,
+} from '../../shared/api/gauntletApi';
+
+function formatLongDate(dateIso: string): string {
+  const d = new Date(dateIso + 'T12:00:00');
+  const weekday = d.toLocaleString('en-US', { weekday: 'long' });
+  const month = d.toLocaleString('en-US', { month: 'long' });
+  return `${weekday} · ${month} ${d.getDate()}`;
+}
+
+// /daily/gauntlet is a smart entry: it only shows the hub when the gauntlet
+// is *unplayed*. A partial gauntlet skips the hub and lands the player on
+// the next round's confirm; a completed gauntlet jumps to the aggregate
+// standings. This keeps the hub from being an unnecessary interstitial in
+// the play loop — the player sees it once on first entry and then moves
+// straight through rounds.
+export function GauntletHubRoute() {
+  const navigate = useNavigate();
+  const { authReady } = useGame();
+  const [status, setStatus] = useState<GauntletStatusResponse | null>(null);
+
+  useEffect(() => {
+    if (!authReady) return;
+    let cancelled = false;
+    fetchGauntletStatus()
+      .then((s) => {
+        if (cancelled) return;
+        if (s.entry.state === 'partial' && s.nextRoundIndex !== null) {
+          navigate(`/daily/gauntlet/round/${s.nextRoundIndex}`, { replace: true });
+          return;
+        }
+        if (s.entry.state === 'completed') {
+          navigate('/daily/gauntlet/results', { replace: true });
+          return;
+        }
+        setStatus(s);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, navigate]);
+
+  if (!status) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]" />
+    );
+  }
+
+  return (
+    <GauntletHubPage
+      dateLabel={formatLongDate(status.date)}
+      puzzleNumber={status.puzzleNumber}
+      roundKinds={status.roundKinds}
+      onStart={() => navigate('/daily/gauntlet/round/0')}
+      onBack={() => navigate('/')}
+    />
+  );
+}

--- a/client/src/pages/dailyGauntlet/GauntletPlayRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletPlayRoute.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { GameState, type Game, type Position } from 'models';
+import { HOT_LETTER_MULTIPLIER } from 'models/gauntlet';
 import { useGame } from '../../GameContext';
 import { GamePage } from '../game/GamePage';
 import { useFeedbackSounds, type FeedbackType } from '../game';
@@ -99,7 +100,7 @@ export function GauntletPlayRoute() {
       if (!modifier || modifier.kind !== 'hotLetter') return null;
       const upper = word.toUpperCase();
       if (!upper.includes(modifier.letter.toUpperCase())) return null;
-      return `${modifier.multiplier}×`;
+      return `${HOT_LETTER_MULTIPLIER}×`;
     },
     [],
   );

--- a/client/src/pages/dailyGauntlet/GauntletPlayRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletPlayRoute.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { GameState, type Game, type Position } from 'models';
+import { useGame } from '../../GameContext';
+import { GamePage } from '../game/GamePage';
+import { useFeedbackSounds, type FeedbackType } from '../game';
+import { useTimer } from '../../hooks/useTimer';
+import { useWordValidator } from '../../hooks/useWordValidator';
+import { scoreGauntletWord } from '../../shared/utils/gauntletScore';
+import { roundTitle } from './modifierDisplay';
+import type { CellDecoration } from '../game/components/Board';
+import {
+  endGauntletRound,
+  fetchGauntletRoundSession,
+  submitGauntletWord,
+  type GauntletRoundSession,
+} from '../../shared/api/gauntletApi';
+
+// Plays one round of the gauntlet. Mirrors the timed-daily play flow in
+// GameContext (synthesize Game from the persisted session, validate
+// locally for instant feedback, fire the server submit in the background)
+// but keeps its state local so GameContext doesn't grow a third copy of
+// the timed-session machinery.
+export function GauntletPlayRoute() {
+  const { round } = useParams<{ round: string }>();
+  const navigate = useNavigate();
+  const roundIndex = Number(round);
+  const { authReady, muted, toggleMute } = useGame();
+
+  const [session, setSession] = useState<GauntletRoundSession | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [feedback, setFeedback] = useState<
+    { type: FeedbackType; path: Position[]; bonus?: string | null } | null
+  >(null);
+  const sessionRef = useRef<GauntletRoundSession | null>(null);
+  const navigatingRef = useRef(false);
+
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+
+  // Initial session load. The confirm route should have already called
+  // startGauntletRound; if it didn't, the GET returns null and we bounce.
+  useEffect(() => {
+    if (!authReady || !Number.isFinite(roundIndex)) return;
+    let cancelled = false;
+    (async () => {
+      // Today's date for the gauntlet — derived from the system clock at
+      // the device. This is OK because the server enforces it via the
+      // session row (date column).
+      const today = new Date().toLocaleDateString('en-CA', {
+        timeZone: 'America/Los_Angeles',
+      });
+      const s = await fetchGauntletRoundSession(today, roundIndex);
+      if (cancelled) return;
+      setSession(s);
+      setLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, roundIndex]);
+
+  const validator = useWordValidator();
+  useEffect(() => {
+    validator.setSource(session?.salt ?? '', session?.wordHashes ?? []);
+  }, [session?.salt, session?.wordHashes, validator]);
+  useEffect(() => {
+    validator.setSubmitted(session?.foundWords ?? []);
+  }, [session?.foundWords, validator]);
+
+  const { playValid, playInvalid, playDuplicate } = useFeedbackSounds(0, 0, 2);
+
+  const flashFeedback = useCallback(
+    (path: Position[], outcome: { valid: boolean; reason?: string }, bonus?: string | null) => {
+      let type: FeedbackType;
+      if (outcome.valid) {
+        type = 'valid';
+        if (!muted) playValid();
+      } else if (outcome.reason === 'repeat') {
+        type = 'duplicate';
+        if (!muted) playDuplicate();
+      } else {
+        type = 'invalid';
+        if (!muted) playInvalid();
+      }
+      setFeedback({ type, path, bonus });
+      setTimeout(() => setFeedback(null), 200);
+    },
+    [muted, playValid, playInvalid, playDuplicate],
+  );
+
+  // Returns the bonus label to flash alongside a valid word, or null if
+  // the round has no per-word bonus. Hot-letter rounds show "Nx" when the
+  // word contains the hot letter; other rounds skip the badge.
+  const computeWordBonus = useCallback(
+    (word: string): string | null => {
+      const modifier = sessionRef.current?.modifier;
+      if (!modifier || modifier.kind !== 'hotLetter') return null;
+      const upper = word.toUpperCase();
+      if (!upper.includes(modifier.letter.toUpperCase())) return null;
+      return `${modifier.multiplier}×`;
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    async (path: Position[]) => {
+      const current = sessionRef.current;
+      if (!current || current.endedAt) return;
+
+      const word = path
+        .map((p) => current.board[p.row]?.[p.col] ?? '')
+        .join('')
+        .toUpperCase();
+
+      if (!validator.isArmed()) {
+        const outcome = await submitGauntletWord(current.date, roundIndex, path);
+        flashFeedback(path, outcome, outcome.valid && outcome.word ? computeWordBonus(outcome.word) : null);
+        if (outcome.valid && outcome.word) {
+          const score = outcome.score ?? scoreGauntletWord(outcome.word, current.modifier);
+          const nextWords = [...current.foundWords, outcome.word];
+          const nextLongest =
+            outcome.word.length > current.longestWord.length ? outcome.word : current.longestWord;
+          setSession({
+            ...current,
+            foundWords: nextWords,
+            points: current.points + score,
+            wordCount: nextWords.length,
+            longestWord: nextLongest,
+          });
+        }
+        return;
+      }
+
+      const local = validator.validate(word);
+      flashFeedback(path, local, local.valid ? computeWordBonus(word) : null);
+      if (!local.valid) return;
+
+      validator.recordSubmitted(word);
+      const score = scoreGauntletWord(word, current.modifier);
+      const nextWords = [...current.foundWords, word];
+      const nextLongest = word.length > current.longestWord.length ? word : current.longestWord;
+      setSession({
+        ...current,
+        foundWords: nextWords,
+        points: current.points + score,
+        wordCount: nextWords.length,
+        longestWord: nextLongest,
+      });
+
+      const fire = () => submitGauntletWord(current.date, roundIndex, path);
+      fire().catch(() => setTimeout(() => fire().catch(() => {}), 200));
+    },
+    [validator, roundIndex, flashFeedback],
+  );
+
+  const finalizeAndExit = useCallback(async () => {
+    const current = sessionRef.current;
+    if (!current) return;
+    if (navigatingRef.current) return;
+    navigatingRef.current = true;
+    if (!current.endedAt) {
+      const ended = await endGauntletRound(current.date, roundIndex);
+      if (ended) setSession(ended);
+    }
+    navigate(`/daily/gauntlet/round/${roundIndex}/results`);
+  }, [navigate, roundIndex]);
+
+  // Synthesize a Game shape so GamePage can render without changes. The
+  // Finished status flip is driven by ended_at the same way timed daily
+  // works in GameContext.
+  const game: Game | null = useMemo(() => {
+    if (!session) return null;
+    return {
+      board: session.board,
+      startedAt: new Date(session.startedAt).getTime(),
+      status: session.endedAt ? GameState.Finished : GameState.InProgress,
+      config: {
+        durationSeconds: session.config.timeLimit,
+        boardSize: session.config.boardSize,
+        minWordLength: session.config.minWordLength,
+      },
+    };
+  }, [session]);
+
+  const timeRemaining = useTimer(game, finalizeAndExit);
+
+  // Bounce-out conditions are deferred to an effect so they don't run
+  // during render — calling navigate() mid-render triggers React's
+  // "Cannot update a component while rendering a different component"
+  // warning (and made the results board preview misbehave on tap).
+  useEffect(() => {
+    if (!loaded) return;
+    if (!session) {
+      navigate(`/daily/gauntlet/round/${roundIndex}`, { replace: true });
+      return;
+    }
+    if (session.endedAt) {
+      navigate(`/daily/gauntlet/round/${roundIndex}/results`, { replace: true });
+    }
+  }, [loaded, session, roundIndex, navigate]);
+
+  // No session loaded yet, or we're about to bounce — keep render side-
+  // effect free (no setState during render). Loading placeholder covers
+  // the moment between the bounce-effect firing and the new route
+  // mounting.
+  if (!loaded || !session || session.endedAt) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]" />
+    );
+  }
+
+  if (!game || game.status !== GameState.InProgress) return null;
+
+  const modeLabel = `Gauntlet R${roundIndex + 1} · ${roundTitle(session.roundKind)}`;
+
+  return (
+    <GamePage
+      game={game}
+      words={[]}
+      timeRemaining={timeRemaining}
+      feedback={feedback}
+      onSubmitWord={handleSubmit}
+      onCancelGame={finalizeAndExit}
+      onEndGame={finalizeAndExit}
+      muted={muted}
+      onToggleMute={toggleMute}
+      modeLabel={modeLabel}
+      cellDecorations={buildCellDecorations(session)}
+    />
+  );
+}
+
+// Per-cell decorations for a gauntlet round. Encodes the modifier visually
+// on the board so the player doesn't need a separate header strip:
+//
+//   hotLetter   → accent ring on every cell whose letter matches the hot
+//                 pick (Qu tile matches if either char matches)
+//   rareLetters → score badge in bottom-right of every cell, Scrabble tile
+//                 style (Qu tile sums Q + U so the badge reflects the
+//                 actual contribution of the tile to a word)
+//   regular     → no decoration
+function buildCellDecorations(session: GauntletRoundSession) {
+  const modifier = session.modifier;
+  if (modifier.kind === 'regular') return undefined;
+  if (modifier.kind === 'hotLetter') {
+    const hot = modifier.letter.toUpperCase();
+    return (_row: number, _col: number, letter: string): CellDecoration | null => {
+      return letter.toUpperCase().includes(hot) ? { accent: 'hot' } : null;
+    };
+  }
+  // rareLetters: sum per-letter values in the cell string so a Qu tile
+  // shows the Q+U total — that's what the player gets when they use it.
+  return (_row: number, _col: number, letter: string): CellDecoration | null => {
+    let total = 0;
+    for (const ch of letter.toUpperCase()) total += modifier.values[ch] ?? 0;
+    if (total === 0) return null;
+    return { badge: total };
+  };
+}

--- a/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { GAUNTLET_ROUND_COUNT, type GauntletRoundSummary } from 'models/gauntlet';
 import { useGame } from '../../GameContext';
 import {
   fetchGauntletLeaderboard,
@@ -9,26 +8,11 @@ import {
   type GauntletStatusResponse,
 } from '../../shared/api/gauntletApi';
 import { InkButton } from '../../shared/components/InkButton';
-import { RankBadge, type PodiumRank } from '../landing/components/RankBadge';
-import { roundTitle } from './modifierDisplay';
-
-function podiumOf(rank: number | null | undefined): PodiumRank | null {
-  if (rank === 1 || rank === 2 || rank === 3) return rank;
-  return null;
-}
-
-// Maps a top-3 rank to its podium color. Used to tint the rank number in
-// the full standings table so the medal hierarchy is baked into the
-// number itself — no separate medal column nudging the name column.
-function podiumColor(rank: PodiumRank | null): string {
-  switch (rank) {
-    case 1: return 'var(--podium-gold)';
-    case 2: return 'var(--podium-silver)';
-    case 3: return 'var(--podium-bronze)';
-    case null:
-    default: return 'var(--ink)';
-  }
-}
+import {
+  RankSumExplainer,
+  RoundSummaryRow,
+  StandingsLeaderboard,
+} from './components';
 
 // Aggregate end screen. Shows the player's per-round ranks, the rank-sum
 // score, and how that placed them in today's gauntlet field. Each round
@@ -119,7 +103,7 @@ export function GauntletResultsRoute() {
 
         <div className="flex flex-col">
           {entry.rounds.map((summary, index) => (
-            <RoundRow
+            <RoundSummaryRow
               key={`agg-round-${index}`}
               index={index}
               summary={summary}
@@ -131,191 +115,9 @@ export function GauntletResultsRoute() {
         </div>
 
         {leaderboard && leaderboard.aggregate.length > 0 && (
-          <Leaderboard leaderboard={leaderboard} />
+          <StandingsLeaderboard leaderboard={leaderboard} />
         )}
       </div>
     </div>
-  );
-}
-
-function Leaderboard({ leaderboard }: { leaderboard: GauntletLeaderboardResponse }) {
-  const meId = leaderboard.currentUserId;
-  return (
-    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
-      <div
-        className="flex items-center justify-between px-3 py-[10px] text-label-xs uppercase tracking-[0.08em] text-[color:var(--ink-muted)] bg-[var(--ink-whisper)] font-[family-name:var(--font-structure)]"
-        style={{ fontWeight: 700 }}
-      >
-        <span>Full standings</span>
-        <span className="flex items-center gap-2 text-[color:var(--ink-faint)]">
-          {Array.from({ length: GAUNTLET_ROUND_COUNT }, (_, i) => (
-            <span key={`hdr-r${i}`} className="w-5 text-center">
-              R{i + 1}
-            </span>
-          ))}
-          <span className="w-9 text-right">Sum</span>
-        </span>
-      </div>
-      <div className="flex flex-col">
-        {leaderboard.aggregate.map((row) => {
-          const isMe = row.userId === meId;
-          const podium = podiumOf(row.aggregateRank);
-          return (
-            <div
-              key={row.userId}
-              className={[
-                'flex items-center justify-between px-3 py-[9px] text-small font-[family-name:var(--font-ui)] border-t border-[var(--ink-border-subtle)] first:border-t-0',
-                isMe ? 'bg-[var(--ink-whisper)]' : '',
-              ].join(' ')}
-              style={{ fontWeight: 500 }}
-            >
-              <div className="flex items-center gap-2 min-w-0">
-                <span
-                  className="tabular-nums w-7 font-[family-name:var(--font-structure)]"
-                  style={{ fontWeight: 700, color: podiumColor(podium) }}
-                >
-                  #{row.aggregateRank}
-                </span>
-                <span
-                  className={[
-                    'truncate',
-                    isMe ? 'text-[color:var(--ink)]' : 'text-[color:var(--ink-soft)]',
-                  ].join(' ')}
-                  style={{ fontWeight: isMe ? 700 : 500 }}
-                >
-                  {row.displayName}
-                  {isMe && (
-                    <span
-                      className="ml-1.5 text-caption text-[color:var(--accent)] font-[family-name:var(--font-structure)]"
-                      style={{ fontWeight: 700 }}
-                    >
-                      you
-                    </span>
-                  )}
-                </span>
-              </div>
-              <span className="flex items-center gap-2 text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-structure)]">
-                {row.roundRanks.map((rank, i) => (
-                  <span key={`r${i}`} className="w-5 text-center" style={{ fontWeight: 600 }}>
-                    {rank}
-                  </span>
-                ))}
-                <span
-                  className="w-9 text-right text-[color:var(--ink)]"
-                  style={{ fontWeight: 700 }}
-                >
-                  {row.rankSum}
-                </span>
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function RankSumExplainer() {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="w-full flex items-center justify-between px-3 py-2 bg-transparent border-none cursor-pointer text-left hover:bg-[var(--ink-whisper)] transition-colors duration-150 font-[family-name:var(--font-ui)]"
-        style={{ WebkitTapHighlightColor: 'transparent' }}
-      >
-        <span
-          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
-          style={{ fontWeight: 700 }}
-        >
-          How standings work
-        </span>
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={`text-[color:var(--ink-faint)] transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
-          aria-hidden
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </button>
-      {open && (
-        <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0 px-3 pb-3">
-          Each round is ranked on its own. Your gauntlet score is the sum of your three
-          round ranks — lowest wins. Crushing one round and stumbling in another can still
-          come out ahead.
-        </p>
-      )}
-    </div>
-  );
-}
-
-function RoundRow({
-  index,
-  summary,
-  onView,
-}: {
-  index: number;
-  summary: GauntletRoundSummary | null;
-  onView: () => void;
-}) {
-  // Single-line layout — round number + kind on the left, "#rank of N" on
-  // the right. Rows share a card so the trio reads as a unit instead of
-  // three discrete cards; the divider falls between rows.
-  const isFirst = index === 0;
-  const baseClasses =
-    'flex items-center justify-between gap-3 px-3 py-[10px] bg-[var(--surface-card)] border-x border-[var(--ink-border-subtle)] font-[family-name:var(--font-ui)]';
-  const positionClasses = `${isFirst ? 'border-t rounded-t-xl' : 'border-t-0'} ${
-    index === 2 ? 'border-b rounded-b-xl' : 'border-b-0'
-  }`;
-
-  if (!summary) {
-    return (
-      <div className={`${baseClasses} ${positionClasses} opacity-60 shadow-[var(--shadow-card)]`}>
-        <span className="text-small text-[color:var(--ink-muted)]">
-          Round {index + 1} · not played
-        </span>
-      </div>
-    );
-  }
-  const podium = podiumOf(summary.rank);
-  return (
-    <button
-      type="button"
-      onClick={onView}
-      className={`${baseClasses} ${positionClasses} cursor-pointer hover:bg-[var(--ink-whisper)] transition-colors duration-150 text-left shadow-[var(--shadow-card)]`}
-      style={{ WebkitTapHighlightColor: 'transparent' }}
-    >
-      <span className="min-w-0 flex items-center gap-2">
-        <span
-          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)] tabular-nums"
-          style={{ fontWeight: 700 }}
-        >
-          R{index + 1}
-        </span>
-        <span
-          className="text-small text-[color:var(--ink)] truncate font-[family-name:var(--font-structure)]"
-          style={{ fontWeight: 700 }}
-        >
-          {roundTitle(summary.kind)}
-        </span>
-        {podium && <RankBadge rank={podium} />}
-      </span>
-      <span
-        className="flex items-baseline gap-1.5 text-[color:var(--ink)] font-[family-name:var(--font-structure)] tabular-nums shrink-0"
-        style={{ fontWeight: 700 }}
-      >
-        <span className="text-base">#{summary.rank ?? '—'}</span>
-        <span className="text-caption text-[color:var(--ink-muted)]">of {summary.playersCount}</span>
-      </span>
-    </button>
   );
 }

--- a/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { GAUNTLET_ROUND_COUNT, type GauntletRoundSummary } from 'models/gauntlet';
+import { useGame } from '../../GameContext';
+import {
+  fetchGauntletLeaderboard,
+  fetchGauntletStatus,
+  type GauntletLeaderboardResponse,
+  type GauntletStatusResponse,
+} from '../../shared/api/gauntletApi';
+import { InkButton } from '../../shared/components/InkButton';
+import { RankBadge, type PodiumRank } from '../landing/components/RankBadge';
+import { roundTitle } from './modifierDisplay';
+
+function podiumOf(rank: number | null | undefined): PodiumRank | null {
+  if (rank === 1 || rank === 2 || rank === 3) return rank;
+  return null;
+}
+
+// Maps a top-3 rank to its podium color. Used to tint the rank number in
+// the full standings table so the medal hierarchy is baked into the
+// number itself — no separate medal column nudging the name column.
+function podiumColor(rank: PodiumRank | null): string {
+  switch (rank) {
+    case 1: return 'var(--podium-gold)';
+    case 2: return 'var(--podium-silver)';
+    case 3: return 'var(--podium-bronze)';
+    case null:
+    default: return 'var(--ink)';
+  }
+}
+
+// Aggregate end screen. Shows the player's per-round ranks, the rank-sum
+// score, and how that placed them in today's gauntlet field. Each round
+// row is click-through to the per-round results so the player can compare
+// words, see missed words, and re-read the modifier rule.
+export function GauntletResultsRoute() {
+  const navigate = useNavigate();
+  const { authReady } = useGame();
+  const [status, setStatus] = useState<GauntletStatusResponse | null>(null);
+  const [leaderboard, setLeaderboard] = useState<GauntletLeaderboardResponse | null>(null);
+
+  useEffect(() => {
+    if (!authReady) return;
+    let cancelled = false;
+    (async () => {
+      const [s, lb] = await Promise.all([
+        fetchGauntletStatus().catch(() => null),
+        fetchGauntletLeaderboard(
+          new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' }),
+        ).catch(() => null),
+      ]);
+      if (cancelled) return;
+      if (s) setStatus(s);
+      setLeaderboard(lb);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady]);
+
+  if (!status) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]" />
+    );
+  }
+
+  const { entry } = status;
+  if (entry.state !== 'completed') {
+    return (
+      <div className="fixed inset-0 flex flex-col items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] p-6 gap-4 text-center">
+        <p className="text-small text-[color:var(--ink-muted)]">
+          Finish all three rounds to see your gauntlet standings.
+        </p>
+        <InkButton onClick={() => navigate('/daily/gauntlet')}>Back to gauntlet</InkButton>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
+      <div className="w-full max-w-[420px] min-h-full flex flex-col px-[22px] pt-[12px] pb-[16px] gap-3">
+        <div className="flex items-center pt-[6px]">
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            className="bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
+            style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
+          >
+            ← Home
+          </button>
+        </div>
+
+        <div className="text-center">
+          <div
+            className="text-caption uppercase tracking-[0.08em] text-[color:var(--ink-soft)] leading-none mb-2 font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 700 }}
+          >
+            Gauntlet #{status.puzzleNumber} · Standings
+          </div>
+          <div
+            className="text-display-sm italic leading-[1.05] tracking-[-0.015em] font-[family-name:var(--font-display)]"
+            style={{ fontWeight: 500 }}
+          >
+            {entry.aggregateRank !== null ? `#${entry.aggregateRank}` : '—'}
+          </div>
+          <div className="mt-1 text-small text-[color:var(--ink-muted)]">
+            of {entry.totalPlayersCompleted.toLocaleString()} players · rank-sum{' '}
+            <span
+              className="font-[family-name:var(--font-structure)] text-[color:var(--ink)]"
+              style={{ fontWeight: 700 }}
+            >
+              {entry.aggregateRankSum ?? '—'}
+            </span>
+          </div>
+        </div>
+
+        <RankSumExplainer />
+
+        <div className="flex flex-col">
+          {entry.rounds.map((summary, index) => (
+            <RoundRow
+              key={`agg-round-${index}`}
+              index={index}
+              summary={summary}
+              onView={() =>
+                navigate(`/daily/gauntlet/round/${index}/results?from=standings`)
+              }
+            />
+          ))}
+        </div>
+
+        {leaderboard && leaderboard.aggregate.length > 0 && (
+          <Leaderboard leaderboard={leaderboard} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Leaderboard({ leaderboard }: { leaderboard: GauntletLeaderboardResponse }) {
+  const meId = leaderboard.currentUserId;
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
+      <div
+        className="flex items-center justify-between px-3 py-[10px] text-label-xs uppercase tracking-[0.08em] text-[color:var(--ink-muted)] bg-[var(--ink-whisper)] font-[family-name:var(--font-structure)]"
+        style={{ fontWeight: 700 }}
+      >
+        <span>Full standings</span>
+        <span className="flex items-center gap-2 text-[color:var(--ink-faint)]">
+          {Array.from({ length: GAUNTLET_ROUND_COUNT }, (_, i) => (
+            <span key={`hdr-r${i}`} className="w-5 text-center">
+              R{i + 1}
+            </span>
+          ))}
+          <span className="w-9 text-right">Sum</span>
+        </span>
+      </div>
+      <div className="flex flex-col">
+        {leaderboard.aggregate.map((row) => {
+          const isMe = row.userId === meId;
+          const podium = podiumOf(row.aggregateRank);
+          return (
+            <div
+              key={row.userId}
+              className={[
+                'flex items-center justify-between px-3 py-[9px] text-small font-[family-name:var(--font-ui)] border-t border-[var(--ink-border-subtle)] first:border-t-0',
+                isMe ? 'bg-[var(--ink-whisper)]' : '',
+              ].join(' ')}
+              style={{ fontWeight: 500 }}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span
+                  className="tabular-nums w-7 font-[family-name:var(--font-structure)]"
+                  style={{ fontWeight: 700, color: podiumColor(podium) }}
+                >
+                  #{row.aggregateRank}
+                </span>
+                <span
+                  className={[
+                    'truncate',
+                    isMe ? 'text-[color:var(--ink)]' : 'text-[color:var(--ink-soft)]',
+                  ].join(' ')}
+                  style={{ fontWeight: isMe ? 700 : 500 }}
+                >
+                  {row.displayName}
+                  {isMe && (
+                    <span
+                      className="ml-1.5 text-caption text-[color:var(--accent)] font-[family-name:var(--font-structure)]"
+                      style={{ fontWeight: 700 }}
+                    >
+                      you
+                    </span>
+                  )}
+                </span>
+              </div>
+              <span className="flex items-center gap-2 text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-structure)]">
+                {row.roundRanks.map((rank, i) => (
+                  <span key={`r${i}`} className="w-5 text-center" style={{ fontWeight: 600 }}>
+                    {rank}
+                  </span>
+                ))}
+                <span
+                  className="w-9 text-right text-[color:var(--ink)]"
+                  style={{ fontWeight: 700 }}
+                >
+                  {row.rankSum}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RankSumExplainer() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-3 py-2 bg-transparent border-none cursor-pointer text-left hover:bg-[var(--ink-whisper)] transition-colors duration-150 font-[family-name:var(--font-ui)]"
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+      >
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          How standings work
+        </span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-[color:var(--ink-faint)] transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          aria-hidden
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      {open && (
+        <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0 px-3 pb-3">
+          Each round is ranked on its own. Your gauntlet score is the sum of your three
+          round ranks — lowest wins. Crushing one round and stumbling in another can still
+          come out ahead.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RoundRow({
+  index,
+  summary,
+  onView,
+}: {
+  index: number;
+  summary: GauntletRoundSummary | null;
+  onView: () => void;
+}) {
+  // Single-line layout — round number + kind on the left, "#rank of N" on
+  // the right. Rows share a card so the trio reads as a unit instead of
+  // three discrete cards; the divider falls between rows.
+  const isFirst = index === 0;
+  const baseClasses =
+    'flex items-center justify-between gap-3 px-3 py-[10px] bg-[var(--surface-card)] border-x border-[var(--ink-border-subtle)] font-[family-name:var(--font-ui)]';
+  const positionClasses = `${isFirst ? 'border-t rounded-t-xl' : 'border-t-0'} ${
+    index === 2 ? 'border-b rounded-b-xl' : 'border-b-0'
+  }`;
+
+  if (!summary) {
+    return (
+      <div className={`${baseClasses} ${positionClasses} opacity-60 shadow-[var(--shadow-card)]`}>
+        <span className="text-small text-[color:var(--ink-muted)]">
+          Round {index + 1} · not played
+        </span>
+      </div>
+    );
+  }
+  const podium = podiumOf(summary.rank);
+  return (
+    <button
+      type="button"
+      onClick={onView}
+      className={`${baseClasses} ${positionClasses} cursor-pointer hover:bg-[var(--ink-whisper)] transition-colors duration-150 text-left shadow-[var(--shadow-card)]`}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+    >
+      <span className="min-w-0 flex items-center gap-2">
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)] tabular-nums"
+          style={{ fontWeight: 700 }}
+        >
+          R{index + 1}
+        </span>
+        <span
+          className="text-small text-[color:var(--ink)] truncate font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          {roundTitle(summary.kind)}
+        </span>
+        {podium && <RankBadge rank={podium} />}
+      </span>
+      <span
+        className="flex items-baseline gap-1.5 text-[color:var(--ink)] font-[family-name:var(--font-structure)] tabular-nums shrink-0"
+        style={{ fontWeight: 700 }}
+      >
+        <span className="text-base">#{summary.rank ?? '—'}</span>
+        <span className="text-caption text-[color:var(--ink-muted)]">of {summary.playersCount}</span>
+      </span>
+    </button>
+  );
+}

--- a/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
@@ -63,8 +63,8 @@ export function GauntletResultsRoute() {
 
   return (
     <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
-      <div className="w-full max-w-[420px] min-h-full flex flex-col px-[22px] pt-[12px] pb-[16px] gap-3">
-        <div className="flex items-center pt-[6px]">
+      <div className="w-full max-w-[360px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px] gap-3">
+        <div className="flex items-center">
           <button
             type="button"
             onClick={() => navigate('/')}

--- a/client/src/pages/dailyGauntlet/GauntletRoundResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletRoundResultsRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { GAUNTLET_ROUND_COUNT } from 'models/gauntlet';
+import { GAUNTLET_ROUND_COUNT, HOT_LETTER_MULTIPLIER } from 'models/gauntlet';
 import { useGame } from '../../GameContext';
 import {
   fetchGauntletCompare,
@@ -16,10 +16,8 @@ import type {
 import { scoreGauntletWord } from '../../shared/utils/gauntletScore';
 import { findWordPath } from '../../shared/utils/findWordPath';
 import { ResultsView } from '../../shared/results/ResultsView';
-import { IconAction } from '../../shared/components/IconAction';
-import { DateChip } from '../../shared/components/DateChip';
-import { ActionButton } from '../../shared/results/components/ActionButton';
 import { roundTitle, modifierDescription } from './modifierDisplay';
+import { GauntletBottomActions, GauntletTopbar } from './components';
 
 // Per-round results, presented through the same shared ResultsView the
 // timed daily and free play use. Round-specific tweaks are confined to
@@ -80,7 +78,7 @@ export function GauntletRoundResultsRoute() {
     modifier.kind === 'hotLetter' ? modifier.letter.toUpperCase() : null;
   const bonusFor = (word: string): string | null => {
     if (!hotLetter || modifier.kind !== 'hotLetter') return null;
-    return word.toUpperCase().includes(hotLetter) ? `${modifier.multiplier}×` : null;
+    return word.toUpperCase().includes(hotLetter) ? `${HOT_LETTER_MULTIPLIER}×` : null;
   };
   // Resolve a path for every found word so tap-to-replay actually
   // animates on the preview board. The server returns word strings
@@ -216,95 +214,6 @@ export function GauntletRoundResultsRoute() {
         />
       }
     />
-  );
-}
-
-function GauntletTopbar({
-  label,
-  onClose,
-  rulePopover,
-}: {
-  label: string;
-  onClose: () => void;
-  rulePopover: string;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <header
-      className="grid items-center gap-2 shrink-0 relative"
-      style={{ gridTemplateColumns: '32px 1fr 32px' }}
-    >
-      <IconAction onClick={onClose} label="Close">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M18 6L6 18M6 6l12 12" />
-        </svg>
-      </IconAction>
-      <div className="flex justify-center min-w-0">
-        <DateChip label={label} />
-      </div>
-      <IconAction onClick={() => setOpen((v) => !v)} label="Scoring rule">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="10" />
-          <line x1="12" y1="16" x2="12" y2="12" />
-          <line x1="12" y1="8" x2="12.01" y2="8" />
-        </svg>
-      </IconAction>
-      {open && (
-        <div className="absolute top-full right-0 mt-2 z-20 max-w-[280px] rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-3 py-3">
-          <div
-            className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] mb-1 font-[family-name:var(--font-structure)]"
-            style={{ fontWeight: 700 }}
-          >
-            Scoring rule
-          </div>
-          <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0">{rulePopover}</p>
-        </div>
-      )}
-    </header>
-  );
-}
-
-function GauntletBottomActions({
-  isLastRound,
-  fromStandings,
-  onBack,
-  onAdvance,
-}: {
-  isLastRound: boolean;
-  fromStandings: boolean;
-  onBack: () => void;
-  onAdvance: () => void;
-}) {
-  return (
-    <div className="grid grid-cols-2 gap-2">
-      <ActionButton
-        onClick={onBack}
-        label={fromStandings ? 'Back' : 'Home'}
-        icon={
-          fromStandings ? (
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M15 18l-6-6 6-6" />
-            </svg>
-          ) : (
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M3 11l9-8 9 8" />
-              <path d="M5 10v10h14V10" />
-              <path d="M9 20v-6h6v6" />
-            </svg>
-          )
-        }
-      />
-      <ActionButton
-        onClick={onAdvance}
-        label={isLastRound ? (fromStandings ? 'See standings' : 'See standings') : 'Next round'}
-        primary
-        icon={
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M5 12h14M13 5l7 7-7 7" />
-          </svg>
-        }
-      />
-    </div>
   );
 }
 

--- a/client/src/pages/dailyGauntlet/GauntletRoundResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletRoundResultsRoute.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { GAUNTLET_ROUND_COUNT } from 'models/gauntlet';
+import { useGame } from '../../GameContext';
+import {
+  fetchGauntletCompare,
+  fetchGauntletLeaderboard,
+  fetchGauntletRoundResult,
+  type GauntletLeaderboardResponse,
+  type GauntletRoundResultResponse,
+} from '../../shared/api/gauntletApi';
+import type {
+  LoadOpponentResult,
+  ResultsRosterEntry,
+} from '../../shared/results/types';
+import { scoreGauntletWord } from '../../shared/utils/gauntletScore';
+import { findWordPath } from '../../shared/utils/findWordPath';
+import { ResultsView } from '../../shared/results/ResultsView';
+import { IconAction } from '../../shared/components/IconAction';
+import { DateChip } from '../../shared/components/DateChip';
+import { ActionButton } from '../../shared/results/components/ActionButton';
+import { roundTitle, modifierDescription } from './modifierDisplay';
+
+// Per-round results, presented through the same shared ResultsView the
+// timed daily and free play use. Round-specific tweaks are confined to
+// the topbar label, the bottom-action pair (Home + Next round / See
+// standings), and a Cell-decoration callback that surfaces the round's
+// modifier visually on the board preview.
+export function GauntletRoundResultsRoute() {
+  const { round } = useParams<{ round: string }>();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const fromStandings = searchParams.get('from') === 'standings';
+  const { authReady, displayName } = useGame();
+  const roundIndex = Number(round);
+  const [result, setResult] = useState<GauntletRoundResultResponse | null>(null);
+  const [leaderboard, setLeaderboard] = useState<GauntletLeaderboardResponse | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!authReady || !Number.isFinite(roundIndex)) return;
+    let cancelled = false;
+    (async () => {
+      const today = new Date().toLocaleDateString('en-CA', {
+        timeZone: 'America/Los_Angeles',
+      });
+      const [r, lb] = await Promise.all([
+        fetchGauntletRoundResult(today, roundIndex),
+        fetchGauntletLeaderboard(today).catch(() => null),
+      ]);
+      if (cancelled) return;
+      setResult(r);
+      setLeaderboard(lb);
+      setLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, roundIndex]);
+
+  // Same render-time navigate guard as the play route — the redirect
+  // is deferred to an effect so it doesn't fire during render.
+  useEffect(() => {
+    if (loaded && !result) {
+      navigate('/daily/gauntlet', { replace: true });
+    }
+  }, [loaded, result, navigate]);
+
+  if (!loaded || !result) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]" />
+    );
+  }
+
+  const modifier = result.modifier;
+  // For hot-letter rounds, mark every word that contains the hot letter
+  // so the post-round list reflects the same purple bonus indicator the
+  // player saw flash during play.
+  const hotLetter =
+    modifier.kind === 'hotLetter' ? modifier.letter.toUpperCase() : null;
+  const bonusFor = (word: string): string | null => {
+    if (!hotLetter || modifier.kind !== 'hotLetter') return null;
+    return word.toUpperCase().includes(hotLetter) ? `${modifier.multiplier}×` : null;
+  };
+  // Resolve a path for every found word so tap-to-replay actually
+  // animates on the preview board. The server returns word strings
+  // without paths (missed_words ship with paths, found_words don't), so
+  // we re-derive against the stored board. findWordPath returns null
+  // for words it can't trace, which is acceptable — they just won't
+  // animate, same as the daily today.
+  const foundWords = result.found_words.map((word) => ({
+    word,
+    path: findWordPath(result.board, word) ?? [],
+    score: scoreGauntletWord(word, modifier),
+    bonus: bonusFor(word),
+  }));
+  const missedWords = result.missed_words.map((m) => ({
+    word: m.word,
+    path: m.path,
+    score: m.score,
+    bonus: bonusFor(m.word),
+  }));
+  const totalPoints = foundWords.reduce((sum, w) => sum + w.score, 0);
+
+  // Per-round roster comes from the leaderboard endpoint, filtered to
+  // this round. If the player tapped into a round mid-gauntlet before
+  // anyone else has finished it, the list collapses to just the viewer
+  // and ResultsView falls back to the solo presentation automatically.
+  const currentUserId = leaderboard?.currentUserId ?? null;
+  const roundEntries = leaderboard?.perRound.filter((r) => r.roundIndex === roundIndex) ?? [];
+  const roster: ResultsRosterEntry[] = roundEntries.length > 0
+    ? roundEntries
+        .slice()
+        .sort((a, b) => a.rank - b.rank)
+        .map((r) => ({
+          id: r.userId,
+          rank: r.rank,
+          displayName: r.userId === currentUserId
+            ? (displayName || r.displayName || 'You')
+            : r.displayName,
+          points: r.points,
+          isYou: r.userId === currentUserId,
+        }))
+    : [
+        {
+          id: 'me',
+          rank: 1,
+          displayName: displayName || 'You',
+          points: totalPoints,
+          isYou: true,
+        },
+      ];
+
+  const loadOpponent = async (userId: string): Promise<LoadOpponentResult> => {
+    const today = new Date().toLocaleDateString('en-CA', {
+      timeZone: 'America/Los_Angeles',
+    });
+    const cmp = await fetchGauntletCompare(today, roundIndex, userId);
+    if (!cmp.ok) return { ok: false, error: cmp.error };
+    return {
+      ok: true,
+      opponent: {
+        id: userId,
+        displayName: cmp.data.them.displayName,
+        points: cmp.data.them.points,
+        wordCount: cmp.data.them.wordCount,
+        foundWords: cmp.data.them.foundWords,
+      },
+    };
+  };
+
+  const isLastRound = roundIndex >= GAUNTLET_ROUND_COUNT - 1;
+  // From the standings page, all rounds are finished — "Next round" jumps
+  // to the next round's results (not confirm). From the mid-play flow,
+  // the next round is unstarted by definition, so it goes to confirm.
+  const advance = () => {
+    if (isLastRound) {
+      navigate('/daily/gauntlet/results');
+      return;
+    }
+    if (fromStandings) {
+      navigate(`/daily/gauntlet/round/${roundIndex + 1}/results?from=standings`);
+      return;
+    }
+    navigate(`/daily/gauntlet/round/${roundIndex + 1}`);
+  };
+
+  // Back nav: from standings, both X and the secondary action route back
+  // to the standings page; from the mid-play flow, X exits to home and
+  // the secondary action stays "Home" as well.
+  const onClose = () =>
+    fromStandings ? navigate('/daily/gauntlet/results') : navigate('/');
+
+  // For the rare-letters round, surface the per-cell point values on
+  // the preview board so a player reading their results can match a
+  // word's score to the letters that produced it.
+  const boardCellBadge =
+    modifier.kind === 'rareLetters'
+      ? (_r: number, _c: number, letter: string) => {
+          let total = 0;
+          for (const ch of letter.toUpperCase()) total += modifier.values[ch] ?? 0;
+          return total > 0 ? total : null;
+        }
+      : undefined;
+
+  return (
+    <ResultsView
+      me={{
+        displayName: displayName || 'You',
+        points: totalPoints,
+        wordCount: foundWords.length,
+        foundWords,
+        missedWords,
+      }}
+      board={result.board}
+      boardCellBadge={boardCellBadge}
+      config={result.config}
+      roster={roster}
+      loadOpponent={loadOpponent}
+      standingsHeader="Round leaderboard"
+      compareSourceLabel="leaderboard"
+      soloPlaceholderVariant="wait"
+      topbar={
+        <GauntletTopbar
+          label={`Gauntlet R${roundIndex + 1} · ${roundTitle(result.roundKind)}`}
+          onClose={onClose}
+          rulePopover={modifierDescription(modifier)}
+        />
+      }
+      bottomActions={
+        <GauntletBottomActions
+          isLastRound={isLastRound}
+          fromStandings={fromStandings}
+          onBack={onClose}
+          onAdvance={advance}
+        />
+      }
+    />
+  );
+}
+
+function GauntletTopbar({
+  label,
+  onClose,
+  rulePopover,
+}: {
+  label: string;
+  onClose: () => void;
+  rulePopover: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <header
+      className="grid items-center gap-2 shrink-0 relative"
+      style={{ gridTemplateColumns: '32px 1fr 32px' }}
+    >
+      <IconAction onClick={onClose} label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </IconAction>
+      <div className="flex justify-center min-w-0">
+        <DateChip label={label} />
+      </div>
+      <IconAction onClick={() => setOpen((v) => !v)} label="Scoring rule">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="16" x2="12" y2="12" />
+          <line x1="12" y1="8" x2="12.01" y2="8" />
+        </svg>
+      </IconAction>
+      {open && (
+        <div className="absolute top-full right-0 mt-2 z-20 max-w-[280px] rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-3 py-3">
+          <div
+            className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] mb-1 font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 700 }}
+          >
+            Scoring rule
+          </div>
+          <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0">{rulePopover}</p>
+        </div>
+      )}
+    </header>
+  );
+}
+
+function GauntletBottomActions({
+  isLastRound,
+  fromStandings,
+  onBack,
+  onAdvance,
+}: {
+  isLastRound: boolean;
+  fromStandings: boolean;
+  onBack: () => void;
+  onAdvance: () => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <ActionButton
+        onClick={onBack}
+        label={fromStandings ? 'Back' : 'Home'}
+        icon={
+          fromStandings ? (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+          ) : (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 11l9-8 9 8" />
+              <path d="M5 10v10h14V10" />
+              <path d="M9 20v-6h6v6" />
+            </svg>
+          )
+        }
+      />
+      <ActionButton
+        onClick={onAdvance}
+        label={isLastRound ? (fromStandings ? 'See standings' : 'See standings') : 'Next round'}
+        primary
+        icon={
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        }
+      />
+    </div>
+  );
+}
+

--- a/client/src/pages/dailyGauntlet/components/BackButton.tsx
+++ b/client/src/pages/dailyGauntlet/components/BackButton.tsx
@@ -1,0 +1,27 @@
+// Shared back-arrow button used by the gauntlet hub and confirm pages.
+// Lives here so both pages reference the same visual instead of each
+// shipping their own copy.
+export function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex items-center gap-1.5 bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
+      style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 18l-6-6 6-6" />
+      </svg>
+      Back
+    </button>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/BonusLetterCard.tsx
+++ b/client/src/pages/dailyGauntlet/components/BonusLetterCard.tsx
@@ -1,0 +1,44 @@
+import { HOT_LETTER_MULTIPLIER } from 'models/gauntlet';
+
+// Today's-specifics card for the bonus (hot-letter) round. The tile on
+// the right renders in the full hot-letter palette — same lavender
+// backdrop + edges the player sees on the in-game board — so the tile
+// is the visual anchor: "this is what to hunt for, and this is exactly
+// how it'll look."
+export function BonusLetterCard({ letter }: { letter: string }) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-4 flex items-center justify-between gap-3">
+      <div className="flex flex-col">
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          Today's bonus letter
+        </span>
+        <span
+          className="text-base mt-0.5 text-[color:var(--ink)]"
+          style={{ fontWeight: 700 }}
+        >
+          Words with it score {HOT_LETTER_MULTIPLIER}×
+        </span>
+      </div>
+      <div
+        className="flex items-center justify-center rounded-xl"
+        style={{
+          width: 56,
+          height: 56,
+          backgroundColor: 'var(--hot-letter-bg)',
+          color: 'var(--hot-letter-fg)',
+          fontFamily: 'var(--font-cell)',
+          fontWeight: 800,
+          fontSize: '2rem',
+          boxShadow:
+            '0 3px 0 0 var(--hot-letter-edge), 0 4px 0 0 var(--hot-letter-edge-deep), 0 6px 10px var(--hot-letter-glow)',
+        }}
+        aria-label={`Bonus letter ${letter}`}
+      >
+        {letter}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/ConfigCard.tsx
+++ b/client/src/pages/dailyGauntlet/components/ConfigCard.tsx
@@ -1,0 +1,63 @@
+// 3-up summary of the round's board size, time limit, and minimum word
+// length. Used on the confirm page so the player sees the round's
+// physical parameters before they tap start.
+
+function formatTimer(seconds: number): string {
+  if (!isFinite(seconds)) return '∞';
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export function ConfigCard({
+  boardSize,
+  timeLimit,
+  minWordLength,
+}: {
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+}) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
+      <div className="grid grid-cols-3 px-3 py-3">
+        <ConfigItem label="Board" value={`${boardSize}×${boardSize}`} divider />
+        <ConfigItem label="Time" value={formatTimer(timeLimit)} divider />
+        <ConfigItem label="Letters" value={String(minWordLength)} />
+      </div>
+    </div>
+  );
+}
+
+function ConfigItem({
+  label,
+  value,
+  divider,
+}: {
+  label: string;
+  value: string;
+  divider?: boolean;
+}) {
+  return (
+    <div className="relative text-center py-1 px-2">
+      <div
+        className="text-label-xs uppercase tracking-[0.06em] text-[color:var(--ink-soft)] leading-none mb-1.5"
+        style={{ fontWeight: 600 }}
+      >
+        {label}
+      </div>
+      <div
+        className="text-xl leading-none tabular-nums tracking-[-0.01em] text-[color:var(--ink)]"
+        style={{ fontWeight: 700 }}
+      >
+        {value}
+      </div>
+      {divider && (
+        <span
+          aria-hidden
+          className="absolute right-0 top-[15%] bottom-[15%] w-px bg-[var(--ink-border-subtle)]"
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/GauntletBottomActions.tsx
+++ b/client/src/pages/dailyGauntlet/components/GauntletBottomActions.tsx
@@ -1,0 +1,51 @@
+import { ActionButton } from '../../../shared/results/components/ActionButton';
+
+// Bottom-of-page action pair on a gauntlet round-results screen. Left
+// side returns the player to wherever they came from (home in mid-play,
+// standings if they arrived from the aggregate page). Right side
+// advances — to the next round's confirm, the next round's results
+// (when viewing from standings), or the aggregate page on the last
+// round.
+export function GauntletBottomActions({
+  isLastRound,
+  fromStandings,
+  onBack,
+  onAdvance,
+}: {
+  isLastRound: boolean;
+  fromStandings: boolean;
+  onBack: () => void;
+  onAdvance: () => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <ActionButton
+        onClick={onBack}
+        label={fromStandings ? 'Back' : 'Home'}
+        icon={
+          fromStandings ? (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+          ) : (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 11l9-8 9 8" />
+              <path d="M5 10v10h14V10" />
+              <path d="M9 20v-6h6v6" />
+            </svg>
+          )
+        }
+      />
+      <ActionButton
+        onClick={onAdvance}
+        label={isLastRound ? 'See standings' : 'Next round'}
+        primary
+        icon={
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        }
+      />
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/GauntletTopbar.tsx
+++ b/client/src/pages/dailyGauntlet/components/GauntletTopbar.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { IconAction } from '../../../shared/components/IconAction';
+import { DateChip } from '../../../shared/components/DateChip';
+
+// Topbar for the per-round results page. Centers the round chip; the
+// right-side info button opens a popover with the round's scoring rule
+// so a player landing here from a deep link can re-read the modifier
+// without bouncing back to the confirm page.
+export function GauntletTopbar({
+  label,
+  onClose,
+  rulePopover,
+}: {
+  label: string;
+  onClose: () => void;
+  rulePopover: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <header
+      className="grid items-center gap-2 shrink-0 relative"
+      style={{ gridTemplateColumns: '32px 1fr 32px' }}
+    >
+      <IconAction onClick={onClose} label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </IconAction>
+      <div className="flex justify-center min-w-0">
+        <DateChip label={label} />
+      </div>
+      <IconAction onClick={() => setOpen((v) => !v)} label="Scoring rule">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="16" x2="12" y2="12" />
+          <line x1="12" y1="8" x2="12.01" y2="8" />
+        </svg>
+      </IconAction>
+      {open && (
+        <div className="absolute top-full right-0 mt-2 z-20 max-w-[280px] rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-3 py-3">
+          <div
+            className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] mb-1 font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 700 }}
+          >
+            Scoring rule
+          </div>
+          <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0">{rulePopover}</p>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/ModifierCard.tsx
+++ b/client/src/pages/dailyGauntlet/components/ModifierCard.tsx
@@ -1,0 +1,31 @@
+// "Scoring rule" card on the gauntlet confirm page. Description is the
+// human rule ("one letter scores extra"), badge is the per-round flavor
+// ("E · 2×"). The pair stays consistent between the confirm page and
+// the post-round popover.
+export function ModifierCard({
+  description,
+  badge,
+}: {
+  description: string;
+  badge: string;
+}) {
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] px-4 py-4">
+      <div className="flex items-center justify-between mb-2">
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          Scoring rule
+        </span>
+        <span
+          className="text-caption text-[color:var(--accent)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          {badge}
+        </span>
+      </div>
+      <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0">{description}</p>
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/ProgressDots.tsx
+++ b/client/src/pages/dailyGauntlet/components/ProgressDots.tsx
@@ -1,0 +1,49 @@
+// Three-step progress indicator on the gauntlet confirm page. Past
+// rounds (in completedRounds) render as tappable buttons so the player
+// can revisit a prior round's results mid-gauntlet without aborting
+// the run. The current round is the wider accent pill.
+export function ProgressDots({
+  current,
+  total,
+  completedRounds,
+  onViewRoundResult,
+}: {
+  current: number;
+  total: number;
+  completedRounds: number[];
+  onViewRoundResult: (index: number) => void;
+}) {
+  const doneSet = new Set(completedRounds);
+  return (
+    <div
+      className="flex items-center justify-center gap-2"
+      aria-label={`Round ${current + 1} of ${total}`}
+    >
+      {Array.from({ length: total }, (_, i) => {
+        const done = doneSet.has(i);
+        const active = i === current;
+        if (done && !active) {
+          return (
+            <button
+              key={`r${i}`}
+              type="button"
+              onClick={() => onViewRoundResult(i)}
+              aria-label={`See round ${i + 1} result`}
+              className="block h-1.5 w-4 rounded-full bg-[var(--ink)] transition-transform duration-150 hover:scale-y-150 cursor-pointer border-none p-0"
+              style={{ WebkitTapHighlightColor: 'transparent' }}
+            />
+          );
+        }
+        return (
+          <span
+            key={`r${i}`}
+            className={`block h-1.5 rounded-full transition-colors duration-200 ${
+              active ? 'w-8 bg-[var(--accent)]' : 'w-4 bg-[var(--track)]'
+            }`}
+            aria-hidden
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/RankSumExplainer.tsx
+++ b/client/src/pages/dailyGauntlet/components/RankSumExplainer.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+// Collapsible "How standings work" disclosure on the gauntlet aggregate
+// results page. Default-collapsed so it doesn't crowd the rank reveal;
+// players who care can expand it.
+export function RankSumExplainer() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-3 py-2 bg-transparent border-none cursor-pointer text-left hover:bg-[var(--ink-whisper)] transition-colors duration-150 font-[family-name:var(--font-ui)]"
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+      >
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          How standings work
+        </span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-[color:var(--ink-faint)] transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          aria-hidden
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      {open && (
+        <p className="text-small text-[color:var(--ink)] leading-[1.5] m-0 px-3 pb-3">
+          Each round is ranked on its own. Your gauntlet score is the sum of your three
+          round ranks — lowest wins. Crushing one round and stumbling in another can still
+          come out ahead.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/RoundSummaryRow.tsx
+++ b/client/src/pages/dailyGauntlet/components/RoundSummaryRow.tsx
@@ -1,0 +1,66 @@
+import type { GauntletRoundSummary } from 'models/gauntlet';
+import { RankBadge } from '../../landing/components/RankBadge';
+import { roundTitle } from '../modifierDisplay';
+import { podiumOf } from './podium';
+
+// Single-line per-round row in the gauntlet aggregate standings. Three
+// rows share a card via the position-aware border classes so the trio
+// reads as a unit instead of three discrete cards.
+export function RoundSummaryRow({
+  index,
+  summary,
+  onView,
+}: {
+  index: number;
+  summary: GauntletRoundSummary | null;
+  onView: () => void;
+}) {
+  const isFirst = index === 0;
+  const baseClasses =
+    'flex items-center justify-between gap-3 px-3 py-[10px] bg-[var(--surface-card)] border-x border-[var(--ink-border-subtle)] font-[family-name:var(--font-ui)]';
+  const positionClasses = `${isFirst ? 'border-t rounded-t-xl' : 'border-t-0'} ${
+    index === 2 ? 'border-b rounded-b-xl' : 'border-b-0'
+  }`;
+
+  if (!summary) {
+    return (
+      <div className={`${baseClasses} ${positionClasses} opacity-60 shadow-[var(--shadow-card)]`}>
+        <span className="text-small text-[color:var(--ink-muted)]">
+          Round {index + 1} · not played
+        </span>
+      </div>
+    );
+  }
+  const podium = podiumOf(summary.rank);
+  return (
+    <button
+      type="button"
+      onClick={onView}
+      className={`${baseClasses} ${positionClasses} cursor-pointer hover:bg-[var(--ink-whisper)] transition-colors duration-150 text-left shadow-[var(--shadow-card)]`}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+    >
+      <span className="min-w-0 flex items-center gap-2">
+        <span
+          className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)] tabular-nums"
+          style={{ fontWeight: 700 }}
+        >
+          R{index + 1}
+        </span>
+        <span
+          className="text-small text-[color:var(--ink)] truncate font-[family-name:var(--font-structure)]"
+          style={{ fontWeight: 700 }}
+        >
+          {roundTitle(summary.kind)}
+        </span>
+        {podium && <RankBadge rank={podium} />}
+      </span>
+      <span
+        className="flex items-baseline gap-1.5 text-[color:var(--ink)] font-[family-name:var(--font-structure)] tabular-nums shrink-0"
+        style={{ fontWeight: 700 }}
+      >
+        <span className="text-base">#{summary.rank ?? '—'}</span>
+        <span className="text-caption text-[color:var(--ink-muted)]">of {summary.playersCount}</span>
+      </span>
+    </button>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/StandingsLeaderboard.tsx
+++ b/client/src/pages/dailyGauntlet/components/StandingsLeaderboard.tsx
@@ -1,0 +1,88 @@
+import { GAUNTLET_ROUND_COUNT } from 'models/gauntlet';
+import type { GauntletLeaderboardResponse } from '../../../shared/api/gauntletApi';
+import { podiumColor, podiumOf } from './podium';
+
+// Full standings table on the gauntlet aggregate results page. Renders
+// every player who has finalized all three rounds, with their per-round
+// ranks and the rank-sum total. The viewer's row gets the whisper
+// background and the "you" badge so they can find themselves at a glance.
+export function StandingsLeaderboard({
+  leaderboard,
+}: {
+  leaderboard: GauntletLeaderboardResponse;
+}) {
+  const meId = leaderboard.currentUserId;
+  return (
+    <div className="rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden">
+      <div
+        className="flex items-center justify-between px-3 py-[10px] text-label-xs uppercase tracking-[0.08em] text-[color:var(--ink-muted)] bg-[var(--ink-whisper)] font-[family-name:var(--font-structure)]"
+        style={{ fontWeight: 700 }}
+      >
+        <span>Full standings</span>
+        <span className="flex items-center gap-2 text-[color:var(--ink-faint)]">
+          {Array.from({ length: GAUNTLET_ROUND_COUNT }, (_, i) => (
+            <span key={`hdr-r${i}`} className="w-5 text-center">
+              R{i + 1}
+            </span>
+          ))}
+          <span className="w-9 text-right">Sum</span>
+        </span>
+      </div>
+      <div className="flex flex-col">
+        {leaderboard.aggregate.map((row) => {
+          const isMe = row.userId === meId;
+          const podium = podiumOf(row.aggregateRank);
+          return (
+            <div
+              key={row.userId}
+              className={[
+                'flex items-center justify-between px-3 py-[9px] text-small font-[family-name:var(--font-ui)] border-t border-[var(--ink-border-subtle)] first:border-t-0',
+                isMe ? 'bg-[var(--ink-whisper)]' : '',
+              ].join(' ')}
+              style={{ fontWeight: 500 }}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span
+                  className="tabular-nums w-7 font-[family-name:var(--font-structure)]"
+                  style={{ fontWeight: 700, color: podiumColor(podium) }}
+                >
+                  #{row.aggregateRank}
+                </span>
+                <span
+                  className={[
+                    'truncate',
+                    isMe ? 'text-[color:var(--ink)]' : 'text-[color:var(--ink-soft)]',
+                  ].join(' ')}
+                  style={{ fontWeight: isMe ? 700 : 500 }}
+                >
+                  {row.displayName}
+                  {isMe && (
+                    <span
+                      className="ml-1.5 text-caption text-[color:var(--accent)] font-[family-name:var(--font-structure)]"
+                      style={{ fontWeight: 700 }}
+                    >
+                      you
+                    </span>
+                  )}
+                </span>
+              </div>
+              <span className="flex items-center gap-2 text-[color:var(--ink-soft)] tabular-nums font-[family-name:var(--font-structure)]">
+                {row.roundRanks.map((rank, i) => (
+                  <span key={`r${i}`} className="w-5 text-center" style={{ fontWeight: 600 }}>
+                    {rank}
+                  </span>
+                ))}
+                <span
+                  className="w-9 text-right text-[color:var(--ink)]"
+                  style={{ fontWeight: 700 }}
+                >
+                  {row.rankSum}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/dailyGauntlet/components/index.ts
+++ b/client/src/pages/dailyGauntlet/components/index.ts
@@ -1,0 +1,11 @@
+export { BackButton } from './BackButton';
+export { BonusLetterCard } from './BonusLetterCard';
+export { ConfigCard } from './ConfigCard';
+export { GauntletBottomActions } from './GauntletBottomActions';
+export { GauntletTopbar } from './GauntletTopbar';
+export { ModifierCard } from './ModifierCard';
+export { ProgressDots } from './ProgressDots';
+export { RankSumExplainer } from './RankSumExplainer';
+export { RoundSummaryRow } from './RoundSummaryRow';
+export { StandingsLeaderboard } from './StandingsLeaderboard';
+export { podiumColor, podiumOf } from './podium';

--- a/client/src/pages/dailyGauntlet/components/podium.ts
+++ b/client/src/pages/dailyGauntlet/components/podium.ts
@@ -1,0 +1,19 @@
+import type { PodiumRank } from '../../landing/components/RankBadge';
+
+export function podiumOf(rank: number | null | undefined): PodiumRank | null {
+  if (rank === 1 || rank === 2 || rank === 3) return rank;
+  return null;
+}
+
+// Tints a top-3 rank number with its medal color. Used in the standings
+// table so the medal hierarchy is baked into the number itself — no
+// separate medal column nudging the name column.
+export function podiumColor(rank: PodiumRank | null): string {
+  switch (rank) {
+    case 1: return 'var(--podium-gold)';
+    case 2: return 'var(--podium-silver)';
+    case 3: return 'var(--podium-bronze)';
+    case null:
+    default: return 'var(--ink)';
+  }
+}

--- a/client/src/pages/dailyGauntlet/index.ts
+++ b/client/src/pages/dailyGauntlet/index.ts
@@ -1,0 +1,5 @@
+export { GauntletHubRoute } from './GauntletHubRoute';
+export { GauntletConfirmRoute } from './GauntletConfirmRoute';
+export { GauntletPlayRoute } from './GauntletPlayRoute';
+export { GauntletRoundResultsRoute } from './GauntletRoundResultsRoute';
+export { GauntletResultsRoute } from './GauntletResultsRoute';

--- a/client/src/pages/dailyGauntlet/modifierDisplay.ts
+++ b/client/src/pages/dailyGauntlet/modifierDisplay.ts
@@ -1,0 +1,52 @@
+import type { GauntletModifier, GauntletRoundKind } from 'models/gauntlet';
+
+// Single source of truth for how a round's modifier is described to the
+// player. Used by the hub cards, confirm pages, the in-game overlay, and
+// the post-round results so we never explain the same mechanic two
+// different ways.
+
+// Display names for each round. Internal kinds stay 'regular' /
+// 'hotLetter' / 'rareLetters' so server payloads and storage are
+// unchanged; only the display text shifts. Each name nods to the
+// scoring rule that round actually carries: nothing extra (Standard),
+// one letter pays a bonus (Bonus), or per-letter values reward rare
+// finds (Bounty).
+export function roundTitle(kind: GauntletRoundKind): string {
+  switch (kind) {
+    case 'regular': return 'Standard';
+    case 'hotLetter': return 'Bonus';
+    case 'rareLetters': return 'Bounty';
+  }
+}
+
+export function modifierBadge(modifier: GauntletModifier): string {
+  switch (modifier.kind) {
+    case 'regular': return 'Standard scoring';
+    case 'hotLetter': return `${modifier.letter} · ${modifier.multiplier}×`;
+    case 'rareLetters': return 'Letter values';
+  }
+}
+
+export function modifierDescription(modifier: GauntletModifier): string {
+  switch (modifier.kind) {
+    case 'regular':
+      return 'Standard length-based scoring. Find as many words as you can.';
+    case 'hotLetter':
+      // Generic rule — the specific letter + multiplier render in their own
+      // dedicated section so the rule reads the same every day.
+      return 'One letter on the board is the bonus letter. Words containing it score extra.';
+    case 'rareLetters':
+      return 'Each letter has its own point value. Word score is the sum of its letters — rare letters are worth more.';
+  }
+}
+
+// Returns the letter-value table sorted high-to-low for display. Only
+// makes sense for rareLetters; returns null otherwise.
+export function letterValueTable(
+  modifier: GauntletModifier,
+): Array<{ letter: string; value: number }> | null {
+  if (modifier.kind !== 'rareLetters') return null;
+  return Object.entries(modifier.values)
+    .map(([letter, value]) => ({ letter, value }))
+    .sort((a, b) => b.value - a.value || a.letter.localeCompare(b.letter));
+}

--- a/client/src/pages/dailyGauntlet/modifierDisplay.ts
+++ b/client/src/pages/dailyGauntlet/modifierDisplay.ts
@@ -1,4 +1,4 @@
-import type { GauntletModifier, GauntletRoundKind } from 'models/gauntlet';
+import { HOT_LETTER_MULTIPLIER, type GauntletModifier, type GauntletRoundKind } from 'models/gauntlet';
 
 // Single source of truth for how a round's modifier is described to the
 // player. Used by the hub cards, confirm pages, the in-game overlay, and
@@ -22,7 +22,7 @@ export function roundTitle(kind: GauntletRoundKind): string {
 export function modifierBadge(modifier: GauntletModifier): string {
   switch (modifier.kind) {
     case 'regular': return 'Standard scoring';
-    case 'hotLetter': return `${modifier.letter} · ${modifier.multiplier}×`;
+    case 'hotLetter': return `${modifier.letter} · ${HOT_LETTER_MULTIPLIER}×`;
     case 'rareLetters': return 'Letter values';
   }
 }

--- a/client/src/pages/game/GamePage.tsx
+++ b/client/src/pages/game/GamePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Game, Position, Word } from 'models';
-import { Board, FeedbackType, computeFeedbackColors } from './components/Board';
+import { Board, FeedbackType, computeFeedbackColors, type CellDecoration } from './components/Board';
 import { TimerBar } from './components/TimerBar';
 
 // Hardcoded board style defaults
@@ -27,13 +27,22 @@ interface GamePageProps {
   game: Game;
   words: Word[];
   timeRemaining: number;
-  feedback: { type: FeedbackType; path: Position[] } | null;
+  feedback: { type: FeedbackType; path: Position[]; bonus?: string | null } | null;
   onSubmitWord: (path: Position[]) => void;
   onCancelGame: () => void;
   onEndGame: () => void;
   muted: boolean;
   onToggleMute: () => void;
   dailyNumber?: number;
+  /** Override for the bottom-left mode label. When set, takes precedence
+   *  over the dailyNumber-derived default. Used by gauntlet rounds to
+   *  carry both the round number and the modifier badge in a single line
+   *  ("Gauntlet R2 · Hot: A · 2×"). */
+  modeLabel?: string;
+  /** Per-cell decorations (score badge / accent ring). Passes through to
+   *  Board; used by gauntlet rounds to render Scrabble-style point values
+   *  and flag the hot letter. */
+  cellDecorations?: (row: number, col: number, letter: string) => CellDecoration | null;
 }
 
 function formatTimer(seconds: number): string {
@@ -43,11 +52,12 @@ function formatTimer(seconds: number): string {
   return `${m}:${String(s).padStart(2, '0')}`;
 }
 
-export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGame, muted, onToggleMute, dailyNumber }: GamePageProps) => {
+export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGame, muted, onToggleMute, dailyNumber, modeLabel: modeLabelOverride, cellDecorations }: GamePageProps) => {
   const boardSize = game.board.length;
   const [displayWord, setDisplayWord] = useState('');
   const [wordFeedback, setWordFeedback] = useState<FeedbackType>(null);
   const [isFading, setIsFading] = useState(false);
+  const [wordBonus, setWordBonus] = useState<string | null>(null);
   const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -55,6 +65,7 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
     if (word) {
       setDisplayWord(word);
       setWordFeedback(null);
+      setWordBonus(null);
       setIsFading(false);
       if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
       if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
@@ -66,6 +77,7 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
       const word = feedback.path.map(p => game.board[p.row]?.[p.col] || '').join('');
       setDisplayWord(word);
       setWordFeedback(feedback.type);
+      setWordBonus(feedback.bonus ?? null);
       setIsFading(false);
 
       if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
@@ -76,6 +88,7 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
         clearTimerRef.current = setTimeout(() => {
           setDisplayWord('');
           setWordFeedback(null);
+          setWordBonus(null);
           setIsFading(false);
         }, 300);
       }, 800);
@@ -102,7 +115,7 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
   }
 
   const isDaily = dailyNumber !== undefined;
-  const modeLabel = isDaily ? `Daily #${dailyNumber}` : 'Free Play';
+  const modeLabel = modeLabelOverride ?? (isDaily ? `Daily #${dailyNumber}` : 'Free Play');
 
   return (
     <div className="w-full max-w-[500px] mx-auto flex flex-col items-center" style={{ '--board-size': boardSize } as React.CSSProperties}>
@@ -143,6 +156,21 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
             ))
           : displayWord.toUpperCase()
         }
+        {wordFeedback === 'valid' && wordBonus && (
+          <span
+            className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs tabular-nums"
+            style={{
+              backgroundColor: 'var(--hot-letter-bg)',
+              color: 'var(--hot-letter-fg)',
+              boxShadow: '0 1px 4px var(--hot-letter-glow)',
+              fontWeight: 800,
+              animation: 'word-pulse 0.4s ease',
+            }}
+          >
+            <span aria-hidden>✦</span>
+            {wordBonus}
+          </span>
+        )}
       </div>
 
       {/* Board */}
@@ -160,6 +188,7 @@ export const GamePage = ({ game, timeRemaining, feedback, onSubmitWord, onEndGam
           preactRadius={BOARD_STYLE.preactRadius}
           preactIntensity={BOARD_STYLE.preactIntensity}
           onCurrentWordChange={handleCurrentWordChange}
+          cellDecorations={cellDecorations}
         />
       </div>
 

--- a/client/src/pages/game/components/Board.tsx
+++ b/client/src/pages/game/components/Board.tsx
@@ -3,7 +3,13 @@ import { Board as BoardType, Position } from 'models';
 import { useBoardInteraction } from '../hooks/useBoardInteraction';
 import { useThockSound } from '../hooks/useThockSound';
 import { Cell } from '../../../shared/components/Cell';
-import type { CellState } from '../../../shared/components/Cell';
+import type { CellAccent, CellState } from '../../../shared/components/Cell';
+import type { ReactNode } from 'react';
+
+export interface CellDecoration {
+  badge?: ReactNode;
+  accent?: CellAccent;
+}
 
 export type FeedbackType = 'valid' | 'invalid' | 'duplicate' | null;
 
@@ -108,6 +114,11 @@ interface BoardProps {
   preactRadius?: number;
   preactIntensity?: number;
   onCurrentWordChange?: (word: string) => void;
+  /** Per-cell decorations (score badge, accent ring). Used by gauntlet
+   *  modifiers to render Scrabble-style point values and to flag the hot
+   *  letter on the board itself, without coupling Board to gauntlet
+   *  concepts — the caller decides what each cell carries. */
+  cellDecorations?: (row: number, col: number, letter: string) => CellDecoration | null;
 }
 
 export const Board = ({
@@ -116,6 +127,7 @@ export const Board = ({
   soundIndex = 0, colorWash = 35,
   preactStyleIndex = 0, preactRadius = 130, preactIntensity = 100,
   onCurrentWordChange,
+  cellDecorations,
 }: BoardProps) => {
   const playThock = useThockSound(soundIndex);
   const {
@@ -181,22 +193,27 @@ export const Board = ({
     >
       {board.map((row, rowIndex) => (
         <div key={rowIndex} className="flex flex-1" style={{ gap: layout.rowGap }}>
-          {row.map((letter, colIndex) => (
-            <Cell
-              key={`${rowIndex}-${colIndex}`}
-              letter={letter}
-              state={getCellState(rowIndex, colIndex)}
-              size="responsive"
-              variant="dice"
-              styleOverride={getDynamicOverride(rowIndex, colIndex)}
-              className="cursor-pointer"
-              data-row={rowIndex}
-              data-col={colIndex}
-              onPointerDown={(e) => handleCellPointerDown(rowIndex, colIndex, e)}
-              onPointerEnter={() => setHoveredCell(`${rowIndex},${colIndex}`)}
-              onPointerLeave={() => setHoveredCell(null)}
-            />
-          ))}
+          {row.map((letter, colIndex) => {
+            const decoration = cellDecorations?.(rowIndex, colIndex, letter) ?? null;
+            return (
+              <Cell
+                key={`${rowIndex}-${colIndex}`}
+                letter={letter}
+                state={getCellState(rowIndex, colIndex)}
+                size="responsive"
+                variant="dice"
+                styleOverride={getDynamicOverride(rowIndex, colIndex)}
+                className="cursor-pointer"
+                data-row={rowIndex}
+                data-col={colIndex}
+                onPointerDown={(e) => handleCellPointerDown(rowIndex, colIndex, e)}
+                onPointerEnter={() => setHoveredCell(`${rowIndex},${colIndex}`)}
+                onPointerLeave={() => setHoveredCell(null)}
+                badge={decoration?.badge}
+                accent={decoration?.accent ?? null}
+              />
+            );
+          })}
         </div>
       ))}
     </div>

--- a/client/src/pages/landing/LandingPage.tsx
+++ b/client/src/pages/landing/LandingPage.tsx
@@ -3,12 +3,14 @@ import {
   DailyCard,
   FeedbackButton,
   FreePlayCard,
+  GauntletDailyCard,
   NextDailyHeader,
   ThemeTogglePill,
   ZenDailyCard,
 } from "./components";
 import type { DailyResults } from "./types";
 import type { DailyZenSession, ProfileResponse, UpdateProfileResult } from "../../shared/api/gameApi";
+import type { GauntletEntry } from "models/gauntlet";
 
 interface LandingPageProps {
   dateLabel: string;
@@ -18,6 +20,8 @@ interface LandingPageProps {
   dailyRank: number | null;
   zenSession: DailyZenSession | null;
   zenRank: number | null;
+  gauntletEntry: GauntletEntry | null;
+  onGauntletPlay: () => void;
   displayName: string;
   nameProfile: ProfileResponse | null;
   onDisplayNameChange: (name: string) => Promise<UpdateProfileResult>;
@@ -43,6 +47,8 @@ export function LandingPage({
   dailyRank,
   zenSession,
   zenRank,
+  gauntletEntry,
+  onGauntletPlay,
   displayName,
   nameProfile,
   onDisplayNameChange,
@@ -90,6 +96,7 @@ export function LandingPage({
             onSeeResult={onZenSeeResult}
             onSeeLeaderboard={onZenLeaderboard}
           />
+          <GauntletDailyCard entry={gauntletEntry} onPlay={onGauntletPlay} />
           <FreePlayCard
             onClick={onFreePlayClick}
             onHistory={onFreePlayHistory}

--- a/client/src/pages/landing/LandingRoute.tsx
+++ b/client/src/pages/landing/LandingRoute.tsx
@@ -10,6 +10,8 @@ import {
   fetchFreePlayUnread,
   type DailyStatsResponse,
 } from '../../shared/api/gameApi';
+import { fetchGauntletStatus } from '../../shared/api/gauntletApi';
+import type { GauntletEntry } from 'models/gauntlet';
 import { scoreWord } from '../../shared/utils/score';
 import { getLandingFixture } from './__fixtures__';
 import type { DailyResults } from './types';
@@ -44,6 +46,7 @@ export function LandingRoute() {
   const [dailyRank, setDailyRank] = useState<number | null>(null);
   const [zenRank, setZenRank] = useState<number | null>(null);
   const [freePlayUnread, setFreePlayUnread] = useState(0);
+  const [gauntletEntry, setGauntletEntry] = useState<GauntletEntry | null>(null);
 
   // Dev-only fixture injection — `?mock=unplayed|completed|partial` renders
   // the page with canned data so visual-regression work can reach either
@@ -62,6 +65,21 @@ export function LandingRoute() {
       })
       .catch(() => {
         // Non-fatal: the dot just doesn't render.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady]);
+
+  useEffect(() => {
+    if (!authReady) return;
+    let cancelled = false;
+    fetchGauntletStatus()
+      .then((s) => {
+        if (!cancelled) setGauntletEntry(s.entry);
+      })
+      .catch(() => {
+        // Non-fatal: gauntlet card falls back to the "unplayed" hint.
       });
     return () => {
       cancelled = true;
@@ -147,6 +165,8 @@ export function LandingRoute() {
     }
   };
 
+  const handleGauntletPlay = () => navigate('/daily/gauntlet');
+
   const handleZenPlay = () => navigate('/daily/zen/play');
   const handleZenResume = () => navigate('/daily/zen/play');
   const handleZenSeeResult = () => navigate('/daily/zen/results');
@@ -168,6 +188,8 @@ export function LandingRoute() {
         dailyRank={null}
         zenSession={mockFixture.zenSession ?? null}
         zenRank={null}
+        gauntletEntry={null}
+        onGauntletPlay={() => {}}
         displayName={mockFixture.displayName}
         nameProfile={null}
         onDisplayNameChange={async () => ({ ok: true as const, profile: {
@@ -228,6 +250,8 @@ export function LandingRoute() {
       dailyRank={dailyRank}
       zenSession={cachedDailyZenSession}
       zenRank={zenRank}
+      gauntletEntry={gauntletEntry}
+      onGauntletPlay={handleGauntletPlay}
       displayName={displayName}
       nameProfile={nameProfile}
       onDisplayNameChange={updateDisplayName}

--- a/client/src/pages/landing/components/GauntletDailyCard.tsx
+++ b/client/src/pages/landing/components/GauntletDailyCard.tsx
@@ -1,0 +1,138 @@
+import type { GauntletEntry } from 'models/gauntlet';
+import { StatusIcon } from '../../../shared/components/StatusIcon';
+
+interface GauntletDailyCardProps {
+  entry: GauntletEntry | null;
+  onPlay: () => void;
+}
+
+// Compact landing entry for the gauntlet. Doesn't reuse DailyRow because
+// the gauntlet's hub view shows progress through 3 rounds (and an aggregate
+// rank when finished) rather than the points/words shape DailyRow is
+// shaped around. Visual rhythm (height, avatar, chevron) matches the
+// other daily rows.
+export function GauntletDailyCard({ entry, onPlay }: GauntletDailyCardProps) {
+  const completedRounds = entry?.rounds.filter((r) => r?.endedAt).length ?? 0;
+  const state: 'unplayed' | 'in-progress' | 'completed' =
+    entry?.state === 'completed'
+      ? 'completed'
+      : entry && entry.state === 'partial'
+      ? 'in-progress'
+      : 'unplayed';
+
+  return (
+    <div className="flex items-stretch w-full rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden font-[family-name:var(--font-ui)]">
+      <button
+        type="button"
+        onClick={onPlay}
+        className="group flex-1 flex items-center gap-3 px-4 py-[12px] bg-transparent border-none cursor-pointer select-none text-left hover:bg-[var(--ink-whisper)] active:scale-[0.99] transition-colors duration-150 min-w-0"
+        style={{ WebkitTapHighlightColor: 'transparent', minHeight: 60 }}
+      >
+        <GauntletAvatar />
+        <div className="flex-1 flex flex-col gap-[3px] min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span
+              className="text-caption uppercase tracking-[0.06em] text-[color:var(--ink-muted)] leading-none font-[family-name:var(--font-structure)] truncate"
+              style={{ fontWeight: 700 }}
+            >
+              Gauntlet
+            </span>
+            {state !== 'unplayed' && <StatusIcon state={state} />}
+          </div>
+          <HintLine state={state} entry={entry} completedRounds={completedRounds} />
+        </div>
+        <Chevron />
+      </button>
+    </div>
+  );
+}
+
+function HintLine({
+  state,
+  entry,
+  completedRounds,
+}: {
+  state: 'unplayed' | 'in-progress' | 'completed';
+  entry: GauntletEntry | null;
+  completedRounds: number;
+}) {
+  if (state === 'completed' && entry) {
+    return (
+      <span
+        className="text-small text-[color:var(--ink-muted)] truncate"
+        style={{ fontWeight: 500 }}
+      >
+        Rank{' '}
+        <span
+          className="font-[family-name:var(--font-structure)] text-[color:var(--ink)]"
+          style={{ fontWeight: 700 }}
+        >
+          #{entry.aggregateRank ?? '—'}
+        </span>{' '}
+        · rank-sum {entry.aggregateRankSum ?? '—'}
+      </span>
+    );
+  }
+  if (state === 'in-progress') {
+    return (
+      <span
+        className="text-small text-[color:var(--ink-muted)] truncate"
+        style={{ fontWeight: 500 }}
+      >
+        {completedRounds}/3 rounds done
+      </span>
+    );
+  }
+  return (
+    <span
+      className="text-small text-[color:var(--ink-muted)] truncate"
+      style={{ fontWeight: 500 }}
+    >
+      3 rounds · 3 modifiers
+    </span>
+  );
+}
+
+function GauntletAvatar() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-center justify-center rounded-full shrink-0 bg-[var(--podium-bronze-bg)] text-[color:var(--podium-bronze)]"
+      style={{ width: 32, height: 32 }}
+    >
+      <svg
+        width={18}
+        height={18}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="6" cy="6" r="2.5" />
+        <circle cx="12" cy="12" r="2.5" />
+        <circle cx="18" cy="18" r="2.5" />
+        <path d="M7.5 7.5l3 3M13.5 13.5l3 3" />
+      </svg>
+    </span>
+  );
+}
+
+function Chevron() {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0 text-[color:var(--ink-faint)] group-hover:text-[color:var(--ink-muted)] group-hover:translate-x-[2px] transition-[transform,color] duration-200"
+    >
+      <path d="M9 18l6-6-6-6" />
+    </svg>
+  );
+}

--- a/client/src/pages/landing/components/index.ts
+++ b/client/src/pages/landing/components/index.ts
@@ -2,6 +2,7 @@ export { AppHeader } from "./AppHeader";
 export { ChangelogControl } from "./ChangelogControl";
 export { DailyCard } from "./DailyCard";
 export { ZenDailyCard } from "./ZenDailyCard";
+export { GauntletDailyCard } from "./GauntletDailyCard";
 export { FeedbackButton } from "./FeedbackButton";
 export { FreePlayCard } from "./FreePlayCard";
 export { NextDailyHeader } from "./NextDailyHeader";

--- a/client/src/pages/results/components/WordsCard.tsx
+++ b/client/src/pages/results/components/WordsCard.tsx
@@ -114,6 +114,7 @@ export function WordsCard({
             key={`${w.word}-${w.found ? 'f' : 'm'}-${i}`}
             word={w.word}
             score={w.score}
+            bonus={w.bonus ?? null}
             first={i === 0}
             found={w.found}
             highlighted={highlightedWord === w.word}
@@ -167,6 +168,7 @@ function SectionHeader({
 function WordRow({
   word,
   score,
+  bonus,
   first,
   found,
   highlighted,
@@ -176,6 +178,7 @@ function WordRow({
 }: {
   word: string;
   score: number;
+  bonus: string | null;
   first: boolean;
   found: boolean;
   highlighted: boolean;
@@ -203,6 +206,20 @@ function WordRow({
       />
       <span className="tabular-nums">{word}</span>
       <span className="flex items-baseline gap-1.5">
+        {bonus && found && (
+          <span
+            className="inline-flex items-center gap-0.5 px-1.5 py-px rounded-full text-[10px] tabular-nums font-[family-name:var(--font-structure)]"
+            style={{
+              backgroundColor: 'var(--hot-letter-bg)',
+              color: 'var(--hot-letter-fg)',
+              fontWeight: 800,
+              boxShadow: '0 1px 3px var(--hot-letter-glow)',
+            }}
+          >
+            <span aria-hidden>✦</span>
+            {bonus}
+          </span>
+        )}
         {showInline && (
           <span
             className="text-[10px] tabular-nums text-[color:var(--ink-faint)] font-[family-name:var(--font-structure)]"

--- a/client/src/shared/api/gauntletApi.ts
+++ b/client/src/shared/api/gauntletApi.ts
@@ -1,0 +1,234 @@
+import type { Position } from 'models';
+import type {
+  GauntletEntry,
+  GauntletModifier,
+  GauntletRoundConfig,
+  GauntletRoundKind,
+} from 'models/gauntlet';
+import { supabase } from '../supabase';
+
+const API_URL = '/api';
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const { data: { session } } = await supabase.auth.getSession();
+  if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
+  return headers;
+}
+
+export interface GauntletRoundSession {
+  date: string;
+  roundIndex: number;
+  roundKind: GauntletRoundKind;
+  board: string[][];
+  modifier: GauntletModifier;
+  config: {
+    boardSize: number;
+    timeLimit: number;
+    minWordLength: number;
+  };
+  foundWords: string[];
+  points: number;
+  wordCount: number;
+  longestWord: string;
+  startedAt: string;
+  endedAt: string | null;
+  completedAt: string | null;
+  total_findable: number;
+  salt: string;
+  wordHashes: string[];
+}
+
+export interface GauntletStatusResponse {
+  date: string;
+  puzzleNumber: number;
+  entry: GauntletEntry;
+  nextRoundIndex: number | null;
+  upcomingConfigs: Record<number, GauntletRoundConfig>;
+  roundKinds: GauntletRoundKind[];
+}
+
+export async function fetchGauntletStatus(): Promise<GauntletStatusResponse> {
+  const res = await fetch(`${API_URL}/daily/gauntlet`, { headers: await authHeaders() });
+  if (!res.ok) throw new Error('Failed to fetch gauntlet status');
+  return res.json();
+}
+
+export interface GauntletPreviewResponse {
+  date: string;
+  puzzleNumber: number;
+  rounds: Array<{ config: GauntletRoundConfig }>;
+}
+
+export async function fetchGauntletPreview(date: string): Promise<GauntletPreviewResponse> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/preview`, {
+    headers: await authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch gauntlet preview');
+  return res.json();
+}
+
+export async function fetchGauntletRoundSession(
+  date: string,
+  round: number,
+): Promise<GauntletRoundSession | null> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/round/${round}`, {
+    headers: await authHeaders(),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.session ?? null;
+}
+
+export async function startGauntletRound(
+  date: string,
+  round: number,
+): Promise<GauntletRoundSession | { error: string }> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/round/${round}/start`, {
+    method: 'POST',
+    headers: await authHeaders(),
+  });
+  const data = await res.json();
+  if (!res.ok) return { error: data.error ?? 'unknown' };
+  return data.session;
+}
+
+export async function submitGauntletWord(
+  date: string,
+  round: number,
+  path: Position[],
+): Promise<{ valid: boolean; word?: string; score?: number; reason?: string }> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/round/${round}/word`, {
+    method: 'POST',
+    headers: await authHeaders(),
+    body: JSON.stringify({ path }),
+  });
+  return res.json();
+}
+
+export async function endGauntletRound(
+  date: string,
+  round: number,
+): Promise<GauntletRoundSession | null> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/round/${round}/end`, {
+    method: 'POST',
+    headers: await authHeaders(),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.session ?? null;
+}
+
+export interface GauntletRoundMissedWord {
+  word: string;
+  path: { row: number; col: number }[];
+  score: number;
+}
+
+export interface GauntletRoundResultResponse {
+  date: string;
+  roundIndex: number;
+  roundKind: GauntletRoundKind;
+  modifier: GauntletModifier;
+  config: { boardSize: number; timeLimit: number; minWordLength: number };
+  board: string[][];
+  found_words: string[];
+  points: number;
+  word_count: number;
+  longest_word: string;
+  missed_words: GauntletRoundMissedWord[];
+  completed_at: string | null;
+}
+
+export async function fetchGauntletRoundResult(
+  date: string,
+  round: number,
+): Promise<GauntletRoundResultResponse | null> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/round/${round}/results`, {
+    headers: await authHeaders(),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.result ?? null;
+}
+
+export interface GauntletLeaderboardResponse {
+  date: string;
+  puzzleNumber: number;
+  currentUserId: string | null;
+  perRound: Array<{
+    userId: string;
+    displayName: string;
+    roundIndex: number;
+    points: number;
+    wordCount: number;
+    rank: number;
+  }>;
+  aggregate: Array<{
+    userId: string;
+    displayName: string;
+    roundRanks: number[];
+    rankSum: number;
+    aggregateRank: number;
+  }>;
+}
+
+export async function fetchGauntletLeaderboard(
+  date: string,
+): Promise<GauntletLeaderboardResponse> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/leaderboard`, {
+    headers: await authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch gauntlet leaderboard');
+  return res.json();
+}
+
+export interface GauntletCompareResponse {
+  date: string;
+  roundIndex: number;
+  roundKind: GauntletRoundKind;
+  modifier: GauntletModifier;
+  puzzleNumber: number;
+  board: string[][];
+  config: { boardSize: number; minWordLength: number; timeLimit: number };
+  me: {
+    userId: string;
+    displayName: string;
+    points: number;
+    wordCount: number;
+    foundWords: { word: string; score: number }[];
+  };
+  them: {
+    userId: string;
+    displayName: string;
+    points: number;
+    wordCount: number;
+    foundWords: { word: string; score: number }[];
+  };
+}
+
+export type GauntletCompareError =
+  | 'unplayed'
+  | 'opponent-missing'
+  | 'forbidden'
+  | 'unknown';
+
+export type GauntletCompareResult =
+  | { ok: true; data: GauntletCompareResponse }
+  | { ok: false; error: GauntletCompareError };
+
+export async function fetchGauntletCompare(
+  date: string,
+  round: number,
+  otherUserId: string,
+): Promise<GauntletCompareResult> {
+  const res = await fetch(
+    `${API_URL}/daily/gauntlet/${date}/round/${round}/compare?other=${otherUserId}`,
+    { headers: await authHeaders() },
+  );
+  if (res.ok) return { ok: true, data: await res.json() };
+  if (res.status === 409) return { ok: false, error: 'unplayed' };
+  if (res.status === 404) return { ok: false, error: 'opponent-missing' };
+  if (res.status === 403) return { ok: false, error: 'forbidden' };
+  return { ok: false, error: 'unknown' };
+}

--- a/client/src/shared/components/Cell.tsx
+++ b/client/src/shared/components/Cell.tsx
@@ -1,9 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
 export type CellState = 'default' | 'selected' | 'valid' | 'invalid' | 'duplicate';
 export type CellSize = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'responsive';
 export type CellMode = 'light' | 'dark';
 export type CellVariant = 'simple' | 'dice';
+export type CellAccent = 'hot' | null;
 
 interface CellProps extends HTMLAttributes<HTMLDivElement> {
   letter: string;
@@ -12,6 +13,12 @@ interface CellProps extends HTMLAttributes<HTMLDivElement> {
   mode?: CellMode;
   variant?: CellVariant;
   styleOverride?: React.CSSProperties;
+  /** Adornment rendered in the bottom-right corner. Used by the gauntlet
+   *  rare-letters round to show per-letter point values, Scrabble-style. */
+  badge?: ReactNode;
+  /** Visual emphasis on the cell itself. 'hot' draws an accent ring
+   *  (used to flag the hot letter during a gauntlet hot-letter round). */
+  accent?: CellAccent;
 }
 
 const SIZE_MAP: Record<string, string> = {
@@ -169,7 +176,7 @@ export function getCellStateStyle(state: CellState, variant: CellVariant = 'simp
 
 export function Cell({
   letter, state = 'default', size = 'md', mode = 'light', variant = 'simple',
-  styleOverride, className = '', ...props
+  styleOverride, className = '', badge, accent = null, ...props
 }: CellProps) {
   const isResponsive = size === 'responsive';
   const dimension = isResponsive ? undefined : SIZE_MAP[size];
@@ -179,9 +186,30 @@ export function Cell({
 
   const stateStyle = STYLE_MAP[`${variant}-${mode}`][state];
 
+  // Hot-letter accent applies only when the cell isn't already mid-feedback,
+  // so the in-progress selection color stays the dominant signal. Recolors
+  // the cell background and (for the dice variant) the edge stack so the
+  // hot cells read as clearly different from the default beige without
+  // borrowing any of the four feedback hues (blue / green / red / yellow).
+  const accentStyle: React.CSSProperties =
+    accent === 'hot' && state === 'default'
+      ? variant === 'dice'
+        ? {
+            backgroundColor: 'var(--hot-letter-bg)',
+            color: 'var(--hot-letter-fg)',
+            boxShadow:
+              '0 3px 0 0 var(--hot-letter-edge), 0 4px 0 0 var(--hot-letter-edge-deep), 0 6px 10px var(--hot-letter-glow)',
+          }
+        : {
+            backgroundColor: 'var(--hot-letter-bg)',
+            color: 'var(--hot-letter-fg)',
+            boxShadow: '0 2px 8px var(--hot-letter-glow), 0 1px 2px rgba(0,0,0,0.04)',
+          }
+      : {};
+
   return (
     <div
-      className={`flex items-center justify-center select-none transition-all duration-[50ms] ${isResponsive ? 'flex-1' : ''} ${className}`}
+      className={`relative flex items-center justify-center select-none transition-all duration-[50ms] ${isResponsive ? 'flex-1' : ''} ${className}`}
       style={{
         width: dimension,
         height: dimension,
@@ -190,11 +218,26 @@ export function Cell({
         fontWeight: 'var(--font-cell-weight)' as any,
         fontSize,
         ...stateStyle,
+        ...accentStyle,
         ...styleOverride,
       }}
       {...props}
     >
       {letter}
+      {badge !== undefined && badge !== null && (
+        <span
+          className="absolute bottom-[6%] right-[8%] leading-none tabular-nums pointer-events-none"
+          style={{
+            fontSize: isResponsive
+              ? `calc(18cqi / var(--board-size, 4))`
+              : `calc(${fontSize} * 0.36)`,
+            opacity: 0.6,
+            fontWeight: 700,
+          }}
+        >
+          {badge}
+        </span>
+      )}
     </div>
   );
 }

--- a/client/src/shared/results/ResultsView.tsx
+++ b/client/src/shared/results/ResultsView.tsx
@@ -24,6 +24,10 @@ interface ResultsViewProps {
   /** The viewer's own results — board + found/missed words + display info. */
   me: ResultsViewer;
   board: string[][];
+  /** Optional bottom-right adornment per cell on the board preview.
+   *  Forwarded to the preview Board so modes like the gauntlet's
+   *  rare-letters round can surface per-letter point values. */
+  boardCellBadge?: (row: number, col: number, letter: string) => ReactNode;
   config: ResultsBoardConfig;
   /** Standings roster. Must include the viewer (entry with isYou=true).
    *  length === 1 collapses to the solo state (no standings panel; right
@@ -68,6 +72,7 @@ interface ResultsViewProps {
 export function ResultsView({
   me,
   board,
+  boardCellBadge,
   config,
   roster,
   loadOpponent,
@@ -260,6 +265,7 @@ export function ResultsView({
               highlightColor={highlightColor}
               config={config}
               compact
+              cellBadge={boardCellBadge}
             />
           </div>
         </section>

--- a/client/src/shared/results/components/Board.tsx
+++ b/client/src/shared/results/components/Board.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import type { Position } from 'models';
 import type { ResultsBoardConfig } from '../types';
 
@@ -11,6 +12,10 @@ interface BoardProps {
   highlightColor?: string | null;
   config: ResultsBoardConfig;
   compact?: boolean;
+  /** Optional bottom-right adornment per cell. Used by the gauntlet
+   *  rare-letters round to surface point values on the preview board so
+   *  the player can see why words add up to their scores. */
+  cellBadge?: (row: number, col: number, letter: string) => ReactNode;
 }
 
 const STEP_MS = 70;
@@ -21,6 +26,7 @@ export function Board({
   highlightColor = null,
   config,
   compact = false,
+  cellBadge,
 }: BoardProps) {
   const size = board.length;
   const [animatedCells, setAnimatedCells] = useState<Set<string>>(new Set());
@@ -55,10 +61,11 @@ export function Board({
               ? `color-mix(in srgb, ${highlightColor} 28%, transparent)`
               : 'var(--ink-trace)';
             const litBorder = highlightColor ?? 'var(--ink-mid)';
+            const badge = cellBadge?.(r, c, letter);
             return (
               <div
                 key={`${r}-${c}`}
-                className={`${compact ? 'rounded-[4px] text-[13px]' : 'rounded-[4px] text-sm'} flex items-center justify-center tabular-nums font-[family-name:var(--font-structure)] transition-[background,border-color,color] duration-150`}
+                className={`relative ${compact ? 'rounded-[4px] text-[13px]' : 'rounded-[4px] text-sm'} flex items-center justify-center tabular-nums font-[family-name:var(--font-structure)] transition-[background,border-color,color] duration-150`}
                 style={{
                   fontWeight: 700,
                   background: lit ? litBackground : 'var(--surface-card)',
@@ -69,6 +76,14 @@ export function Board({
                 }}
               >
                 {letter}
+                {badge !== undefined && badge !== null && (
+                  <span
+                    className="absolute bottom-[1px] right-[2px] leading-none tabular-nums pointer-events-none text-[8px] opacity-60"
+                    style={{ fontWeight: 700 }}
+                  >
+                    {badge}
+                  </span>
+                )}
               </div>
             );
           }),

--- a/client/src/shared/types.ts
+++ b/client/src/shared/types.ts
@@ -4,6 +4,11 @@ export interface ScoredWord {
   word: string;
   path: Position[];
   score: number;
+  /** Optional "this word scored extra" label rendered next to the score
+   *  in the post-round word list. Used by the gauntlet hot-letter round
+   *  to flag words that picked up the multiplier; left blank for modes
+   *  that don't have a per-word bonus. */
+  bonus?: string | null;
 }
 
 export interface GameResults {

--- a/client/src/shared/utils/gauntletScore.ts
+++ b/client/src/shared/utils/gauntletScore.ts
@@ -1,0 +1,1 @@
+export { scoreGauntletWord, scoreGauntletWords } from 'engine/gauntletScoring';

--- a/client/src/stories/ProfileCard.stories.tsx
+++ b/client/src/stories/ProfileCard.stories.tsx
@@ -55,6 +55,8 @@ function InContextWrapper({ completed }: { completed: boolean }) {
         dailyRank={null}
         zenSession={null}
         zenRank={null}
+        gauntletEntry={null}
+        onGauntletPlay={() => {}}
         displayName={name}
         nameProfile={null}
         onDisplayNameChange={async (n) => {

--- a/client/src/tailwind.css
+++ b/client/src/tailwind.css
@@ -53,6 +53,18 @@ button, input, select, textarea {
   --color-invalid: hsl(4, 60%, 63%);
   --color-duplicate: hsl(45, 65%, 60%);
 
+  /* Gauntlet hot-letter palette. Picked in violet so the indicator
+   * doesn't clash with the four feedback colors above (blue / green /
+   * red / yellow). Cell uses the lavender backdrop in its default state;
+   * the deeper shades drive the dice variant's edge stack and the
+   * highlight pill that flags hot-letter words in the post-round word
+   * list and on the in-progress word feedback string. */
+  --hot-letter-bg: #EDE2F7;
+  --hot-letter-edge: #D5C3EB;
+  --hot-letter-edge-deep: #BFA9DE;
+  --hot-letter-fg: #5B2F8C;
+  --hot-letter-glow: rgba(168, 85, 247, 0.35);
+
   /* Score palette — shared by results page (squares) and word list (dots).
    * Tiers 3, 5, 11 are rendered as gradients in the squares view and as solid
    * fills in the dots view, so each tier defines both a `from`/`to` gradient

--- a/engine/gauntletScoring.test.ts
+++ b/engine/gauntletScoring.test.ts
@@ -6,7 +6,7 @@ import {
 import { scoreGauntletWord } from './gauntletScoring';
 
 const regular: GauntletModifier = { kind: 'regular' };
-const hotE: GauntletModifier = { kind: 'hotLetter', letter: 'E', multiplier: 2 };
+const hotE: GauntletModifier = { kind: 'hotLetter', letter: 'E' };
 const rare: GauntletModifier = {
   kind: 'rareLetters',
   values: { ...DEFAULT_RARE_LETTER_VALUES },

--- a/engine/gauntletScoring.test.ts
+++ b/engine/gauntletScoring.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_RARE_LETTER_VALUES,
+  type GauntletModifier,
+} from 'models/gauntlet';
+import { scoreGauntletWord } from './gauntletScoring';
+
+const regular: GauntletModifier = { kind: 'regular' };
+const hotE: GauntletModifier = { kind: 'hotLetter', letter: 'E', multiplier: 2 };
+const rare: GauntletModifier = {
+  kind: 'rareLetters',
+  values: { ...DEFAULT_RARE_LETTER_VALUES },
+};
+
+describe('scoreGauntletWord', () => {
+  it('regular delegates to base length scoring', () => {
+    expect(scoreGauntletWord('CAT', regular)).toBe(1);
+    expect(scoreGauntletWord('CARTS', regular)).toBe(3);
+    expect(scoreGauntletWord('CARTING', regular)).toBe(8);
+  });
+
+  it('hot letter doubles a base score when the word contains the letter', () => {
+    expect(scoreGauntletWord('CARE', hotE)).toBe(4); // base 2 × 2
+    expect(scoreGauntletWord('TREES', hotE)).toBe(6); // base 3 × 2
+  });
+
+  it('hot letter leaves base score alone when the letter is absent', () => {
+    expect(scoreGauntletWord('CATS', hotE)).toBe(2);
+    expect(scoreGauntletWord('NIGHT', hotE)).toBe(3);
+  });
+
+  it('rare letters sums per-letter values regardless of length tiers', () => {
+    expect(scoreGauntletWord('QUIZ', rare)).toBe(10 + 1 + 1 + 10);
+    expect(scoreGauntletWord('JAZZ', rare)).toBe(8 + 1 + 10 + 10);
+    expect(scoreGauntletWord('CARE', rare)).toBe(3 + 1 + 1 + 1);
+  });
+
+  it('rare letters treats unknown characters as zero', () => {
+    const limited: GauntletModifier = { kind: 'rareLetters', values: { A: 1, B: 1 } };
+    expect(scoreGauntletWord('CAB', limited)).toBe(2);
+  });
+});

--- a/engine/gauntletScoring.ts
+++ b/engine/gauntletScoring.ts
@@ -1,10 +1,11 @@
-import type { GauntletModifier } from 'models/gauntlet';
+import { HOT_LETTER_MULTIPLIER, type GauntletModifier } from 'models/gauntlet';
 import { scoreWord } from './scoring.js';
 
 // Per-word score under a gauntlet round's modifier.
 //
 //  - regular:      delegates to the standard length-tier scorer
-//  - hotLetter:    base × multiplier when the word contains the hot letter
+//  - hotLetter:    base × HOT_LETTER_MULTIPLIER when the word contains the
+//                  hot letter
 //  - rareLetters:  sum of per-letter values, replacing length-based scoring
 //
 // The word string is whatever the player's path joined produced (e.g. a Qu
@@ -18,7 +19,7 @@ export function scoreGauntletWord(word: string, modifier: GauntletModifier): num
     case 'hotLetter': {
       const base = scoreWord(upper);
       const hot = modifier.letter.toUpperCase();
-      return upper.includes(hot) ? Math.floor(base * modifier.multiplier) : base;
+      return upper.includes(hot) ? base * HOT_LETTER_MULTIPLIER : base;
     }
     case 'rareLetters': {
       let sum = 0;

--- a/engine/gauntletScoring.ts
+++ b/engine/gauntletScoring.ts
@@ -1,0 +1,35 @@
+import type { GauntletModifier } from 'models/gauntlet';
+import { scoreWord } from './scoring.js';
+
+// Per-word score under a gauntlet round's modifier.
+//
+//  - regular:      delegates to the standard length-tier scorer
+//  - hotLetter:    base × multiplier when the word contains the hot letter
+//  - rareLetters:  sum of per-letter values, replacing length-based scoring
+//
+// The word string is whatever the player's path joined produced (e.g. a Qu
+// tile contributes both Q and U into the joined string), so iterating
+// characters here matches what the player actually sees.
+export function scoreGauntletWord(word: string, modifier: GauntletModifier): number {
+  const upper = word.toUpperCase();
+  switch (modifier.kind) {
+    case 'regular':
+      return scoreWord(upper);
+    case 'hotLetter': {
+      const base = scoreWord(upper);
+      const hot = modifier.letter.toUpperCase();
+      return upper.includes(hot) ? Math.floor(base * modifier.multiplier) : base;
+    }
+    case 'rareLetters': {
+      let sum = 0;
+      for (const ch of upper) sum += modifier.values[ch] ?? 0;
+      return sum;
+    }
+  }
+}
+
+export function scoreGauntletWords(words: string[], modifier: GauntletModifier): number {
+  let total = 0;
+  for (const w of words) total += scoreGauntletWord(w, modifier);
+  return total;
+}

--- a/engine/package.json
+++ b/engine/package.json
@@ -11,6 +11,8 @@
     "./dictionary.js": "./dictionary.ts",
     "./scoring": "./scoring.ts",
     "./scoring.js": "./scoring.ts",
+    "./gauntletScoring": "./gauntletScoring.ts",
+    "./gauntletScoring.js": "./gauntletScoring.ts",
     "./solver": "./solver.ts",
     "./solver.js": "./solver.ts"
   },

--- a/models/gauntlet.ts
+++ b/models/gauntlet.ts
@@ -6,6 +6,11 @@ export type GauntletRoundKind = 'regular' | 'hotLetter' | 'rareLetters';
 
 export const GAUNTLET_ROUND_COUNT = 3;
 
+// Single source of truth for the hot-letter bonus. Lives in models so the
+// engine scorer, server config, and client display strings all import the
+// same value. Bump here to change the bonus everywhere.
+export const HOT_LETTER_MULTIPLIER = 2;
+
 export const GAUNTLET_ROUND_KINDS: readonly GauntletRoundKind[] = [
   'regular',
   'hotLetter',
@@ -29,7 +34,7 @@ export const DEFAULT_RARE_LETTER_VALUES: Readonly<Record<string, number>> = {
 
 export type GauntletModifier =
   | { kind: 'regular' }
-  | { kind: 'hotLetter'; letter: string; multiplier: number }
+  | { kind: 'hotLetter'; letter: string }
   | { kind: 'rareLetters'; values: Record<string, number> };
 
 export interface GauntletRoundConfig {

--- a/models/gauntlet.ts
+++ b/models/gauntlet.ts
@@ -1,0 +1,69 @@
+// Daily Gauntlet — a 3-round daily chain. Each round has its own board,
+// timer, and scoring modifier. Rounds are played in order; the aggregate
+// winner is determined by sum-of-per-round-ranks (lowest wins).
+
+export type GauntletRoundKind = 'regular' | 'hotLetter' | 'rareLetters';
+
+export const GAUNTLET_ROUND_COUNT = 3;
+
+export const GAUNTLET_ROUND_KINDS: readonly GauntletRoundKind[] = [
+  'regular',
+  'hotLetter',
+  'rareLetters',
+];
+
+// Per-letter point values used by the rare-letters round. Inspired by the
+// canonical Scrabble distribution but kept as an explicit table so we can
+// tune independently. The table is carried inside the modifier itself so
+// every persisted gauntlet row is self-describing — a future tweak to the
+// defaults won't retroactively change scores stored against old rounds.
+export const DEFAULT_RARE_LETTER_VALUES: Readonly<Record<string, number>> = {
+  A: 1, E: 1, I: 1, O: 1, U: 1, L: 1, N: 1, R: 1, S: 1, T: 1,
+  D: 2, G: 2,
+  B: 3, C: 3, M: 3, P: 3,
+  F: 4, H: 4, V: 4, W: 4, Y: 4,
+  K: 5,
+  J: 8, X: 8,
+  Q: 10, Z: 10,
+};
+
+export type GauntletModifier =
+  | { kind: 'regular' }
+  | { kind: 'hotLetter'; letter: string; multiplier: number }
+  | { kind: 'rareLetters'; values: Record<string, number> };
+
+export interface GauntletRoundConfig {
+  index: number;
+  kind: GauntletRoundKind;
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+  modifier: GauntletModifier;
+}
+
+export type GauntletState = 'unplayed' | 'partial' | 'completed';
+
+export interface GauntletRoundSummary {
+  index: number;
+  kind: GauntletRoundKind;
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+  modifier: GauntletModifier;
+  points: number;
+  wordsFound: number;
+  longestWord: string;
+  endedAt: string | null;
+  rank: number | null;
+  playersCount: number;
+}
+
+export interface GauntletEntry {
+  date: string;
+  puzzleNumber: number;
+  state: GauntletState;
+  rounds: Array<GauntletRoundSummary | null>;
+  aggregateRankSum: number | null;
+  aggregateRank: number | null;
+  totalPlayersCompleted: number;
+}

--- a/models/package.json
+++ b/models/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./index.ts",
     "./seedCode": "./seedCode.ts",
-    "./zenRanks": "./zenRanks.ts"
+    "./zenRanks": "./zenRanks.ts",
+    "./gauntlet": "./gauntlet.ts"
   },
   "private": true
 }

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -60,9 +60,30 @@ export interface FeedbackTable {
   created_at: Generated<Date>;
 }
 
+export interface DailyGauntletResultsTable {
+  id: Generated<string>;
+  user_id: string;
+  date: string;
+  round_index: number;
+  round_kind: string;
+  board: string; // JSON string
+  modifier: string; // JSON string
+  found_words: Generated<string>; // JSON string
+  points: Generated<number>;
+  word_count: Generated<number>;
+  longest_word: Generated<string>;
+  board_size: number;
+  min_word_length: number;
+  time_limit: number;
+  started_at: Generated<Date>;
+  ended_at: Date | null;
+  completed_at: Date | null;
+}
+
 export interface Database {
   daily_results: DailyResultsTable;
   daily_zen_results: DailyZenResultsTable;
+  daily_gauntlet_results: DailyGauntletResultsTable;
   free_play_sessions: FreePlaySessionsTable;
   feedback: FeedbackTable;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { gameRouter } from './routes/game.js';
 import { userRouter } from './routes/user.js';
 import { dailyRouter } from './routes/daily.js';
 import { dailyZenRouter } from './routes/dailyZen.js';
+import { dailyGauntletRouter } from './routes/dailyGauntlet.js';
 import { leaderboardRouter } from './routes/leaderboard.js';
 import { freeplayRouter } from './routes/freeplay.js';
 import { feedbackRouter } from './routes/feedback.js';
@@ -49,6 +50,7 @@ app.use('/api/freeplay', freeplayRouter);
 app.use('/api/feedback', feedbackRouter);
 app.use('/api/daily/leaderboard', leaderboardRouter);
 app.use('/api/daily/zen', dailyZenRouter);
+app.use('/api/daily/gauntlet', dailyGauntletRouter);
 app.use('/api/daily', dailyRouter);
 app.use('/api/version', versionRouter);
 

--- a/server/routes/dailyGauntlet.ts
+++ b/server/routes/dailyGauntlet.ts
@@ -1,0 +1,405 @@
+import { Router } from 'express';
+import { findAllWords } from 'engine/solver.js';
+import { scoreGauntletWord } from 'engine/gauntletScoring.js';
+import { generateSalt, hashWord } from 'models';
+import {
+  GAUNTLET_ROUND_COUNT,
+  type GauntletModifier,
+} from 'models/gauntlet';
+import { requireAuth } from '../middleware/auth.js';
+import { getDb } from '../db/index.js';
+import { cachePrivate, noStore } from '../httpCache.js';
+import { dictionary } from '../services/dictionary.js';
+import { getDailyDatePST } from '../services/dailyConfig.js';
+import {
+  getDailyGauntletNumber,
+  prepareAllGauntletRounds,
+  prepareGauntletRound,
+} from '../services/dailyGauntletConfig.js';
+import {
+  endGauntletRound,
+  getGauntletAggregate,
+  getGauntletRoundRanks,
+  getGauntletRoundSession,
+  getGauntletStatus,
+  startGauntletRound,
+  submitGauntletWord,
+} from '../services/DailyGauntletService.js';
+import { getDisplayNames } from '../services/displayNames.js';
+
+export const dailyGauntletRouter = Router();
+
+// Cache solved boards per (date, round) so the dictionary solver runs
+// at most once per round per day. Salted hashes are re-generated per
+// request, but the underlying word list comes from this cache.
+const solvedRoundCache = new Map<string, { totalFindable: number; words: string[] }>();
+
+function solveRoundBoard(
+  board: string[][],
+  date: string,
+  roundIndex: number,
+  minWordLength: number,
+): { totalFindable: number; salt: string; wordHashes: string[] } {
+  const key = `${date}:${roundIndex}:${board.flat().join('')}`;
+  let solved = solvedRoundCache.get(key);
+  if (!solved) {
+    const all = findAllWords(board, dictionary, minWordLength);
+    solved = { totalFindable: all.length, words: all.map((w) => w.word) };
+    solvedRoundCache.set(key, solved);
+  }
+  const salt = generateSalt();
+  const wordHashes = solved.words.map((word) => hashWord(word, salt));
+  return { totalFindable: solved.totalFindable, salt, wordHashes };
+}
+
+function parseRoundIndex(raw: string): number | null {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n >= GAUNTLET_ROUND_COUNT) return null;
+  return n;
+}
+
+// ─── Today's status (hub payload) ────────────────────────────────────────
+
+dailyGauntletRouter.get('/', requireAuth, async (req, res) => {
+  try {
+    const date = getDailyDatePST();
+    const status = await getGauntletStatus(getDb(), req.userId!, date);
+    noStore(res);
+    res.json({
+      date,
+      puzzleNumber: getDailyGauntletNumber(date),
+      ...status,
+    });
+  } catch (err) {
+    console.error('Failed to fetch gauntlet status:', err);
+    res.status(500).json({ error: 'Failed to fetch gauntlet status' });
+  }
+});
+
+// Returns just the round configs (no user state) for /preview-style use.
+// Useful for confirm-page rendering before /start has been called.
+dailyGauntletRouter.get('/:date/preview', requireAuth, (req, res) => {
+  try {
+    const rounds = prepareAllGauntletRounds(req.params.date);
+    res.json({
+      date: req.params.date,
+      puzzleNumber: getDailyGauntletNumber(req.params.date),
+      rounds: rounds.map((r) => ({ config: r.config })),
+    });
+  } catch (err) {
+    console.error('Failed to preview gauntlet:', err);
+    res.status(500).json({ error: 'Failed to preview gauntlet' });
+  }
+});
+
+// ─── Per-round session lifecycle ─────────────────────────────────────────
+
+dailyGauntletRouter.get('/:date/round/:round', requireAuth, async (req, res) => {
+  const roundIndex = parseRoundIndex(req.params.round);
+  if (roundIndex === null) {
+    return res.status(400).json({ error: 'Invalid round index' });
+  }
+  try {
+    const session = await getGauntletRoundSession(
+      getDb(),
+      req.userId!,
+      req.params.date,
+      roundIndex,
+    );
+    if (!session) {
+      noStore(res);
+      return res.json({ session: null });
+    }
+    const { totalFindable, salt, wordHashes } = solveRoundBoard(
+      session.board,
+      req.params.date,
+      roundIndex,
+      session.config.minWordLength,
+    );
+    noStore(res);
+    res.json({
+      session: {
+        ...session,
+        total_findable: totalFindable,
+        salt,
+        wordHashes,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to fetch gauntlet round session:', err);
+    res.status(500).json({ error: 'Failed to fetch session' });
+  }
+});
+
+dailyGauntletRouter.post('/:date/round/:round/start', requireAuth, async (req, res) => {
+  const roundIndex = parseRoundIndex(req.params.round);
+  if (roundIndex === null) {
+    return res.status(400).json({ error: 'Invalid round index' });
+  }
+  const date = req.params.date;
+  const today = getDailyDatePST();
+  if (date !== today) {
+    return res.status(400).json({ error: 'Can only start today\'s gauntlet round' });
+  }
+  try {
+    const result = await startGauntletRound(getDb(), req.userId!, date, roundIndex);
+    if ('error' in result) {
+      if (result.error === 'locked') return res.status(409).json({ error: 'previous_round_incomplete' });
+      return res.status(400).json({ error: 'invalid_round' });
+    }
+    const { totalFindable, salt, wordHashes } = solveRoundBoard(
+      result.board,
+      date,
+      roundIndex,
+      result.config.minWordLength,
+    );
+    noStore(res);
+    res.json({
+      session: { ...result, total_findable: totalFindable, salt, wordHashes },
+    });
+  } catch (err) {
+    console.error('Failed to start gauntlet round:', err);
+    res.status(500).json({ error: 'Failed to start round' });
+  }
+});
+
+dailyGauntletRouter.post('/:date/round/:round/word', requireAuth, async (req, res) => {
+  const roundIndex = parseRoundIndex(req.params.round);
+  if (roundIndex === null) {
+    return res.status(400).json({ error: 'Invalid round index' });
+  }
+  const path = req.body?.path;
+  if (!Array.isArray(path)) {
+    return res.status(400).json({ error: 'Missing path' });
+  }
+  try {
+    const outcome = await submitGauntletWord(
+      getDb(),
+      req.userId!,
+      req.params.date,
+      roundIndex,
+      path,
+    );
+    noStore(res);
+    res.json(outcome);
+  } catch (err) {
+    console.error('Failed to submit gauntlet word:', err);
+    res.status(500).json({ error: 'Failed to submit word' });
+  }
+});
+
+dailyGauntletRouter.post('/:date/round/:round/end', requireAuth, async (req, res) => {
+  const roundIndex = parseRoundIndex(req.params.round);
+  if (roundIndex === null) {
+    return res.status(400).json({ error: 'Invalid round index' });
+  }
+  try {
+    const session = await endGauntletRound(
+      getDb(),
+      req.userId!,
+      req.params.date,
+      roundIndex,
+    );
+    if (!session) {
+      return res.status(404).json({ error: 'No session to end' });
+    }
+    noStore(res);
+    res.json({ session });
+  } catch (err) {
+    console.error('Failed to end gauntlet round:', err);
+    res.status(500).json({ error: 'Failed to end round' });
+  }
+});
+
+// ─── Per-round results (deep-dive page) ──────────────────────────────────
+
+dailyGauntletRouter.get('/:date/round/:round/results', requireAuth, async (req, res) => {
+  const roundIndex = parseRoundIndex(req.params.round);
+  if (roundIndex === null) {
+    return res.status(400).json({ error: 'Invalid round index' });
+  }
+  try {
+    const db = getDb();
+    const session = await getGauntletRoundSession(
+      db,
+      req.userId!,
+      req.params.date,
+      roundIndex,
+    );
+    if (!session || !session.endedAt) {
+      noStore(res);
+      return res.json({ result: null });
+    }
+
+    const foundSet = new Set(session.foundWords.map((w) => w.toUpperCase()));
+    const missedWords = findAllWords(session.board, dictionary, session.config.minWordLength)
+      .filter((w) => !foundSet.has(w.word))
+      .map((w) => ({
+        word: w.word,
+        path: w.path,
+        score: scoreGauntletWord(w.word, session.modifier as GauntletModifier),
+      }))
+      .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
+
+    cachePrivate(res, 60);
+    res.json({
+      result: {
+        date: session.date,
+        roundIndex,
+        roundKind: session.roundKind,
+        modifier: session.modifier,
+        config: session.config,
+        board: session.board,
+        found_words: session.foundWords,
+        points: session.points,
+        word_count: session.wordCount,
+        longest_word: session.longestWord,
+        missed_words: missedWords,
+        completed_at: session.completedAt,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to fetch gauntlet round results:', err);
+    res.status(500).json({ error: 'Failed to fetch results' });
+  }
+});
+
+// ─── Aggregate results + leaderboard ─────────────────────────────────────
+
+dailyGauntletRouter.get('/:date/leaderboard', requireAuth, async (req, res) => {
+  try {
+    const db = getDb();
+    const date = req.params.date;
+    const [perRound, aggregate] = await Promise.all([
+      getGauntletRoundRanks(db, date),
+      getGauntletAggregate(db, date),
+    ]);
+
+    // Display names resolved in one pass against the union of users
+    // appearing in either list. Cached helper so repeated calls within
+    // the TTL hit memory.
+    const userIds = new Set<string>();
+    for (const r of perRound) userIds.add(r.user_id);
+    for (const a of aggregate) userIds.add(a.userId);
+    const names = await getDisplayNames(Array.from(userIds));
+
+    cachePrivate(res, 30);
+    res.json({
+      date,
+      puzzleNumber: getDailyGauntletNumber(date),
+      currentUserId: req.userId,
+      perRound: perRound.map((r) => ({
+        userId: r.user_id,
+        displayName: names.get(r.user_id) ?? 'Anonymous',
+        roundIndex: r.round_index,
+        points: r.points,
+        wordCount: r.word_count,
+        rank: r.rank,
+      })),
+      aggregate: aggregate.map((a) => ({
+        userId: a.userId,
+        displayName: names.get(a.userId) ?? 'Anonymous',
+        roundRanks: a.roundRanks,
+        rankSum: a.rankSum,
+        aggregateRank: a.aggregateRank,
+      })),
+    });
+  } catch (err) {
+    console.error('Failed to fetch gauntlet leaderboard:', err);
+    res.status(500).json({ error: 'Failed to fetch leaderboard' });
+  }
+});
+
+// Side-by-side compare for a single gauntlet round. Mirrors the timed
+// daily /compare endpoint shape so the shared ResultsView's
+// loadOpponent surface plugs in without bespoke handling. Both players
+// must have finalized the round; the response carries each side's
+// scored word list against the shared board + modifier.
+dailyGauntletRouter.get(
+  '/:date/round/:round/compare',
+  requireAuth,
+  async (req, res) => {
+    const roundIndex = parseRoundIndex(req.params.round);
+    if (roundIndex === null) {
+      return res.status(400).json({ error: 'Invalid round index' });
+    }
+    const { date } = req.params;
+    const otherUserId = typeof req.query.other === 'string' ? req.query.other : '';
+    const meUserId = req.userId!;
+    if (!otherUserId) {
+      return res.status(400).json({ error: 'Missing query param: other' });
+    }
+    if (otherUserId === meUserId) {
+      return res.status(400).json({ error: 'Cannot compare with yourself' });
+    }
+
+    try {
+      const db = getDb();
+      const rows = await db
+        .selectFrom('daily_gauntlet_results')
+        .selectAll()
+        .where('date', '=', date)
+        .where('round_index', '=', roundIndex)
+        .where('user_id', 'in', [meUserId, otherUserId])
+        .execute();
+
+      const mine = rows.find((r) => r.user_id === meUserId);
+      const theirs = rows.find((r) => r.user_id === otherUserId);
+      if (!mine || !mine.ended_at) {
+        return res.status(409).json({ error: 'You have not played this round yet' });
+      }
+      if (!theirs || !theirs.ended_at) {
+        return res.status(404).json({ error: 'Opponent has not played this round' });
+      }
+
+      const names = await getDisplayNames([meUserId, otherUserId]);
+      const modifier = (typeof theirs.modifier === 'string'
+        ? JSON.parse(theirs.modifier)
+        : theirs.modifier) as GauntletModifier;
+      const parseWords = (raw: unknown): string[] =>
+        typeof raw === 'string' ? JSON.parse(raw) : (raw as string[]);
+      const myWords = parseWords(mine.found_words);
+      const theirWords = parseWords(theirs.found_words);
+      const board = (typeof mine.board === 'string'
+        ? JSON.parse(mine.board)
+        : mine.board) as string[][];
+
+      const scored = (word: string) => ({
+        word,
+        score: scoreGauntletWord(word, modifier),
+      });
+
+      cachePrivate(res, 30);
+      res.json({
+        date,
+        roundIndex,
+        roundKind: theirs.round_kind,
+        modifier,
+        puzzleNumber: getDailyGauntletNumber(date),
+        board,
+        config: {
+          boardSize: mine.board_size,
+          minWordLength: mine.min_word_length,
+          timeLimit: mine.time_limit,
+        },
+        me: {
+          userId: meUserId,
+          displayName: names.get(meUserId) ?? 'Anonymous',
+          points: mine.points,
+          wordCount: mine.word_count,
+          foundWords: myWords.map(scored),
+        },
+        them: {
+          userId: otherUserId,
+          displayName: names.get(otherUserId) ?? 'Anonymous',
+          points: theirs.points,
+          wordCount: theirs.word_count,
+          foundWords: theirWords.map(scored),
+        },
+      });
+    } catch (err) {
+      console.error('Failed to fetch gauntlet compare:', err);
+      res.status(500).json({ error: 'Failed to fetch compare' });
+    }
+  },
+);

--- a/server/routes/dailyGauntlet.ts
+++ b/server/routes/dailyGauntlet.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { findAllWords } from 'engine/solver.js';
-import { scoreGauntletWord } from 'engine/gauntletScoring.js';
 import { generateSalt, hashWord } from 'models';
 import {
   GAUNTLET_ROUND_COUNT,
@@ -22,6 +21,7 @@ import {
   getGauntletRoundRanks,
   getGauntletRoundSession,
   getGauntletStatus,
+  scoreFoundWords,
   startGauntletRound,
   submitGauntletWord,
 } from '../services/DailyGauntletService.js';
@@ -232,13 +232,14 @@ dailyGauntletRouter.get('/:date/round/:round/results', requireAuth, async (req, 
     }
 
     const foundSet = new Set(session.foundWords.map((w) => w.toUpperCase()));
-    const missedWords = findAllWords(session.board, dictionary, session.config.minWordLength)
-      .filter((w) => !foundSet.has(w.word))
-      .map((w) => ({
-        word: w.word,
-        path: w.path,
-        score: scoreGauntletWord(w.word, session.modifier as GauntletModifier),
-      }))
+    const missed = findAllWords(session.board, dictionary, session.config.minWordLength)
+      .filter((w) => !foundSet.has(w.word));
+    const scoredMissed = scoreFoundWords(
+      missed.map((w) => w.word),
+      session.modifier as GauntletModifier,
+    );
+    const missedWords = missed
+      .map((w, i) => ({ word: w.word, path: w.path, score: scoredMissed[i].score }))
       .sort((a, b) => b.score - a.score || b.word.length - a.word.length);
 
     cachePrivate(res, 60);
@@ -364,11 +365,6 @@ dailyGauntletRouter.get(
         ? JSON.parse(mine.board)
         : mine.board) as string[][];
 
-      const scored = (word: string) => ({
-        word,
-        score: scoreGauntletWord(word, modifier),
-      });
-
       cachePrivate(res, 30);
       res.json({
         date,
@@ -387,14 +383,14 @@ dailyGauntletRouter.get(
           displayName: names.get(meUserId) ?? 'Anonymous',
           points: mine.points,
           wordCount: mine.word_count,
-          foundWords: myWords.map(scored),
+          foundWords: scoreFoundWords(myWords, modifier),
         },
         them: {
           userId: otherUserId,
           displayName: names.get(otherUserId) ?? 'Anonymous',
           points: theirs.points,
           wordCount: theirs.word_count,
-          foundWords: theirWords.map(scored),
+          foundWords: scoreFoundWords(theirWords, modifier),
         },
       });
     } catch (err) {

--- a/server/services/DailyGauntletService.test.ts
+++ b/server/services/DailyGauntletService.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateFromRoundRanks, type RankedRow } from './DailyGauntletService.js';
+
+function row(
+  user: string,
+  roundIndex: number,
+  rank: number,
+  completedAt: string,
+  points = 0,
+  wordCount = 0,
+): RankedRow {
+  return {
+    user_id: user,
+    date: '2026-05-21',
+    round_index: roundIndex,
+    points,
+    word_count: wordCount,
+    rank,
+    completed_at: new Date(completedAt),
+  };
+}
+
+describe('aggregateFromRoundRanks', () => {
+  it('drops players who have not finalized every round', () => {
+    const ranked: RankedRow[] = [
+      row('a', 0, 1, '2026-05-21T12:00:00Z'),
+      row('a', 1, 2, '2026-05-21T12:05:00Z'),
+      // 'a' missing round 2
+      row('b', 0, 2, '2026-05-21T12:00:00Z'),
+      row('b', 1, 3, '2026-05-21T12:05:00Z'),
+      row('b', 2, 1, '2026-05-21T12:10:00Z'),
+    ];
+    const out = aggregateFromRoundRanks(ranked, 3);
+    expect(out.map((e) => e.userId)).toEqual(['b']);
+  });
+
+  it('lowest rank-sum wins, with round ranks ordered by round_index', () => {
+    const ranked: RankedRow[] = [
+      // 'a' submits in reverse order — output must still order ranks by round.
+      row('a', 2, 3, '2026-05-21T12:10:00Z'),
+      row('a', 0, 1, '2026-05-21T12:00:00Z'),
+      row('a', 1, 2, '2026-05-21T12:05:00Z'),
+      row('b', 0, 4, '2026-05-21T12:00:00Z'),
+      row('b', 1, 4, '2026-05-21T12:05:00Z'),
+      row('b', 2, 4, '2026-05-21T12:10:00Z'),
+    ];
+    const out = aggregateFromRoundRanks(ranked, 3);
+    expect(out[0].userId).toBe('a');
+    expect(out[0].roundRanks).toEqual([1, 2, 3]);
+    expect(out[0].rankSum).toBe(6);
+    expect(out[0].aggregateRank).toBe(1);
+    expect(out[1].userId).toBe('b');
+    expect(out[1].rankSum).toBe(12);
+    expect(out[1].aggregateRank).toBe(2);
+  });
+
+  it('tiebreaks rank-sum ties on best single-round rank', () => {
+    // Both 'a' and 'b' have rank-sum 6, but 'a' has a 1st-place round
+    // while 'b' has no rank better than 2. Specialist wins.
+    const ranked: RankedRow[] = [
+      row('a', 0, 1, '2026-05-21T12:00:00Z'),
+      row('a', 1, 2, '2026-05-21T12:05:00Z'),
+      row('a', 2, 3, '2026-05-21T12:10:00Z'),
+      row('b', 0, 2, '2026-05-21T12:00:00Z'),
+      row('b', 1, 2, '2026-05-21T12:05:00Z'),
+      row('b', 2, 2, '2026-05-21T12:10:00Z'),
+    ];
+    const out = aggregateFromRoundRanks(ranked, 3);
+    expect(out.map((e) => e.userId)).toEqual(['a', 'b']);
+    expect(out[0].aggregateRank).toBe(1);
+    expect(out[1].aggregateRank).toBe(2);
+  });
+
+  it('tiebreaks identical rank-sum + best-single on earliest last-finish', () => {
+    // 'a' and 'b' identical rank-sum (6) and best (2). 'a' finished round
+    // 2 earlier, so it places first.
+    const ranked: RankedRow[] = [
+      row('a', 0, 2, '2026-05-21T12:00:00Z'),
+      row('a', 1, 2, '2026-05-21T12:05:00Z'),
+      row('a', 2, 2, '2026-05-21T12:10:00Z'),
+      row('b', 0, 2, '2026-05-21T12:00:00Z'),
+      row('b', 1, 2, '2026-05-21T12:05:00Z'),
+      row('b', 2, 2, '2026-05-21T12:15:00Z'),
+    ];
+    const out = aggregateFromRoundRanks(ranked, 3);
+    expect(out.map((e) => e.userId)).toEqual(['a', 'b']);
+  });
+
+  it('dense-ranks true ties (same rank-sum, best, and last-finish)', () => {
+    // Identical on all three keys → dense rank assigns same number to
+    // both; the next distinct player gets the next sequential rank.
+    const ranked: RankedRow[] = [
+      row('a', 0, 1, '2026-05-21T12:00:00Z'),
+      row('a', 1, 1, '2026-05-21T12:05:00Z'),
+      row('a', 2, 1, '2026-05-21T12:10:00Z'),
+      row('b', 0, 1, '2026-05-21T12:00:00Z'),
+      row('b', 1, 1, '2026-05-21T12:05:00Z'),
+      row('b', 2, 1, '2026-05-21T12:10:00Z'),
+      row('c', 0, 5, '2026-05-21T12:00:00Z'),
+      row('c', 1, 5, '2026-05-21T12:05:00Z'),
+      row('c', 2, 5, '2026-05-21T12:10:00Z'),
+    ];
+    const out = aggregateFromRoundRanks(ranked, 3);
+    const byUser = new Map(out.map((e) => [e.userId, e.aggregateRank]));
+    expect(byUser.get('a')).toBe(1);
+    expect(byUser.get('b')).toBe(1);
+    // Dense rank: the next distinct group takes index+1, not "rank after
+    // skipping ties". For 'c' that's position 3 (zero-indexed 2 → +1).
+    expect(byUser.get('c')).toBe(3);
+  });
+
+  it('lastFinishedAt is the latest completed_at across the three rounds', () => {
+    // Submitting round 1 last (later than round 2) should still produce a
+    // lastFinishedAt that reflects the latest timestamp.
+    const ranked: RankedRow[] = [
+      row('a', 0, 1, '2026-05-21T12:00:00Z'),
+      row('a', 1, 1, '2026-05-21T12:30:00Z'),
+      row('a', 2, 1, '2026-05-21T12:15:00Z'),
+    ];
+    const out = aggregateFromRoundRanks(ranked, 3);
+    expect(out[0].lastFinishedAt.toISOString()).toBe('2026-05-21T12:30:00.000Z');
+  });
+
+  it('returns empty when no players have finalized all rounds', () => {
+    const ranked: RankedRow[] = [
+      row('a', 0, 1, '2026-05-21T12:00:00Z'),
+      row('a', 1, 1, '2026-05-21T12:05:00Z'),
+    ];
+    expect(aggregateFromRoundRanks(ranked, 3)).toEqual([]);
+  });
+});

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -1,0 +1,611 @@
+import { sql, type Kysely } from 'kysely';
+import { isValidPath } from 'engine/adjacency.js';
+import { isValidWord } from 'engine/dictionary.js';
+import { scoreGauntletWord } from 'engine/gauntletScoring.js';
+import type { Position } from 'models';
+import {
+  GAUNTLET_ROUND_COUNT,
+  type GauntletEntry,
+  type GauntletModifier,
+  type GauntletRoundConfig,
+  type GauntletRoundKind,
+  type GauntletRoundSummary,
+  type GauntletState,
+} from 'models/gauntlet';
+import type { Database } from '../db/types.js';
+import { dictionary } from './dictionary.js';
+import {
+  getDailyGauntletNumber,
+  prepareGauntletRound,
+} from './dailyGauntletConfig.js';
+
+// Same grace window as timed daily — a few hundred ms of client/server
+// clock drift shouldn't reject the last fairly-played word.
+export const TIMED_GAUNTLET_GRACE_SECONDS = 2;
+
+export interface GauntletRoundSession {
+  date: string;
+  roundIndex: number;
+  roundKind: GauntletRoundKind;
+  board: string[][];
+  modifier: GauntletModifier;
+  config: {
+    boardSize: number;
+    timeLimit: number;
+    minWordLength: number;
+  };
+  foundWords: string[];
+  points: number;
+  wordCount: number;
+  longestWord: string;
+  startedAt: Date;
+  endedAt: Date | null;
+  completedAt: Date | null;
+}
+
+export type GauntletSubmitOutcome =
+  | { valid: true; word: string; score: number }
+  | { valid: false; reason: 'invalid' | 'repeat' | 'ended' | 'expired' | 'not_started' | 'locked' };
+
+// Per-round score-with-aggregates. Returns the data we persist alongside
+// the row. Mirrors scoreResult in DailyService but uses the gauntlet
+// scorer so the round's modifier shapes the point total.
+export function scoreGauntletResult(
+  words: string[],
+  modifier: GauntletModifier,
+): { points: number; wordCount: number; longestWord: string } {
+  let longestWord = '';
+  let points = 0;
+  for (const word of words) {
+    points += scoreGauntletWord(word, modifier);
+    if (
+      word.length > longestWord.length ||
+      (word.length === longestWord.length && word < longestWord)
+    ) {
+      longestWord = word;
+    }
+  }
+  return { points, wordCount: words.length, longestWord };
+}
+
+function parseSessionRow(row: {
+  date: string;
+  round_index: number;
+  round_kind: string;
+  board: unknown;
+  modifier: unknown;
+  found_words: unknown;
+  points: number;
+  word_count: number;
+  longest_word: string;
+  board_size: number;
+  min_word_length: number;
+  time_limit: number;
+  started_at: Date;
+  ended_at: Date | null;
+  completed_at: Date | null;
+}): GauntletRoundSession {
+  const board = typeof row.board === 'string' ? JSON.parse(row.board) : (row.board as string[][]);
+  const modifier = typeof row.modifier === 'string'
+    ? JSON.parse(row.modifier)
+    : (row.modifier as GauntletModifier);
+  const foundWords = typeof row.found_words === 'string'
+    ? JSON.parse(row.found_words)
+    : (row.found_words as string[]);
+  return {
+    date: row.date,
+    roundIndex: row.round_index,
+    roundKind: row.round_kind as GauntletRoundKind,
+    board,
+    modifier,
+    config: {
+      boardSize: row.board_size,
+      timeLimit: row.time_limit,
+      minWordLength: row.min_word_length,
+    },
+    foundWords,
+    points: row.points,
+    wordCount: row.word_count,
+    longestWord: row.longest_word,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function isExpired(
+  session: { startedAt: Date; config: { timeLimit: number } },
+  now: Date,
+): boolean {
+  const elapsed = Math.floor((now.getTime() - session.startedAt.getTime()) / 1000);
+  return elapsed > session.config.timeLimit + TIMED_GAUNTLET_GRACE_SECONDS;
+}
+
+function expiryInstant(
+  session: { startedAt: Date; config: { timeLimit: number } },
+): Date {
+  return new Date(session.startedAt.getTime() + session.config.timeLimit * 1000);
+}
+
+async function autoFinalizeIfExpired(
+  db: Kysely<Database>,
+  userId: string,
+  session: GauntletRoundSession,
+): Promise<GauntletRoundSession> {
+  if (session.endedAt || !isExpired(session, new Date())) return session;
+  const endedAt = expiryInstant(session);
+  await db
+    .updateTable('daily_gauntlet_results')
+    .set({ ended_at: endedAt, completed_at: endedAt })
+    .where('user_id', '=', userId)
+    .where('date', '=', session.date)
+    .where('round_index', '=', session.roundIndex)
+    .where('ended_at', 'is', null)
+    .execute();
+  return { ...session, endedAt, completedAt: endedAt };
+}
+
+export async function getGauntletRoundSession(
+  db: Kysely<Database>,
+  userId: string,
+  date: string,
+  roundIndex: number,
+): Promise<GauntletRoundSession | null> {
+  const row = await db
+    .selectFrom('daily_gauntlet_results')
+    .select([
+      'date',
+      'round_index',
+      'round_kind',
+      'board',
+      'modifier',
+      'found_words',
+      'points',
+      'word_count',
+      'longest_word',
+      'board_size',
+      'min_word_length',
+      'time_limit',
+      'started_at',
+      'ended_at',
+      'completed_at',
+    ])
+    .where('user_id', '=', userId)
+    .where('date', '=', date)
+    .where('round_index', '=', roundIndex)
+    .executeTakeFirst();
+  if (!row) return null;
+  return autoFinalizeIfExpired(db, userId, parseSessionRow(row));
+}
+
+// Returns all rounds the player has at least started for the date, indexed
+// by round_index. Used both to check the sequential gate and to render
+// the gauntlet hub.
+async function getRoundsForUser(
+  db: Kysely<Database>,
+  userId: string,
+  date: string,
+): Promise<Map<number, GauntletRoundSession>> {
+  const rows = await db
+    .selectFrom('daily_gauntlet_results')
+    .select([
+      'date',
+      'round_index',
+      'round_kind',
+      'board',
+      'modifier',
+      'found_words',
+      'points',
+      'word_count',
+      'longest_word',
+      'board_size',
+      'min_word_length',
+      'time_limit',
+      'started_at',
+      'ended_at',
+      'completed_at',
+    ])
+    .where('user_id', '=', userId)
+    .where('date', '=', date)
+    .execute();
+  const map = new Map<number, GauntletRoundSession>();
+  for (const row of rows) {
+    let session = parseSessionRow(row);
+    session = await autoFinalizeIfExpired(db, userId, session);
+    map.set(session.roundIndex, session);
+  }
+  return map;
+}
+
+// Sequential gate: round N can only start if rounds 0..N-1 are ended.
+// Returns the index of the first round that is *not* eligible to start
+// because the predecessor isn't done, or null if the requested round
+// is fine to start.
+function gateBlocked(
+  rounds: Map<number, GauntletRoundSession>,
+  roundIndex: number,
+): boolean {
+  for (let i = 0; i < roundIndex; i++) {
+    const prior = rounds.get(i);
+    if (!prior || !prior.endedAt) return true;
+  }
+  return false;
+}
+
+// Idempotent. Locks in the board + modifier captured at start time so a
+// resumed page after reload sees the exact same round. Enforces the
+// sequential gate — round N requires rounds 0..N-1 ended.
+export async function startGauntletRound(
+  db: Kysely<Database>,
+  userId: string,
+  date: string,
+  roundIndex: number,
+): Promise<GauntletRoundSession | { error: 'locked' | 'invalid_round' }> {
+  if (roundIndex < 0 || roundIndex >= GAUNTLET_ROUND_COUNT) {
+    return { error: 'invalid_round' };
+  }
+  const existingRounds = await getRoundsForUser(db, userId, date);
+
+  const existing = existingRounds.get(roundIndex);
+  if (existing) return existing; // idempotent
+
+  if (gateBlocked(existingRounds, roundIndex)) {
+    return { error: 'locked' };
+  }
+
+  const prepared = prepareGauntletRound(date, roundIndex);
+  await db
+    .insertInto('daily_gauntlet_results')
+    .values({
+      user_id: userId,
+      date,
+      round_index: roundIndex,
+      round_kind: prepared.config.kind,
+      board: JSON.stringify(prepared.board),
+      modifier: JSON.stringify(prepared.config.modifier),
+      found_words: JSON.stringify([]),
+      board_size: prepared.config.boardSize,
+      min_word_length: prepared.config.minWordLength,
+      time_limit: prepared.config.timeLimit,
+    })
+    .onConflict((oc) => oc.columns(['user_id', 'date', 'round_index']).doNothing())
+    .execute();
+
+  const session = await getGauntletRoundSession(db, userId, date, roundIndex);
+  if (!session) throw new Error('Failed to start gauntlet round');
+  return session;
+}
+
+export async function submitGauntletWord(
+  db: Kysely<Database>,
+  userId: string,
+  date: string,
+  roundIndex: number,
+  path: Position[],
+): Promise<GauntletSubmitOutcome> {
+  const session = await getGauntletRoundSession(db, userId, date, roundIndex);
+  if (!session) return { valid: false, reason: 'not_started' };
+  if (session.endedAt) return { valid: false, reason: 'ended' };
+
+  if (!isValidPath(path, session.config.boardSize)) {
+    return { valid: false, reason: 'invalid' };
+  }
+
+  const word = path
+    .map((pos) => session.board[pos.row][pos.col])
+    .join('')
+    .toUpperCase();
+
+  if (word.length < session.config.minWordLength) {
+    return { valid: false, reason: 'invalid' };
+  }
+  if (!isValidWord(dictionary, word.toLowerCase())) {
+    return { valid: false, reason: 'invalid' };
+  }
+  if (session.foundWords.some((w) => w.toUpperCase() === word)) {
+    return { valid: false, reason: 'repeat' };
+  }
+
+  const nextWords = [...session.foundWords, word];
+  const { points, wordCount, longestWord } = scoreGauntletResult(nextWords, session.modifier);
+
+  await db
+    .updateTable('daily_gauntlet_results')
+    .set({
+      found_words: JSON.stringify(nextWords),
+      points,
+      word_count: wordCount,
+      longest_word: longestWord,
+    })
+    .where('user_id', '=', userId)
+    .where('date', '=', date)
+    .where('round_index', '=', roundIndex)
+    .where('ended_at', 'is', null)
+    .execute();
+
+  return {
+    valid: true,
+    word,
+    score: scoreGauntletWord(word, session.modifier),
+  };
+}
+
+export async function endGauntletRound(
+  db: Kysely<Database>,
+  userId: string,
+  date: string,
+  roundIndex: number,
+): Promise<GauntletRoundSession | null> {
+  const session = await getGauntletRoundSession(db, userId, date, roundIndex);
+  if (!session) return null;
+  if (session.endedAt) return session;
+
+  const now = new Date();
+  const cap = expiryInstant(session);
+  const endedAt = now > cap ? cap : now;
+
+  await db
+    .updateTable('daily_gauntlet_results')
+    .set({ ended_at: endedAt, completed_at: endedAt })
+    .where('user_id', '=', userId)
+    .where('date', '=', date)
+    .where('round_index', '=', roundIndex)
+    .where('ended_at', 'is', null)
+    .execute();
+  return getGauntletRoundSession(db, userId, date, roundIndex);
+}
+
+// ─── Ranking ──────────────────────────────────────────────────────────────
+
+interface RankedRow {
+  user_id: string;
+  date: string;
+  round_index: number;
+  points: number;
+  word_count: number;
+  rank: number;
+  completed_at: Date;
+}
+
+// Per-round ranks across all finalized rows on the date. Used to render
+// per-round leaderboards and to feed the aggregate. Tiebreak mirrors
+// timed daily: points desc, word_count desc, completed_at asc.
+export async function getGauntletRoundRanks(
+  db: Kysely<Database>,
+  date: string,
+): Promise<RankedRow[]> {
+  const rows = await db
+    .with('ranked', (qb) =>
+      qb
+        .selectFrom('daily_gauntlet_results')
+        .select((eb) => [
+          'user_id',
+          'date',
+          'round_index',
+          'points',
+          'word_count',
+          'completed_at',
+          sql<number>`rank() over (partition by ${eb.ref('round_index')} order by ${eb.ref('points')} desc, ${eb.ref('word_count')} desc, ${eb.ref('completed_at')} asc)`.as('rank'),
+        ])
+        .where('date', '=', date)
+        .where('ended_at', 'is not', null),
+    )
+    .selectFrom('ranked')
+    .select(['user_id', 'date', 'round_index', 'points', 'word_count', 'completed_at', 'rank'])
+    .execute();
+  return rows.map((r) => ({
+    user_id: r.user_id,
+    date: r.date,
+    round_index: r.round_index,
+    points: Number(r.points),
+    word_count: Number(r.word_count),
+    rank: Number(r.rank),
+    completed_at: r.completed_at as Date,
+  }));
+}
+
+export interface AggregateEntry {
+  userId: string;
+  roundRanks: number[];           // length 3
+  rankSum: number;
+  bestSingleRank: number;
+  lastFinishedAt: Date;
+  aggregateRank: number;          // global rank by rankSum
+}
+
+// Aggregate ranks across all 3 rounds. Only includes players who have
+// finalized all three rounds. Tiebreak order:
+//   primary:    rankSum asc (lower = better — the gauntlet "score")
+//   secondary:  best single-round rank (rewards specialists when tied)
+//   tertiary:   last-round completed_at asc (earliest finisher wins)
+export async function getGauntletAggregate(
+  db: Kysely<Database>,
+  date: string,
+): Promise<AggregateEntry[]> {
+  const ranked = await getGauntletRoundRanks(db, date);
+
+  // Bucket per user. A player needs exactly GAUNTLET_ROUND_COUNT entries.
+  const byUser = new Map<string, RankedRow[]>();
+  for (const r of ranked) {
+    const list = byUser.get(r.user_id) ?? [];
+    list.push(r);
+    byUser.set(r.user_id, list);
+  }
+
+  const entries: AggregateEntry[] = [];
+  for (const [userId, rows] of byUser) {
+    if (rows.length < GAUNTLET_ROUND_COUNT) continue;
+    rows.sort((a, b) => a.round_index - b.round_index);
+    const roundRanks = rows.map((r) => r.rank);
+    const rankSum = roundRanks.reduce((s, r) => s + r, 0);
+    const bestSingleRank = Math.min(...roundRanks);
+    const lastFinishedAt = rows.reduce(
+      (latest, r) => (r.completed_at > latest ? r.completed_at : latest),
+      rows[0].completed_at,
+    );
+    entries.push({
+      userId,
+      roundRanks,
+      rankSum,
+      bestSingleRank,
+      lastFinishedAt,
+      aggregateRank: 0,
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (a.rankSum !== b.rankSum) return a.rankSum - b.rankSum;
+    if (a.bestSingleRank !== b.bestSingleRank) return a.bestSingleRank - b.bestSingleRank;
+    return a.lastFinishedAt.getTime() - b.lastFinishedAt.getTime();
+  });
+
+  // Dense-rank by (rankSum, bestSingleRank, lastFinishedAt) so tied
+  // players share a rank. The trio is unique enough in practice that
+  // pure ties are rare, but keeping dense-rank semantics avoids
+  // surprising the player who is "tied for 3rd" with a 4th-place display.
+  let lastKey = '';
+  let lastRank = 0;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    const key = `${e.rankSum}|${e.bestSingleRank}|${e.lastFinishedAt.getTime()}`;
+    if (key !== lastKey) {
+      lastRank = i + 1;
+      lastKey = key;
+    }
+    e.aggregateRank = lastRank;
+  }
+
+  return entries;
+}
+
+// ─── Status helper used by the hub + results pages ───────────────────────
+
+function gauntletState(rounds: Map<number, GauntletRoundSession>): GauntletState {
+  let endedCount = 0;
+  for (let i = 0; i < GAUNTLET_ROUND_COUNT; i++) {
+    if (rounds.get(i)?.endedAt) endedCount++;
+  }
+  if (endedCount === 0) {
+    // A round started but not ended still counts as "partial" from the
+    // user's perspective — they've engaged with the gauntlet today.
+    for (let i = 0; i < GAUNTLET_ROUND_COUNT; i++) {
+      if (rounds.get(i)) return 'partial';
+    }
+    return 'unplayed';
+  }
+  if (endedCount === GAUNTLET_ROUND_COUNT) return 'completed';
+  return 'partial';
+}
+
+export interface GauntletStatus {
+  entry: GauntletEntry;
+  // Index of the round the player should play next, or null if all done.
+  nextRoundIndex: number | null;
+  // Per-round configs for rounds the player has not yet started — sent
+  // so the confirm page can describe the upcoming round before /start
+  // creates the row.
+  upcomingConfigs: Record<number, GauntletRoundConfig>;
+  // Round *kinds* for every round (including locked ones), so the hub
+  // can show "Hot letter" / "Rare letters" as titles for not-yet-playable
+  // rounds without revealing the specific modifier instance (e.g. which
+  // letter is hot — that's the reveal-on-start moment).
+  roundKinds: GauntletRoundKind[];
+}
+
+export async function getGauntletStatus(
+  db: Kysely<Database>,
+  userId: string,
+  date: string,
+): Promise<GauntletStatus> {
+  const rounds = await getRoundsForUser(db, userId, date);
+  const state = gauntletState(rounds);
+
+  // Per-round rank lookups — only needed once all 3 rounds are ended,
+  // but cheap to fetch for partial states too so the hub can show
+  // provisional ranks on rounds the player has finalized.
+  const ranks = await getGauntletRoundRanks(db, date);
+  const userRankByRound = new Map<number, number>();
+  const playersByRound = new Map<number, number>();
+  for (const r of ranks) {
+    if (r.user_id === userId) userRankByRound.set(r.round_index, r.rank);
+    playersByRound.set(r.round_index, (playersByRound.get(r.round_index) ?? 0) + 1);
+  }
+
+  const summaries: Array<GauntletRoundSummary | null> = [];
+  let nextRoundIndex: number | null = null;
+  const upcomingConfigs: Record<number, GauntletRoundConfig> = {};
+
+  for (let i = 0; i < GAUNTLET_ROUND_COUNT; i++) {
+    const session = rounds.get(i);
+    if (!session) {
+      summaries.push(null);
+      // Sequential gate: the first not-started round whose predecessor is
+      // ended (or which has no predecessor) is the playable one.
+      if (nextRoundIndex === null) {
+        const priorEnded = i === 0 || rounds.get(i - 1)?.endedAt != null;
+        if (priorEnded) {
+          nextRoundIndex = i;
+          upcomingConfigs[i] = prepareGauntletRound(date, i).config;
+        }
+      }
+      continue;
+    }
+    if (!session.endedAt && nextRoundIndex === null) {
+      // Already-started-but-not-ended round is the playable one — the
+      // player resumes here instead of advancing.
+      nextRoundIndex = i;
+    }
+    summaries.push({
+      index: i,
+      kind: session.roundKind,
+      boardSize: session.config.boardSize,
+      timeLimit: session.config.timeLimit,
+      minWordLength: session.config.minWordLength,
+      modifier: session.modifier,
+      points: session.points,
+      wordsFound: session.wordCount,
+      longestWord: session.longestWord,
+      endedAt: session.endedAt ? session.endedAt.toISOString() : null,
+      rank: userRankByRound.get(i) ?? null,
+      playersCount: playersByRound.get(i) ?? 0,
+    });
+  }
+
+  // Aggregate rank only meaningful once the player has finalized all 3.
+  let aggregateRankSum: number | null = null;
+  let aggregateRank: number | null = null;
+  let totalPlayersCompleted = 0;
+  if (state === 'completed') {
+    const aggregate = await getGauntletAggregate(db, date);
+    totalPlayersCompleted = aggregate.length;
+    const mine = aggregate.find((a) => a.userId === userId);
+    if (mine) {
+      aggregateRankSum = mine.rankSum;
+      aggregateRank = mine.aggregateRank;
+    }
+  }
+
+  const roundKinds: GauntletRoundKind[] = [];
+  for (let i = 0; i < GAUNTLET_ROUND_COUNT; i++) {
+    // Round kinds are fixed by index; prepareGauntletRound returns the
+    // config shape deterministically from the date+index. We only need
+    // the kind here, so derive it without exposing the modifier instance
+    // for locked rounds.
+    roundKinds.push(prepareGauntletRound(date, i).config.kind);
+  }
+
+  return {
+    entry: {
+      date,
+      puzzleNumber: getDailyGauntletNumber(date),
+      state,
+      rounds: summaries,
+      aggregateRankSum,
+      aggregateRank,
+      totalPlayersCompleted,
+    },
+    nextRoundIndex,
+    upcomingConfigs,
+    roundKinds,
+  };
+}

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -68,6 +68,17 @@ export function scoreGauntletResult(
   return { points, wordCount: words.length, longestWord };
 }
 
+// Pairs each word with its per-word score under the round's modifier.
+// Route handlers use this for results / compare payloads so the modifier
+// is applied through the service rather than reimplemented inline at the
+// edge — keeps a single seam if the scoring rules ever change.
+export function scoreFoundWords(
+  words: string[],
+  modifier: GauntletModifier,
+): Array<{ word: string; score: number }> {
+  return words.map((word) => ({ word, score: scoreGauntletWord(word, modifier) }));
+}
+
 function parseSessionRow(row: {
   date: string;
   round_index: number;
@@ -357,7 +368,7 @@ export async function endGauntletRound(
 
 // ─── Ranking ──────────────────────────────────────────────────────────────
 
-interface RankedRow {
+export interface RankedRow {
   user_id: string;
   date: string;
   round_index: number;
@@ -413,18 +424,14 @@ export interface AggregateEntry {
   aggregateRank: number;          // global rank by rankSum
 }
 
-// Aggregate ranks across all 3 rounds. Only includes players who have
-// finalized all three rounds. Tiebreak order:
-//   primary:    rankSum asc (lower = better — the gauntlet "score")
-//   secondary:  best single-round rank (rewards specialists when tied)
-//   tertiary:   last-round completed_at asc (earliest finisher wins)
-export async function getGauntletAggregate(
-  db: Kysely<Database>,
-  date: string,
-): Promise<AggregateEntry[]> {
-  const ranked = await getGauntletRoundRanks(db, date);
-
-  // Bucket per user. A player needs exactly GAUNTLET_ROUND_COUNT entries.
+// Pure aggregation step. Splits out from getGauntletAggregate so the
+// rank-sum / tiebreak / dense-rank logic can be unit-tested without a
+// database. Only includes players with exactly `roundCount` rows. The
+// caller is expected to pass GAUNTLET_ROUND_COUNT in production.
+export function aggregateFromRoundRanks(
+  ranked: RankedRow[],
+  roundCount: number,
+): AggregateEntry[] {
   const byUser = new Map<string, RankedRow[]>();
   for (const r of ranked) {
     const list = byUser.get(r.user_id) ?? [];
@@ -434,7 +441,7 @@ export async function getGauntletAggregate(
 
   const entries: AggregateEntry[] = [];
   for (const [userId, rows] of byUser) {
-    if (rows.length < GAUNTLET_ROUND_COUNT) continue;
+    if (rows.length < roundCount) continue;
     rows.sort((a, b) => a.round_index - b.round_index);
     const roundRanks = rows.map((r) => r.rank);
     const rankSum = roundRanks.reduce((s, r) => s + r, 0);
@@ -476,6 +483,19 @@ export async function getGauntletAggregate(
   }
 
   return entries;
+}
+
+// Aggregate ranks across all 3 rounds. Only includes players who have
+// finalized all three rounds. Tiebreak order:
+//   primary:    rankSum asc (lower = better — the gauntlet "score")
+//   secondary:  best single-round rank (rewards specialists when tied)
+//   tertiary:   last-round completed_at asc (earliest finisher wins)
+export async function getGauntletAggregate(
+  db: Kysely<Database>,
+  date: string,
+): Promise<AggregateEntry[]> {
+  const ranked = await getGauntletRoundRanks(db, date);
+  return aggregateFromRoundRanks(ranked, GAUNTLET_ROUND_COUNT);
 }
 
 // ─── Status helper used by the hub + results pages ───────────────────────

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -220,6 +220,48 @@ function stampTierFor(rank: number, totalPlayers: number): StampTier {
   return null;
 }
 
+// Set of dates in the window where the user engaged with any daily mode.
+// Used by the unified streak — a played-day signal that doesn't require
+// the user to have submitted to a specific mode.
+async function getUserPlayedDatesAcrossModes(
+  db: Kysely<Database>,
+  userId: string,
+  windowStart: string,
+  windowEnd: string,
+): Promise<Set<string>> {
+  const dates = new Set<string>();
+
+  const [timed, zen, gauntlet] = await Promise.all([
+    db
+      .selectFrom('daily_results')
+      .select('date')
+      .where('user_id', '=', userId)
+      .where('date', '>=', windowStart)
+      .where('date', '<=', windowEnd)
+      .where('ended_at', 'is not', null)
+      .execute(),
+    db
+      .selectFrom('daily_zen_results')
+      .select('date')
+      .where('user_id', '=', userId)
+      .where('date', '>=', windowStart)
+      .where('date', '<=', windowEnd)
+      .execute(),
+    db
+      .selectFrom('daily_gauntlet_results')
+      .select('date')
+      .where('user_id', '=', userId)
+      .where('date', '>=', windowStart)
+      .where('date', '<=', windowEnd)
+      .execute(),
+  ]);
+
+  for (const row of timed) dates.add(row.date);
+  for (const row of zen) dates.add(row.date);
+  for (const row of gauntlet) dates.add(row.date);
+  return dates;
+}
+
 export async function getDailyStats(
   db: Kysely<Database>,
   userId: string,
@@ -331,12 +373,26 @@ export async function getDailyStats(
     });
   }
 
-  // Streak: walk backwards from today; today missing is not a break yet.
+  // Streak is unified across all daily modes: playing the timed daily,
+  // the zen daily, or the gauntlet on a given date all count as a played
+  // day. The per-day stats below stay timed-specific (points/longest/etc.
+  // only make sense for the timed mode), but the streak signal reflects
+  // every form of daily engagement so users aren't punished for choosing
+  // a mode that doesn't have streak semantics of its own.
+  const playedDates = await getUserPlayedDatesAcrossModes(
+    db,
+    userId,
+    windowStart,
+    windowEnd,
+  );
+
+  // Walk backwards from today; today missing is not a break yet.
   let currentStreak = 0;
   for (let i = days.length - 1; i >= 0; i--) {
     const day = days[i];
-    if (i === days.length - 1 && day.state === 'unplayed') continue;
-    if (day.state !== 'completed') break;
+    const played = playedDates.has(day.date);
+    if (i === days.length - 1 && !played) continue;
+    if (!played) break;
     currentStreak++;
   }
 
@@ -347,7 +403,7 @@ export async function getDailyStats(
   const tail = days.slice(-7);
   const streakDays: boolean[] = [
     ...Array(Math.max(0, 7 - tail.length)).fill(false),
-    ...tail.map((d) => d.state === 'completed'),
+    ...tail.map((d) => playedDates.has(d.date)),
   ];
 
   // 7-day avg: last 7 PLAYED days anywhere in window. Includes today if

--- a/server/services/dailyGauntletConfig.ts
+++ b/server/services/dailyGauntletConfig.ts
@@ -1,0 +1,114 @@
+import { generateSeededBoard } from 'engine/board.js';
+import type { Board } from 'models';
+import {
+  DEFAULT_RARE_LETTER_VALUES,
+  GAUNTLET_ROUND_COUNT,
+  type GauntletModifier,
+  type GauntletRoundConfig,
+  type GauntletRoundKind,
+} from 'models/gauntlet';
+import { mulberry32 } from 'models/seedCode';
+
+export const DAILY_GAUNTLET_LAUNCH_DATE = '2026-05-21';
+
+interface RoundShape {
+  kind: GauntletRoundKind;
+  boardSize: number;
+  timeLimit: number;
+  minWordLength: number;
+}
+
+// Round configs are fixed up front. The three rounds are deliberately
+// distinct in board size + modifier so each round has a single, legible
+// twist. We keep min_word_length and time_limit identical across rounds
+// so the only thing the player has to learn round-to-round is the
+// modifier — board geometry and pacing stay stable.
+const ROUND_SHAPES: Readonly<Record<number, RoundShape>> = {
+  0: { kind: 'regular', boardSize: 4, timeLimit: 120, minWordLength: 4 },
+  1: { kind: 'hotLetter', boardSize: 5, timeLimit: 120, minWordLength: 4 },
+  2: { kind: 'rareLetters', boardSize: 5, timeLimit: 120, minWordLength: 4 },
+};
+
+function fnv1a(str: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+export function getGauntletRoundSeed(dateStr: string, index: number): number {
+  return fnv1a(`froggle-gauntlet-${dateStr}-${index}`);
+}
+
+export function getDailyGauntletNumber(dateStr: string): number {
+  const launch = new Date(DAILY_GAUNTLET_LAUNCH_DATE + 'T00:00:00Z');
+  const current = new Date(dateStr + 'T00:00:00Z');
+  const diffMs = current.getTime() - launch.getTime();
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000)) + 1;
+}
+
+// Pick a hot letter by sampling cell *characters* uniformly. A Qu tile
+// contributes both Q and U as independent candidates, so a one-off Qu
+// gives equal odds to either letter. This naturally weights toward
+// letters that show up more often on the board, which keeps the
+// modifier impactful instead of landing on a single Z most words avoid.
+function pickHotLetter(board: Board, prng: () => number): string {
+  const chars: string[] = [];
+  for (const row of board) {
+    for (const cell of row) {
+      for (const ch of cell.toUpperCase()) chars.push(ch);
+    }
+  }
+  return chars[Math.floor(prng() * chars.length)] ?? 'E';
+}
+
+function buildModifier(
+  kind: GauntletRoundKind,
+  board: Board,
+  prng: () => number,
+): GauntletModifier {
+  switch (kind) {
+    case 'regular':
+      return { kind: 'regular' };
+    case 'hotLetter':
+      return { kind: 'hotLetter', letter: pickHotLetter(board, prng), multiplier: 2 };
+    case 'rareLetters':
+      return { kind: 'rareLetters', values: { ...DEFAULT_RARE_LETTER_VALUES } };
+  }
+}
+
+export interface PreparedGauntletRound {
+  config: GauntletRoundConfig;
+  board: Board;
+  seed: number;
+}
+
+export function prepareGauntletRound(
+  dateStr: string,
+  index: number,
+): PreparedGauntletRound {
+  const shape = ROUND_SHAPES[index];
+  if (!shape) throw new Error(`Invalid gauntlet round index: ${index}`);
+  const seed = getGauntletRoundSeed(dateStr, index);
+  const board = generateSeededBoard(shape.boardSize, seed);
+  // Derive modifier RNG from a transformation of the seed so the modifier
+  // and the board don't share the same PRNG stream — picking the hot
+  // letter shouldn't be perfectly correlated with the board's first cell.
+  const prng = mulberry32((seed ^ 0xa5a5a5a5) >>> 0);
+  const modifier = buildModifier(shape.kind, board, prng);
+  return {
+    config: { ...shape, index, modifier },
+    board,
+    seed,
+  };
+}
+
+export function prepareAllGauntletRounds(dateStr: string): PreparedGauntletRound[] {
+  const rounds: PreparedGauntletRound[] = [];
+  for (let i = 0; i < GAUNTLET_ROUND_COUNT; i++) {
+    rounds.push(prepareGauntletRound(dateStr, i));
+  }
+  return rounds;
+}

--- a/server/services/dailyGauntletConfig.ts
+++ b/server/services/dailyGauntletConfig.ts
@@ -73,7 +73,7 @@ function buildModifier(
     case 'regular':
       return { kind: 'regular' };
     case 'hotLetter':
-      return { kind: 'hotLetter', letter: pickHotLetter(board, prng), multiplier: 2 };
+      return { kind: 'hotLetter', letter: pickHotLetter(board, prng) };
     case 'rareLetters':
       return { kind: 'rareLetters', values: { ...DEFAULT_RARE_LETTER_VALUES } };
   }

--- a/supabase/migrations/20260521000000_create_daily_gauntlet_results.sql
+++ b/supabase/migrations/20260521000000_create_daily_gauntlet_results.sql
@@ -1,0 +1,41 @@
+-- Daily Gauntlet mode: a 3-round chain played sequentially in a day.
+-- One row per (user, date, round). The row is created when the player
+-- starts a round; the board + modifier captured at start-time are
+-- persisted so the row stays interpretable even if round-generation
+-- logic shifts later. Submissions append to found_words and update
+-- aggregates; the row is finalized on player /end or auto-finalize
+-- when the round's time limit elapses.
+--
+-- Aggregate ranking is computed at read time as sum-of-per-round-ranks
+-- across the three rounds the user finished — no denormalized aggregate
+-- column is stored, so tweaks to per-round ranking tiebreaks
+-- automatically propagate to the gauntlet leaderboard.
+
+create table public.daily_gauntlet_results (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  date text not null,
+  round_index smallint not null check (round_index between 0 and 2),
+  round_kind text not null check (round_kind in ('regular', 'hotLetter', 'rareLetters')),
+  board jsonb not null,
+  modifier jsonb not null,
+  found_words jsonb not null default '[]'::jsonb,
+  points int not null default 0,
+  word_count int not null default 0,
+  longest_word text not null default '',
+  board_size smallint not null,
+  min_word_length smallint not null,
+  time_limit int not null,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  completed_at timestamptz,
+  unique(user_id, date, round_index)
+);
+
+create index idx_daily_gauntlet_results_date_round
+  on public.daily_gauntlet_results(date, round_index);
+create index idx_daily_gauntlet_results_user_date
+  on public.daily_gauntlet_results(user_id, date);
+create index idx_daily_gauntlet_results_date_ended
+  on public.daily_gauntlet_results(date)
+  where ended_at is not null;


### PR DESCRIPTION
Adds Daily Gauntlet, a three-round daily mode with regular, hot-letter, and rare-letter rounds, sequential round flow, per-round results, aggregate standings, and landing-page entry points.

Adds shared gauntlet models and scoring plus client API, routes, UI components, and board/result rendering updates for modifier-aware play and comparison.

Adds authenticated server routes and services, deterministic daily gauntlet config, a persistence migration, leaderboard aggregation, and scoring and aggregate-rank tests.