### PR TITLE
chore(changelog): add daily gauntlet entry

### DIFF
--- a/client/src/shared/changelog/entries/2026-05-22-daily-gauntlet.tsx
+++ b/client/src/shared/changelog/entries/2026-05-22-daily-gauntlet.tsx
@@ -9,7 +9,7 @@ const entry: ChangelogEntry = {
     <>
       <p>
         A new daily mode chains three rounds back to back, each with its
-        own scoring twist:
+        own scoring twist!
       </p>
       <ul>
         <li>
@@ -24,8 +24,7 @@ const entry: ChangelogEntry = {
       </ul>
       <p>
         Your gauntlet standing is the sum of your three round ranks —
-        lowest wins. Crushing one round and stumbling in another can still
-        come out ahead.
+        lowest wins!
       </p>
     </>
   ),

--- a/client/src/shared/changelog/entries/2026-05-22-daily-gauntlet.tsx
+++ b/client/src/shared/changelog/entries/2026-05-22-daily-gauntlet.tsx
@@ -1,0 +1,34 @@
+import type { ChangelogEntry } from '../types';
+
+const entry: ChangelogEntry = {
+  id: 'daily-gauntlet-2026-05-22',
+  date: '2026-05-22',
+  kind: 'major',
+  title: 'Daily Gauntlet',
+  body: (
+    <>
+      <p>
+        A new daily mode chains three rounds back to back, each with its
+        own scoring twist:
+      </p>
+      <ul>
+        <li>
+          <strong>Standard</strong> — regular play, no twist
+        </li>
+        <li>
+          <strong>Bonus</strong> — one letter on the board scores 2×
+        </li>
+        <li>
+          <strong>Bounty</strong> — every letter has its own point value
+        </li>
+      </ul>
+      <p>
+        Your gauntlet standing is the sum of your three round ranks —
+        lowest wins. Crushing one round and stumbling in another can still
+        come out ahead.
+      </p>
+    </>
+  ),
+};
+
+export default entry;


### PR DESCRIPTION
## Summary
- Adds the changelog entry that should have shipped with #91. Major entry under `client/src/shared/changelog/entries/2026-05-22-daily-gauntlet.tsx` introducing the three rounds (Standard / Bonus / Bounty) and how the gauntlet standing is scored.

## Why this approach
- Each changelog entry is its own file (per the comment in `entries.tsx`), so adding one as a separate PR keeps merges conflict-free and surfaces on next visit just like any other entry.

## Follow-ups
- None.

## Test plan
- [ ] Pull the branch, run `npm run dev`, clear the changelog-seen key, and confirm the "Daily Gauntlet" card appears in the What's new sheet on next landing visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)