### PR TITLE
feat(freeplay): server-resume mid-game on refresh

### DIFF
--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -20,6 +20,7 @@ import type {
 } from './shared/api/gameApi';
 import {
   endDailyTimedSession,
+  fetchActiveFreePlaySession,
   fetchDaily,
   fetchDailyResult,
   fetchDailyTimedSession,
@@ -131,6 +132,12 @@ interface GameContextValue {
   session: Session | null;
   authReady: boolean;
 
+  // True once the server-resume probe for an in-progress free-play row
+  // has settled. Routes that would otherwise bounce a null-game user
+  // away from /game should wait for this before redirecting so a
+  // mid-game refresh doesn't strand the player on the landing screen.
+  freePlayHydrated: boolean;
+
   // Profile
   displayName: string;
   nameProfile: ProfileResponse | null;
@@ -146,7 +153,7 @@ export function useGame() {
 }
 
 export function GameProvider({ children }: { children: ReactNode }) {
-  const { game, words, results, gameSeed, createGame, startGame, cancelGame, endGame, fetchGameState, submitWord } = useGameApi();
+  const { game, words, results, gameSeed, createGame, startGame, cancelGame, endGame, fetchGameState, submitWord, hydrate } = useGameApi();
   const [feedback, setFeedback] = useState<{ type: FeedbackType; path: Position[] } | null>(null);
   const [muted, setMuted] = useState(loadMuted);
   const [dailyInfo, setDailyInfo] = useState<DailyInfo | null>(null);
@@ -226,6 +233,56 @@ export function GameProvider({ children }: { children: ReactNode }) {
     fetchProfile()
       .then((profile) => applyProfile(profile))
       .catch(() => {}); // Fall back to default 'Anonymous'
+  }, [authReady]);
+
+  // Resume an in-progress free-play game from server state when the user
+  // refreshes mid-play. Mirrors the daily-timed session-fetch pattern:
+  // GameProvider mounts → anonymous auth completes → we ask the server
+  // whether the caller has an unfinished row and rehydrate React state
+  // from it, so the existing /game route + timer pick up where they left
+  // off.
+  //
+  // The fetch runs exactly once per mount, gated on authReady. Stashing
+  // hydrate + game into refs lets the .then closure read the latest
+  // values without putting them in the effect dep array — which would
+  // otherwise cause the effect to re-run on every render and have its
+  // cleanup cancel the in-flight resume.
+  //
+  // freePlayHydrated stays false until this fetch settles, so route
+  // components that would otherwise bounce a null-game user away from
+  // /game can hold the redirect until we know whether there's a session
+  // to resume.
+  const [freePlayHydrated, setFreePlayHydrated] = useState(false);
+  const hydrateAttemptedRef = useRef(false);
+  const hydrateRef = useRef(hydrate);
+  const gameRef = useRef(game);
+  useEffect(() => {
+    hydrateRef.current = hydrate;
+    gameRef.current = game;
+  });
+  useEffect(() => {
+    if (!authReady || hydrateAttemptedRef.current) return;
+    hydrateAttemptedRef.current = true;
+    fetchActiveFreePlaySession()
+      .then((session) => {
+        if (session && !gameRef.current) {
+          hydrateRef.current({
+            game: session.game,
+            foundWords: session.found_words,
+            salt: session.salt,
+            wordHashes: session.wordHashes,
+            seed: session.seed,
+          });
+          if (session.challenge_id) setActiveChallengeId(session.challenge_id);
+        }
+      })
+      .catch(() => {
+        // Network blip or 401 — the user just won't get a resume. Better
+        // than crashing the app at boot.
+      })
+      .finally(() => {
+        setFreePlayHydrated(true);
+      });
   }, [authReady]);
 
   const timeRemaining = useTimer(game, fetchGameState);
@@ -654,6 +711,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       showHomeConfirm, setShowHomeConfirm,
       theme, toggleTheme,
       session, authReady,
+      freePlayHydrated,
       displayName, nameProfile, updateDisplayName,
     }}>
       <div data-theme={theme} className="contents">

--- a/client/src/hooks/useGameApi.ts
+++ b/client/src/hooks/useGameApi.ts
@@ -51,6 +51,29 @@ export const useGameApi = () => {
     submittedWordsRef.current = new Set();
   };
 
+  // Rehydrates state from a server-resumed session so a page refresh
+  // during free play picks up the in-progress game instead of dropping
+  // it. Path arrays aren't stored server-side (only word strings are),
+  // so resumed words render without a board-replay path until the game
+  // ends and /results recomputes them — the practical impact is none
+  // because the in-game word list shows the word text alone.
+  const hydrate = (params: {
+    game: Game;
+    foundWords: string[];
+    salt: string;
+    wordHashes: string[];
+    seed: number | null;
+  }) => {
+    setGame(params.game);
+    setWords(params.foundWords.map((word) => ({ word, path: [], submittedAt: 0 })));
+    setGameSeed(params.seed);
+    setResults(null);
+    fetchingResults.current = false;
+    wordHashesRef.current = new Set(params.wordHashes);
+    saltRef.current = params.salt;
+    submittedWordsRef.current = new Set(params.foundWords.map((w) => w.toUpperCase()));
+  };
+
   const endGame = async () => {
     const data = await gameApi.endGame();
     setGame(data.game);
@@ -122,5 +145,6 @@ export const useGameApi = () => {
     endGame,
     fetchGameState,
     submitWord,
+    hydrate,
   };
 };

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -16,12 +16,15 @@ export const useTimer = (game: Game | null, onTimeExpired: () => void) => {
         return;
       }
 
-      // Record a client-local start time the first time we see this game in progress.
-      // Use performance.now() (monotonic clock) instead of Date.now() to avoid jumps
-      // caused by NTP clock synchronization on Android, which would make elapsed time
-      // spike and the timer display less time remaining than it should.
+      // Anchor a client-local start time the first time we see this game in progress.
+      // Seed from the server's startedAt so a page refresh resumes the existing
+      // countdown instead of restarting it. After this one-time read of the wall
+      // clock, all subsequent ticks use performance.now() (monotonic) to avoid jumps
+      // from NTP clock synchronization on Android, which would otherwise make the
+      // timer display less time remaining than it should.
       if (localStartRef.current === null) {
-        localStartRef.current = performance.now();
+        const serverElapsedMs = Math.max(0, Date.now() - game.startedAt);
+        localStartRef.current = performance.now() - serverElapsedMs;
       }
       const localStart = localStartRef.current;
 

--- a/client/src/pages/config/ConfigRoute.tsx
+++ b/client/src/pages/config/ConfigRoute.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { GameState } from 'models';
 import { useGame } from '../../GameContext';
 import { GameConfigPage } from './GameConfigPage';
 import type { GameConfig } from './types';
@@ -37,6 +38,17 @@ export function ConfigRoute() {
   const sharedGame = useMemo(() => decodeGameParams(searchParams), [searchParams]);
   const isSharedGame = sharedGame !== null;
   const challengeId = sharedGame?.challengeId;
+
+  // GameProvider hydrates an in-progress free-play row at mount; if one
+  // resumed, send the player back into /game instead of dropping them on
+  // the config screen for a game that's already underway. The Finished
+  // case is intentionally left to fall through — the player needs a
+  // start affordance to begin a fresh game once their old one's done.
+  useEffect(() => {
+    if (game?.status === GameState.InProgress) {
+      navigate('/game', { replace: true });
+    }
+  }, [game?.status, navigate]);
 
   useEffect(() => {
     if (initRef.current) return;

--- a/client/src/pages/game/GameRoute.tsx
+++ b/client/src/pages/game/GameRoute.tsx
@@ -22,12 +22,14 @@ export function GameRoute() {
     dailyTimeRemaining,
     handleSubmitDailyWord,
     endDailyGame,
+    freePlayHydrated,
   } = useGame();
   const navigate = useNavigate();
   const navigatingRef = useRef(false);
 
   // Daily mode dispatches to its own session-backed game state; free play
-  // continues to use the in-memory GameController session.
+  // is also DB-backed now via /api/game/active, with GameProvider
+  // hydrating React state at mount.
   const isDaily = !!dailyInfo;
   const activeGame = isDaily ? dailyGame : game;
   const activeTime = isDaily ? dailyTimeRemaining : timeRemaining;
@@ -37,8 +39,11 @@ export function GameRoute() {
     : !!results;
 
   useEffect(() => {
+    // Free-play null-game might just mean hydration hasn't settled yet
+    // after a mid-game refresh. Hold the redirect until the probe is
+    // done so the player isn't bounced to landing on every reload.
     if (!activeGame) {
-      navigate('/');
+      if (isDaily || freePlayHydrated) navigate('/');
     } else if (
       activeGame.status === GameState.Finished &&
       activeFinished &&
@@ -47,7 +52,7 @@ export function GameRoute() {
       navigatingRef.current = true;
       navigate(isDaily ? '/daily/results' : '/results');
     }
-  }, [activeGame, activeGame?.status, activeFinished, navigate, isDaily]);
+  }, [activeGame, activeGame?.status, activeFinished, navigate, isDaily, freePlayHydrated]);
 
   if (!activeGame || activeGame.status !== GameState.InProgress) return null;
 

--- a/client/src/pages/game/components/TimerBar.tsx
+++ b/client/src/pages/game/components/TimerBar.tsx
@@ -7,7 +7,12 @@ interface TimerBarProps {
 
 export const TimerBar = ({ game }: TimerBarProps) => {
   const [remainingPercentage, setRemainingPercentage] = useState(100);
-  const localStartRef = useRef<number>(performance.now());
+  // Anchor the local start time against the server-issued game.startedAt
+  // so a refresh mid-play picks up where the bar was, instead of snapping
+  // back to 100%. The one-time wall-clock read mirrors useTimer's
+  // approach — subsequent ticks stay on performance.now() (monotonic) to
+  // avoid jumps from NTP sync on Android.
+  const localStartRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (game.config.durationSeconds <= 0) {
@@ -15,6 +20,10 @@ export const TimerBar = ({ game }: TimerBarProps) => {
       return;
     }
 
+    if (localStartRef.current === null) {
+      const serverElapsedMs = Math.max(0, Date.now() - game.startedAt);
+      localStartRef.current = performance.now() - serverElapsedMs;
+    }
     const localStart = localStartRef.current;
 
     const updateTimerBar = () => {
@@ -27,7 +36,7 @@ export const TimerBar = ({ game }: TimerBarProps) => {
     updateTimerBar();
     const interval = setInterval(updateTimerBar, 100);
     return () => clearInterval(interval);
-  }, [game.config.durationSeconds]);
+  }, [game.config.durationSeconds, game.startedAt]);
 
   const isUnlimited = game.config.durationSeconds <= 0;
 

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -131,6 +131,29 @@ export const fetchGameState = async (): Promise<{
   return response.json();
 };
 
+export interface ActiveFreePlaySession {
+  id: string;
+  game: Game;
+  found_words: string[];
+  challenge_id: string | null;
+  seed: number | null;
+  salt: string;
+  wordHashes: string[];
+}
+
+/** Server-authoritative resume payload for a free-play game still
+ *  in progress. Returned by GET /api/game/active. Used at mount to
+ *  rehydrate React state so a refresh during free play picks up where
+ *  the player left off instead of restarting the timer. */
+export const fetchActiveFreePlaySession = async (): Promise<ActiveFreePlaySession | null> => {
+  const response = await fetch(`${API_URL}/game/active`, {
+    headers: await sessionHeaders(),
+  });
+  if (!response.ok) return null;
+  const data = await response.json();
+  return data.session ?? null;
+};
+
 export const fetchResults = async (): Promise<GameResults> => {
   const response = await fetch(`${API_URL}/game/results`, {
     headers: await sessionHeaders(),

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -41,7 +41,8 @@ export interface FreePlaySessionsTable {
   date: string;
   found_words: Generated<string>;
   board: string;
-  completed_at: Generated<Date>;
+  started_at: Generated<Date>;
+  completed_at: Date | null;
   points: Generated<number>;
   word_count: Generated<number>;
   longest_word: Generated<string>;

--- a/server/routes/freeplay.ts
+++ b/server/routes/freeplay.ts
@@ -63,6 +63,7 @@ freeplayRouter.get('/history', requireAuth, async (req, res) => {
         'seed',
       ])
       .where('user_id', '=', req.userId!)
+      .where('completed_at', 'is not', null)
       .orderBy('completed_at', 'desc')
       .limit(200)
       .execute();
@@ -71,7 +72,11 @@ freeplayRouter.get('/history', requireAuth, async (req, res) => {
     // /api/game/start before the daily-skip flag landed. Filter them out
     // by matching seed + config against the canonical daily for the row's
     // date so the free-play history stays dedicated to free-play games.
-    const rows = rawRows.filter((r) => !isDailyRow(r));
+    // completed_at is non-null by the WHERE filter above; narrow the type
+    // so downstream consumers (toISOString, getTime) don't need guards.
+    const rows = rawRows.filter(
+      (r): r is typeof r & { completed_at: Date } => !isDailyRow(r) && r.completed_at !== null,
+    );
 
     // For every challenge the caller participated in (owned or joined),
     // pull every other participant once and reduce twice: a participant
@@ -90,7 +95,8 @@ freeplayRouter.get('/history', requireAuth, async (req, res) => {
         .selectFrom('free_play_sessions')
         .select(['id', 'challenge_id', 'completed_at', 'points', 'word_count'])
         .where('challenge_id', 'in', challengeIds)
-        .execute();
+        .where('completed_at', 'is not', null)
+        .execute() as { id: string; challenge_id: string | null; completed_at: Date; points: number; word_count: number }[];
       for (const p of participants) {
         const cid = p.challenge_id!;
         playerCountByChallenge.set(cid, (playerCountByChallenge.get(cid) ?? 0) + 1);
@@ -170,7 +176,8 @@ freeplayRouter.get('/unread', requireAuth, async (req, res) => {
       .select(['id', 'completed_at', 'last_viewed_at'])
       .where('user_id', '=', req.userId!)
       .whereRef('id', '=', 'challenge_id')
-      .execute();
+      .where('completed_at', 'is not', null)
+      .execute() as { id: string; completed_at: Date; last_viewed_at: Date | null }[];
 
     if (ownedRows.length === 0) {
       cachePrivate(res, 15);
@@ -181,7 +188,8 @@ freeplayRouter.get('/unread', requireAuth, async (req, res) => {
       .selectFrom('free_play_sessions')
       .select(['id', 'challenge_id', 'completed_at'])
       .where('challenge_id', 'in', ownedRows.map((r) => r.id))
-      .execute();
+      .where('completed_at', 'is not', null)
+      .execute() as { id: string; challenge_id: string | null; completed_at: Date }[];
 
     const counts = computeChallengeNewResults(
       ownedRows.map((r) => ({
@@ -224,6 +232,12 @@ freeplayRouter.get('/session/:sessionId', requireAuth, async (req, res) => {
     if (row.user_id !== req.userId!) {
       return res.status(403).json({ error: 'Cannot view another player\'s session' });
     }
+    // Mid-game sessions don't have a results view yet — the player needs
+    // to finish (or time out) before the saved-replay payload makes sense.
+    if (!row.completed_at) {
+      return res.status(404).json({ error: 'Session not finished' });
+    }
+    const completedAt = row.completed_at;
 
     const board: string[][] = typeof row.board === 'string' ? JSON.parse(row.board) : row.board;
     const foundWords: string[] = typeof row.found_words === 'string'
@@ -246,7 +260,7 @@ freeplayRouter.get('/session/:sessionId', requireAuth, async (req, res) => {
       sessionId: row.id,
       challengeId: row.challenge_id,
       seed: row.seed,
-      completedAt: row.completed_at.toISOString(),
+      completedAt: completedAt.toISOString(),
       board,
       foundWords: found,
       missedWords: missed,
@@ -272,13 +286,19 @@ freeplayRouter.post('/share/:sessionId', requireAuth, async (req, res) => {
     const db = getDb();
     const row = await db
       .selectFrom('free_play_sessions')
-      .select(['id', 'user_id', 'challenge_id'])
+      .select(['id', 'user_id', 'challenge_id', 'completed_at'])
       .where('id', '=', sessionId)
       .executeTakeFirst();
 
     if (!row) return res.status(404).json({ error: 'Session not found' });
     if (row.user_id !== req.userId!) {
       return res.status(403).json({ error: 'Cannot share another player\'s session' });
+    }
+    // Sharing a still-in-progress session would surface a challenge link
+    // that points at an incomplete row — the share endpoint stays gated
+    // on finalization so recipients always land on a finished baseline.
+    if (!row.completed_at) {
+      return res.status(409).json({ error: 'Session not finished' });
     }
 
     if (row.challenge_id) {
@@ -310,6 +330,7 @@ freeplayRouter.get('/challenge/:challengeId/me', requireAuth, async (req, res) =
       .select('id')
       .where('challenge_id', '=', challengeId)
       .where('user_id', '=', req.userId!)
+      .where('completed_at', 'is not', null)
       .executeTakeFirst();
     res.json({ played: !!row, sessionId: row?.id ?? null });
   } catch (err) {
@@ -336,6 +357,7 @@ freeplayRouter.get('/challenge/:challengeId/preview', requireAuth, async (req, r
         'seed',
       ])
       .where('challenge_id', '=', challengeId)
+      .where('completed_at', 'is not', null)
       .execute();
 
     if (rows.length === 0) {
@@ -378,11 +400,17 @@ freeplayRouter.get('/challenge/:challengeId', requireAuth, async (req, res) => {
   const { challengeId } = req.params;
   try {
     const db = getDb();
-    const rows = await db
+    const rawRows = await db
       .selectFrom('free_play_sessions')
       .selectAll()
       .where('challenge_id', '=', challengeId)
+      .where('completed_at', 'is not', null)
       .execute();
+    // Narrow completed_at to non-null for the downstream toISOString /
+    // localeCompare calls. The WHERE clause is the runtime guarantee.
+    const rows = rawRows.filter(
+      (r): r is typeof r & { completed_at: Date } => r.completed_at !== null,
+    );
 
     if (rows.length === 0) {
       return res.status(404).json({ error: 'Challenge not found' });

--- a/server/routes/game.ts
+++ b/server/routes/game.ts
@@ -1,132 +1,181 @@
-import crypto from 'crypto';
 import { Router } from 'express';
-import { GameState } from 'models';
-import { createSession, destroySession, getSession, getRequestSessionId, type Session } from '../session.js';
+import { GameState, type Game } from 'models';
+import { requireAuth } from '../middleware/auth.js';
 import { getDb } from '../db/index.js';
-import { recordFreePlayCompletion } from '../services/FreePlayService.js';
+import {
+  buildFreePlayResults,
+  cancelFreePlaySession,
+  endFreePlaySession,
+  getActiveFreePlaySession,
+  solveFreePlayBoard,
+  startFreePlaySession,
+  submitFreePlayWord,
+  type FreePlaySession,
+} from '../services/FreePlayService.js';
 
 export const gameRouter = Router();
 
-// Writes one history row per completed free-play game. Idempotent across
-// /end and /results — whichever the client hits first records the row;
-// subsequent calls early-return on the freePlayRecorded flag. The actual
-// DB insert is fire-and-forget so a transient failure can't break the
-// response the client is waiting on. The row id is generated synchronously
-// up front so callers can expose it to the client immediately.
-function recordIfFinishedOnce(session: Session, userId: string | null): void {
-  if (session.freePlayRecorded) return;
-  // Daily games are recorded via /api/daily/results into daily_results.
-  // Skip the free_play_sessions insert so dailies don't appear in the
-  // free-play history list.
-  if (session.isDaily) return;
-  const { game, words } = session.controller.getGameState();
-  if (!game || game.status !== GameState.Finished) return;
-  session.freePlayRecorded = true;
-  const id = crypto.randomUUID();
-  session.freePlayDbId = id;
-  recordFreePlayCompletion(getDb(), {
-    id,
-    userId,
-    board: game.board,
-    foundWords: words.map((w) => w.word),
-    timeLimit: game.config.durationSeconds,
-    boardSize: game.config.boardSize,
-    minWordLength: game.config.minWordLength,
-    challengeId: session.challengeId,
-    seed: session.gameSeed,
-  }).catch((err) => {
-    console.warn('Failed to record free-play completion:', (err as Error).message);
-  });
+// Default config used by /create to seed the client's "Config" gate. The
+// real config is supplied by the player on /start; these defaults exist
+// only so the ConfigRoute has a Game-shaped object to gate on.
+const DEFAULT_CONFIG = {
+  durationSeconds: 180,
+  boardSize: 4,
+  minWordLength: 3,
+} as const;
+
+function toGame(session: FreePlaySession): Game {
+  return {
+    board: session.board,
+    startedAt: session.started_at.getTime(),
+    status: session.completed_at ? GameState.Finished : GameState.InProgress,
+    config: {
+      durationSeconds: session.time_limit,
+      boardSize: session.board_size,
+      minWordLength: session.min_word_length,
+    },
+  };
 }
 
+// Returns a placeholder Config-state Game so ConfigRoute can render its
+// setup screen. No server-side state is mutated — the actual session row
+// is created on /start. The legacy sessionId field is preserved in the
+// response shape for client backward compatibility but is no longer
+// consulted on subsequent calls.
 gameRouter.post('/create', (_req, res) => {
-  const { sessionId, controller } = createSession();
-  const game = controller.createGame();
-  res.json({ game, sessionId });
+  const game: Game = {
+    board: [],
+    startedAt: 0,
+    status: GameState.Config,
+    config: { ...DEFAULT_CONFIG },
+  };
+  res.json({ game, sessionId: 'noop' });
 });
 
-gameRouter.post('/start', (req, res) => {
-  const session = getSession(getRequestSessionId(req));
-  if (!session) return res.status(401).json({ error: 'Invalid session' });
-
-  const { durationSeconds, boardSize, minWordLength, board, seed, challengeId, isDaily } = req.body;
+gameRouter.post('/start', requireAuth, async (req, res) => {
+  const { durationSeconds, boardSize, minWordLength, board, seed, challengeId } = req.body;
   try {
-    const result = session.controller.startGame(
-      durationSeconds || 180,
-      boardSize || 4,
-      minWordLength || 3,
-      board,
+    const { session, salt, wordHashes } = await startFreePlaySession(getDb(), {
+      userId: req.userId!,
+      durationSeconds: durationSeconds || 180,
+      boardSize: boardSize || 4,
+      minWordLength: minWordLength || 3,
+      predefinedBoard: board,
       seed,
-    );
-    // Stamp the challenge id onto the session so the completion row
-    // written at /end or /results gets grouped with the other players
-    // who accepted the same share link.
-    session.challengeId = typeof challengeId === 'string' && challengeId ? challengeId : null;
-    // Capture the actual seed the controller used (it may have generated
-    // its own when none was supplied) so the completion row records it.
-    session.gameSeed = result.seed;
-    // Suppresses the free_play_sessions insert at /end and /results so
-    // the daily doesn't appear in the free-play history list.
-    session.isDaily = isDaily === true;
+      challengeId: typeof challengeId === 'string' && challengeId ? challengeId : null,
+    });
+    res.json({
+      game: toGame(session),
+      wordHashes,
+      salt,
+      seed: session.seed,
+    });
+  } catch (err) {
+    console.error('Failed to start free-play session:', err);
+    res.status(500).json({ error: 'Failed to start game' });
+  }
+});
+
+gameRouter.post('/cancel', requireAuth, async (req, res) => {
+  try {
+    await cancelFreePlaySession(getDb(), req.userId!);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to cancel free-play session:', err);
+    res.status(500).json({ error: 'Failed to cancel game' });
+  }
+});
+
+gameRouter.post('/end', requireAuth, async (req, res) => {
+  try {
+    const session = await endFreePlaySession(getDb(), req.userId!);
+    if (!session) {
+      return res.status(400).json({ error: 'No active game to end' });
+    }
+    res.json({ game: toGame(session), freePlaySessionId: session.id });
+  } catch (err) {
+    console.error('Failed to end free-play session:', err);
+    res.status(500).json({ error: 'Failed to end game' });
+  }
+});
+
+gameRouter.post('/submit', requireAuth, async (req, res) => {
+  try {
+    const result = await submitFreePlayWord(getDb(), req.userId!, req.body.path);
     res.json(result);
-  } catch (error) {
-    res.status(400).json({ error: (error as Error).message });
+  } catch (err) {
+    console.error('Failed to submit free-play word:', err);
+    res.status(500).json({ error: 'Failed to submit word' });
   }
 });
 
-gameRouter.post('/cancel', (req, res) => {
-  const sessionId = getRequestSessionId(req);
-  const session = getSession(sessionId);
-  if (!session) return res.status(401).json({ error: 'Invalid session' });
-
-  session.controller.cancelGame();
-  destroySession(sessionId);
-  res.json({ success: true });
-});
-
-gameRouter.post('/end', (req, res) => {
-  const session = getSession(getRequestSessionId(req));
-  if (!session) return res.status(401).json({ error: 'Invalid session' });
-
-  const game = session.controller.endGame();
-  if (game) {
-    recordIfFinishedOnce(session, req.userId ?? null);
-    res.json({ game, freePlaySessionId: session.freePlayDbId });
-    return;
-  }
-  const state = session.controller.getGameState();
-  if (state.game) {
-    recordIfFinishedOnce(session, req.userId ?? null);
-    res.json({ game: state.game, freePlaySessionId: session.freePlayDbId });
-  } else {
-    res.status(400).json({ error: 'No active game to end' });
+// Returns the caller's active in-progress session, or null if none. The
+// salt + wordHashes are included so a refresh-resumed client can re-arm
+// its local validator without an extra round trip.
+gameRouter.get('/active', requireAuth, async (req, res) => {
+  try {
+    const session = await getActiveFreePlaySession(getDb(), req.userId!);
+    if (!session) return res.json({ session: null });
+    const { salt, wordHashes } = solveFreePlayBoard(session.board, session.min_word_length);
+    res.json({
+      session: {
+        id: session.id,
+        game: toGame(session),
+        found_words: session.found_words,
+        challenge_id: session.challenge_id,
+        seed: session.seed,
+        salt,
+        wordHashes,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to fetch active free-play session:', err);
+    res.status(500).json({ error: 'Failed to fetch active session' });
   }
 });
 
-gameRouter.post('/submit', (req, res) => {
-  const session = getSession(getRequestSessionId(req));
-  if (!session) return res.status(401).json({ error: 'Invalid session' });
-
-  const result = session.controller.submitWord(req.body.path);
-  res.json(result);
+// Returns the same shape /active returns. Retained so the existing
+// useGameApi.fetchGameState path keeps working without changes — the
+// game object reflects the current DB state (status flips to Finished
+// after expiry), and words are the persisted found_words list.
+gameRouter.get('/state', requireAuth, async (req, res) => {
+  try {
+    const session = await getActiveFreePlaySession(getDb(), req.userId!);
+    if (!session) return res.json({ game: null, words: [] });
+    res.json({
+      game: toGame(session),
+      words: session.found_words.map((word) => ({
+        word,
+        path: [],
+        submittedAt: 0,
+      })),
+    });
+  } catch (err) {
+    console.error('Failed to fetch free-play state:', err);
+    res.status(500).json({ error: 'Failed to fetch state' });
+  }
 });
 
-gameRouter.get('/state', (req, res) => {
-  const session = getSession(getRequestSessionId(req));
-  if (!session) return res.json({ game: null, words: [] });
-
-  res.json(session.controller.getGameState());
-});
-
-gameRouter.get('/results', (req, res) => {
-  const session = getSession(getRequestSessionId(req));
-  if (!session) return res.status(401).json({ error: 'Invalid session' });
-
-  const results = session.controller.getResults();
-  if (results) {
-    recordIfFinishedOnce(session, req.userId ?? null);
-    res.json({ ...results, freePlaySessionId: session.freePlayDbId });
-  } else {
-    res.status(400).json({ error: 'No finished game' });
+gameRouter.get('/results', requireAuth, async (req, res) => {
+  try {
+    const db = getDb();
+    // Force finalization on read so a player whose timer ran out without
+    // /end firing still gets their results page. endFreePlaySession is a
+    // no-op when the row already finalized.
+    let session = await getActiveFreePlaySession(db, req.userId!);
+    if (session) {
+      session = await endFreePlaySession(db, req.userId!);
+    } else {
+      // Fall back to the player's most recently finished session.
+      session = await endFreePlaySession(db, req.userId!);
+    }
+    if (!session) {
+      return res.status(400).json({ error: 'No finished game' });
+    }
+    const results = buildFreePlayResults(session);
+    res.json({ ...results, freePlaySessionId: session.id });
+  } catch (err) {
+    console.error('Failed to fetch free-play results:', err);
+    res.status(500).json({ error: 'Failed to fetch results' });
   }
 });

--- a/server/routes/game.ts
+++ b/server/routes/game.ts
@@ -7,6 +7,7 @@ import {
   cancelFreePlaySession,
   endFreePlaySession,
   getActiveFreePlaySession,
+  getFreePlaySessionForState,
   solveFreePlayBoard,
   startFreePlaySession,
   submitFreePlayWord,
@@ -137,10 +138,12 @@ gameRouter.get('/active', requireAuth, async (req, res) => {
 // Returns the same shape /active returns. Retained so the existing
 // useGameApi.fetchGameState path keeps working without changes — the
 // game object reflects the current DB state (status flips to Finished
-// after expiry), and words are the persisted found_words list.
+// after expiry), and words are the persisted found_words list. Unlike
+// /active, this endpoint also surfaces a session that this read just
+// auto-finalized, so the client sees `Finished` and can fetch results.
 gameRouter.get('/state', requireAuth, async (req, res) => {
   try {
-    const session = await getActiveFreePlaySession(getDb(), req.userId!);
+    const session = await getFreePlaySessionForState(getDb(), req.userId!);
     if (!session) return res.json({ game: null, words: [] });
     res.json({
       game: toGame(session),

--- a/server/services/DailySummaryService.ts
+++ b/server/services/DailySummaryService.ts
@@ -15,6 +15,12 @@ export interface DailySummary {
 // time. Counts vs. distinct-user counts: daily_results and
 // daily_zen_results have a unique (user_id, date) constraint, so count(*)
 // is already a per-player count for those.
+//
+// freePlayGames counts *completed* sessions only. The table now inserts
+// at /start with completed_at null, so without the filter we'd over-count
+// abandoned games. The session's `date` is rewritten on finalization to
+// the completion-PST date, so cross-midnight games still land on the day
+// they finished (matching the pre-migration semantics).
 export async function getDailySummary(
   db: Kysely<Database>,
   date: string,
@@ -37,6 +43,7 @@ export async function getDailySummary(
       .selectFrom('free_play_sessions')
       .select((eb) => eb.fn.countAll<number>().as('games'))
       .where('date', '=', date)
+      .where('completed_at', 'is not', null)
       .executeTakeFirstOrThrow(),
   ]);
 

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -1,5 +1,14 @@
+import crypto from 'crypto';
 import type { Kysely } from 'kysely';
+import { generateSalt, hashWord, type Position } from 'models';
+import { isValidPath } from 'engine/adjacency.js';
+import { isValidWord } from 'engine/dictionary.js';
+import { findAllWords } from 'engine/solver.js';
+import { scoreWord } from 'engine/scoring.js';
+import { generateSeededBoard } from 'engine/board.js';
+import { randomSeed } from 'models/seedCode';
 import type { Database } from '../db/types.js';
+import { dictionary } from './dictionary.js';
 import { getDailyDatePST } from './dailyConfig.js';
 import { scoreResult } from './DailyService.js';
 
@@ -46,54 +55,367 @@ export function computeChallengeNewResults(
   return counts;
 }
 
-export interface RecordFreePlayCompletionOpts {
-  userId: string | null;
-  board: string[][];
-  foundWords: string[];
-  timeLimit: number;
-  boardSize: number;
-  minWordLength: number;
-  // Non-null when this session was started via a shared-challenge link.
-  // The id is the originator session id and groups every player who
-  // accepted that link, including the originator after they tap share.
-  challengeId: string | null;
-  // Pre-generated row id. Letting the caller pick the id means we can
-  // expose it on the /end and /results responses without waiting on the
-  // (fire-and-forget) insert to round-trip first.
+// ─── Session lifecycle ────────────────────────────────────────────────────
+//
+// Free-play runs as a server-authoritative session mirroring daily timed:
+// the row is created on /start with started_at = now() and completed_at
+// null, mutated on every word submission, finalized either by /end or by
+// the auto-expiry check on read. The DB row is the source of truth so a
+// browser refresh resumes the in-progress game from server state instead
+// of restarting the local timer.
+
+export interface FreePlaySession {
   id: string;
-  // The numeric board seed used to generate this game. Persisted so a
-  // historic share link can hand the same board to another player.
+  board: string[][];
+  found_words: string[];
+  started_at: Date;
+  completed_at: Date | null;
+  points: number;
+  word_count: number;
+  longest_word: string;
+  time_limit: number;
+  board_size: number;
+  min_word_length: number;
+  challenge_id: string | null;
   seed: number | null;
 }
 
-// Records a completed free-play game as a historical row. Mirrors the
-// shape of daily_results so a "play history" UI can union the two tables
-// with a single projection.
-//
-// Scoring is recomputed from foundWords via scoreResult — same source of
-// truth daily_results uses — so the persisted points/word_count/
-// longest_word are always consistent with the canonical scoring rules.
-export async function recordFreePlayCompletion(
+// Same grace window as the daily timed session. The client perceives the
+// timer hitting zero from its local clock; the same submission reaching
+// the server can be a few hundred ms behind that, and a 2s buffer keeps
+// the last fairly-played word from getting rejected on slow connections.
+export const FREE_PLAY_GRACE_SECONDS = 2;
+
+export type FreePlaySubmitOutcome =
+  | { valid: true; word: string; score: number }
+  | { valid: false; reason: 'invalid' | 'repeat' | 'ended' | 'expired' };
+
+function parseFreePlaySession(row: {
+  id: string;
+  board: unknown;
+  found_words: unknown;
+  started_at: Date;
+  completed_at: Date | null;
+  points: number;
+  word_count: number;
+  longest_word: string;
+  time_limit: number;
+  board_size: number;
+  min_word_length: number;
+  challenge_id: string | null;
+  seed: number | null;
+}): FreePlaySession {
+  const board = typeof row.board === 'string' ? JSON.parse(row.board) : (row.board as string[][]);
+  const foundWords = typeof row.found_words === 'string'
+    ? JSON.parse(row.found_words)
+    : (row.found_words as string[]);
+  return {
+    id: row.id,
+    board,
+    found_words: foundWords,
+    started_at: row.started_at,
+    completed_at: row.completed_at,
+    points: row.points,
+    word_count: row.word_count,
+    longest_word: row.longest_word,
+    time_limit: row.time_limit,
+    board_size: row.board_size,
+    min_word_length: row.min_word_length,
+    challenge_id: row.challenge_id,
+    seed: row.seed,
+  };
+}
+
+// time_limit = 0 means an unlimited (untimed) game — never auto-expires.
+function isExpired(
+  session: { started_at: Date; time_limit: number },
+  now: Date,
+): boolean {
+  if (session.time_limit <= 0) return false;
+  const elapsed = Math.floor((now.getTime() - session.started_at.getTime()) / 1000);
+  return elapsed > session.time_limit + FREE_PLAY_GRACE_SECONDS;
+}
+
+function expiryInstant(session: { started_at: Date; time_limit: number }): Date {
+  return new Date(session.started_at.getTime() + session.time_limit * 1000);
+}
+
+async function autoFinalizeIfExpired(
   db: Kysely<Database>,
-  opts: RecordFreePlayCompletionOpts,
-): Promise<void> {
-  const { points, wordCount, longestWord } = scoreResult(opts.foundWords);
+  session: FreePlaySession,
+): Promise<FreePlaySession> {
+  if (session.completed_at || !isExpired(session, new Date())) return session;
+  const completedAt = expiryInstant(session);
+  await db
+    .updateTable('free_play_sessions')
+    .set({ completed_at: completedAt })
+    .where('id', '=', session.id)
+    .where('completed_at', 'is', null)
+    .execute();
+  return { ...session, completed_at: completedAt };
+}
+
+export async function getActiveFreePlaySession(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<FreePlaySession | null> {
+  const row = await db
+    .selectFrom('free_play_sessions')
+    .select([
+      'id',
+      'board',
+      'found_words',
+      'started_at',
+      'completed_at',
+      'points',
+      'word_count',
+      'longest_word',
+      'time_limit',
+      'board_size',
+      'min_word_length',
+      'challenge_id',
+      'seed',
+    ])
+    .where('user_id', '=', userId)
+    .where('completed_at', 'is', null)
+    .orderBy('started_at', 'desc')
+    .limit(1)
+    .executeTakeFirst();
+  if (!row) return null;
+  const session = await autoFinalizeIfExpired(db, parseFreePlaySession(row));
+  // A row that auto-finalized between the select and the update is no
+  // longer "active" — surface as null so callers don't treat it as
+  // resumable.
+  return session.completed_at ? null : session;
+}
+
+export interface StartFreePlayOpts {
+  userId: string;
+  durationSeconds: number;
+  boardSize: number;
+  minWordLength: number;
+  predefinedBoard?: string[][];
+  seed?: number;
+  challengeId: string | null;
+}
+
+export interface StartFreePlayResult {
+  session: FreePlaySession;
+  // Salted board solution for client-side instant validation. Same role
+  // as the salt/wordHashes pair returned by the daily endpoints.
+  salt: string;
+  wordHashes: string[];
+}
+
+// Starts a fresh free-play session. Any pre-existing in-progress row for
+// the same user is dropped first so the partial unique index on
+// (user_id) where completed_at is null doesn't reject the insert — this
+// matches the prior /create-then-/start UX where calling /start always
+// began a new game.
+export async function startFreePlaySession(
+  db: Kysely<Database>,
+  opts: StartFreePlayOpts,
+): Promise<StartFreePlayResult> {
+  const gameSeed = opts.seed ?? randomSeed();
+  const board = opts.predefinedBoard && opts.predefinedBoard.length === opts.boardSize
+    ? opts.predefinedBoard
+    : generateSeededBoard(opts.boardSize, gameSeed);
+
+  const id = crypto.randomUUID();
+
+  await db
+    .deleteFrom('free_play_sessions')
+    .where('user_id', '=', opts.userId)
+    .where('completed_at', 'is', null)
+    .execute();
+
   await db
     .insertInto('free_play_sessions')
     .values({
-      id: opts.id,
+      id,
       user_id: opts.userId,
       date: getDailyDatePST(),
-      board: JSON.stringify(opts.board),
-      found_words: JSON.stringify(opts.foundWords),
-      points,
-      word_count: wordCount,
-      longest_word: longestWord,
-      time_limit: opts.timeLimit,
+      board: JSON.stringify(board),
+      found_words: JSON.stringify([]),
+      time_limit: opts.durationSeconds,
       board_size: opts.boardSize,
       min_word_length: opts.minWordLength,
       challenge_id: opts.challengeId,
-      seed: opts.seed,
+      seed: gameSeed,
     })
     .execute();
+
+  const session = await getActiveFreePlaySession(db, opts.userId);
+  if (!session) throw new Error('Failed to start free-play session');
+
+  const { salt, wordHashes } = solveFreePlayBoard(session.board, session.min_word_length);
+  return { session, salt, wordHashes };
+}
+
+// Trust-but-verify per-word write. Path is bounds-checked, the word is
+// derived from the stored board (so the client can't smuggle in
+// off-board letters), dictionary-checked, deduped, and atomically
+// appended. Auto-finalizes if the time window elapsed.
+export async function submitFreePlayWord(
+  db: Kysely<Database>,
+  userId: string,
+  path: Position[],
+): Promise<FreePlaySubmitOutcome> {
+  const session = await getActiveFreePlaySession(db, userId);
+  if (!session) return { valid: false, reason: 'ended' };
+
+  if (!isValidPath(path, session.board_size)) {
+    return { valid: false, reason: 'invalid' };
+  }
+
+  const word = path
+    .map((pos) => session.board[pos.row][pos.col])
+    .join('')
+    .toUpperCase();
+
+  if (word.length < session.min_word_length) {
+    return { valid: false, reason: 'invalid' };
+  }
+  if (!isValidWord(dictionary, word.toLowerCase())) {
+    return { valid: false, reason: 'invalid' };
+  }
+  if (session.found_words.some((w) => w.toUpperCase() === word)) {
+    return { valid: false, reason: 'repeat' };
+  }
+
+  const nextWords = [...session.found_words, word];
+  const { points, wordCount, longestWord } = scoreResult(nextWords);
+
+  await db
+    .updateTable('free_play_sessions')
+    .set({
+      found_words: JSON.stringify(nextWords),
+      points,
+      word_count: wordCount,
+      longest_word: longestWord,
+    })
+    .where('id', '=', session.id)
+    .where('completed_at', 'is', null)
+    .execute();
+
+  return { valid: true, word, score: scoreWord(word) };
+}
+
+// Player-triggered finalize. Caps completed_at at started_at + time_limit
+// so a delayed /end call can't make the row look like the player took
+// longer than allowed.
+export async function endFreePlaySession(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<FreePlaySession | null> {
+  const session = await getActiveFreePlaySession(db, userId);
+  if (!session) {
+    // Either there's no row, or it already finalized between calls. Fall
+    // back to the most-recently-completed row for the user so the client
+    // still gets a session id to surface on the results page.
+    return getMostRecentFreePlaySession(db, userId);
+  }
+  const now = new Date();
+  const completedAt = session.time_limit > 0
+    ? (now > expiryInstant(session) ? expiryInstant(session) : now)
+    : now;
+  await db
+    .updateTable('free_play_sessions')
+    .set({ completed_at: completedAt })
+    .where('id', '=', session.id)
+    .where('completed_at', 'is', null)
+    .execute();
+  return { ...session, completed_at: completedAt };
+}
+
+// Discards the in-progress row outright. Used by /api/game/cancel when
+// the player abandons the configuration step or backs out of a running
+// game — abandoned sessions shouldn't pollute history.
+export async function cancelFreePlaySession(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<void> {
+  await db
+    .deleteFrom('free_play_sessions')
+    .where('user_id', '=', userId)
+    .where('completed_at', 'is', null)
+    .execute();
+}
+
+async function getMostRecentFreePlaySession(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<FreePlaySession | null> {
+  const row = await db
+    .selectFrom('free_play_sessions')
+    .select([
+      'id',
+      'board',
+      'found_words',
+      'started_at',
+      'completed_at',
+      'points',
+      'word_count',
+      'longest_word',
+      'time_limit',
+      'board_size',
+      'min_word_length',
+      'challenge_id',
+      'seed',
+    ])
+    .where('user_id', '=', userId)
+    .where('completed_at', 'is not', null)
+    .orderBy('completed_at', 'desc')
+    .limit(1)
+    .executeTakeFirst();
+  return row ? parseFreePlaySession(row) : null;
+}
+
+// Computes the results payload the /api/game/results endpoint returns:
+// found + missed words with scores, sorted highest first. Pure function
+// of the session row plus the dictionary.
+export function buildFreePlayResults(session: FreePlaySession): {
+  board: string[][];
+  foundWords: { word: string; path: Position[]; score: number }[];
+  missedWords: { word: string; path: Position[]; score: number }[];
+} {
+  const allWords = findAllWords(session.board, dictionary, session.min_word_length);
+  const foundSet = new Set(session.found_words.map((w) => w.toUpperCase()));
+
+  // Found words: pair each persisted word with its canonical board path,
+  // so the results page can replay them on the board. A word that's in
+  // found_words but no longer reachable on the board (shouldn't happen,
+  // since the board is locked at session start) is omitted from the
+  // replay rather than fabricating a path.
+  const pathByWord = new Map(allWords.map((w) => [w.word, w.path]));
+  const foundWords = session.found_words
+    .map((w) => {
+      const upper = w.toUpperCase();
+      const path = pathByWord.get(upper);
+      return path ? { word: upper, path, score: scoreWord(upper) } : null;
+    })
+    .filter((w): w is { word: string; path: Position[]; score: number } => w !== null);
+
+  const missedWords = allWords
+    .filter((w) => !foundSet.has(w.word))
+    .map((w) => ({ word: w.word, path: w.path, score: scoreWord(w.word) }));
+
+  foundWords.sort((a, b) => b.score - a.score || b.word.length - a.word.length);
+  missedWords.sort((a, b) => b.score - a.score || b.word.length - a.word.length);
+
+  return { board: session.board, foundWords, missedWords };
+}
+
+// Per-fetch salted hash payload for client-side instant validation.
+// Re-solves on every call — the call sites are /start and the per-mount
+// active-session hydration, not every word submission, so the solver
+// cost is amortized away.
+export function solveFreePlayBoard(board: string[][], minWordLength: number): {
+  salt: string;
+  wordHashes: string[];
+} {
+  const all = findAllWords(board, dictionary, minWordLength);
+  const salt = generateSalt();
+  const wordHashes = all.map((w) => hashWord(w.word, salt));
+  return { salt, wordHashes };
 }

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -140,6 +140,22 @@ function expiryInstant(session: { started_at: Date; time_limit: number }): Date 
   return new Date(session.started_at.getTime() + session.time_limit * 1000);
 }
 
+const SESSION_COLUMNS = [
+  'id',
+  'board',
+  'found_words',
+  'started_at',
+  'completed_at',
+  'points',
+  'word_count',
+  'longest_word',
+  'time_limit',
+  'board_size',
+  'min_word_length',
+  'challenge_id',
+  'seed',
+] as const;
+
 async function autoFinalizeIfExpired(
   db: Kysely<Database>,
   session: FreePlaySession,
@@ -148,7 +164,7 @@ async function autoFinalizeIfExpired(
   const completedAt = expiryInstant(session);
   await db
     .updateTable('free_play_sessions')
-    .set({ completed_at: completedAt })
+    .set({ completed_at: completedAt, date: getDailyDatePST(completedAt) })
     .where('id', '=', session.id)
     .where('completed_at', 'is', null)
     .execute();
@@ -159,34 +175,38 @@ export async function getActiveFreePlaySession(
   db: Kysely<Database>,
   userId: string,
 ): Promise<FreePlaySession | null> {
+  const session = await readAndAutoFinalize(db, userId);
+  // A row that auto-finalized between the select and the update is no
+  // longer "active" — surface as null so callers don't treat it as
+  // resumable.
+  return session && !session.completed_at ? session : null;
+}
+
+// Like getActiveFreePlaySession, but preserves the session row after this
+// read auto-finalizes it so callers (e.g. /api/game/state) can observe the
+// Finished state and route the client to results. Returns null only when
+// there is no open session at all.
+export async function getFreePlaySessionForState(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<FreePlaySession | null> {
+  return readAndAutoFinalize(db, userId);
+}
+
+async function readAndAutoFinalize(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<FreePlaySession | null> {
   const row = await db
     .selectFrom('free_play_sessions')
-    .select([
-      'id',
-      'board',
-      'found_words',
-      'started_at',
-      'completed_at',
-      'points',
-      'word_count',
-      'longest_word',
-      'time_limit',
-      'board_size',
-      'min_word_length',
-      'challenge_id',
-      'seed',
-    ])
+    .select(SESSION_COLUMNS)
     .where('user_id', '=', userId)
     .where('completed_at', 'is', null)
     .orderBy('started_at', 'desc')
     .limit(1)
     .executeTakeFirst();
   if (!row) return null;
-  const session = await autoFinalizeIfExpired(db, parseFreePlaySession(row));
-  // A row that auto-finalized between the select and the update is no
-  // longer "active" — surface as null so callers don't treat it as
-  // resumable.
-  return session.completed_at ? null : session;
+  return autoFinalizeIfExpired(db, parseFreePlaySession(row));
 }
 
 export interface StartFreePlayOpts {
@@ -256,49 +276,85 @@ export async function startFreePlaySession(
 // derived from the stored board (so the client can't smuggle in
 // off-board letters), dictionary-checked, deduped, and atomically
 // appended. Auto-finalizes if the time window elapsed.
+//
+// Wraps the read/validate/write cycle in a transaction with SELECT FOR
+// UPDATE on the session row. Concurrent submissions serialize on the
+// row lock, so two valid words can no longer clobber each other and a
+// duplicate of an in-flight word deterministically lands as `repeat`.
 export async function submitFreePlayWord(
   db: Kysely<Database>,
   userId: string,
   path: Position[],
 ): Promise<FreePlaySubmitOutcome> {
-  const session = await getActiveFreePlaySession(db, userId);
-  if (!session) return { valid: false, reason: 'ended' };
+  return db.transaction().execute(async (trx) => {
+    const row = await trx
+      .selectFrom('free_play_sessions')
+      .select(SESSION_COLUMNS)
+      .where('user_id', '=', userId)
+      .where('completed_at', 'is', null)
+      .orderBy('started_at', 'desc')
+      .limit(1)
+      .forUpdate()
+      .executeTakeFirst();
+    if (!row) return { valid: false, reason: 'ended' };
 
-  if (!isValidPath(path, session.board_size)) {
-    return { valid: false, reason: 'invalid' };
-  }
+    const session = parseFreePlaySession(row);
 
-  const word = path
-    .map((pos) => session.board[pos.row][pos.col])
-    .join('')
-    .toUpperCase();
+    if (isExpired(session, new Date())) {
+      const completedAt = expiryInstant(session);
+      await trx
+        .updateTable('free_play_sessions')
+        .set({ completed_at: completedAt, date: getDailyDatePST(completedAt) })
+        .where('id', '=', session.id)
+        .where('completed_at', 'is', null)
+        .execute();
+      return { valid: false, reason: 'expired' };
+    }
 
-  if (word.length < session.min_word_length) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (!isValidWord(dictionary, word.toLowerCase())) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (session.found_words.some((w) => w.toUpperCase() === word)) {
-    return { valid: false, reason: 'repeat' };
-  }
+    if (!isValidPath(path, session.board_size)) {
+      return { valid: false, reason: 'invalid' };
+    }
 
-  const nextWords = [...session.found_words, word];
-  const { points, wordCount, longestWord } = scoreResult(nextWords);
+    const word = path
+      .map((pos) => session.board[pos.row][pos.col])
+      .join('')
+      .toUpperCase();
 
-  await db
-    .updateTable('free_play_sessions')
-    .set({
-      found_words: JSON.stringify(nextWords),
-      points,
-      word_count: wordCount,
-      longest_word: longestWord,
-    })
-    .where('id', '=', session.id)
-    .where('completed_at', 'is', null)
-    .execute();
+    if (word.length < session.min_word_length) {
+      return { valid: false, reason: 'invalid' };
+    }
+    if (!isValidWord(dictionary, word.toLowerCase())) {
+      return { valid: false, reason: 'invalid' };
+    }
+    if (session.found_words.some((w) => w.toUpperCase() === word)) {
+      return { valid: false, reason: 'repeat' };
+    }
 
-  return { valid: true, word, score: scoreWord(word) };
+    const nextWords = [...session.found_words, word];
+    const { points, wordCount, longestWord } = scoreResult(nextWords);
+
+    const result = await trx
+      .updateTable('free_play_sessions')
+      .set({
+        found_words: JSON.stringify(nextWords),
+        points,
+        word_count: wordCount,
+        longest_word: longestWord,
+      })
+      .where('id', '=', session.id)
+      .where('completed_at', 'is', null)
+      .executeTakeFirst();
+
+    // Defensive: if the row finalized between the locked select and the
+    // update landing (e.g. /end ran in another connection that beat the
+    // lock), the update affects zero rows. Don't claim the word was
+    // accepted in that case.
+    if (Number(result.numUpdatedRows ?? 0) === 0) {
+      return { valid: false, reason: 'ended' };
+    }
+
+    return { valid: true, word, score: scoreWord(word) };
+  });
 }
 
 // Player-triggered finalize. Caps completed_at at started_at + time_limit
@@ -321,7 +377,7 @@ export async function endFreePlaySession(
     : now;
   await db
     .updateTable('free_play_sessions')
-    .set({ completed_at: completedAt })
+    .set({ completed_at: completedAt, date: getDailyDatePST(completedAt) })
     .where('id', '=', session.id)
     .where('completed_at', 'is', null)
     .execute();
@@ -348,21 +404,7 @@ async function getMostRecentFreePlaySession(
 ): Promise<FreePlaySession | null> {
   const row = await db
     .selectFrom('free_play_sessions')
-    .select([
-      'id',
-      'board',
-      'found_words',
-      'started_at',
-      'completed_at',
-      'points',
-      'word_count',
-      'longest_word',
-      'time_limit',
-      'board_size',
-      'min_word_length',
-      'challenge_id',
-      'seed',
-    ])
+    .select(SESSION_COLUMNS)
     .where('user_id', '=', userId)
     .where('completed_at', 'is not', null)
     .orderBy('completed_at', 'desc')

--- a/server/services/dailyConfig.ts
+++ b/server/services/dailyConfig.ts
@@ -45,8 +45,8 @@ export function getDailyConfig(dateStr: string): DailyConfig {
   return dailyConfigFromSeed(getDailySeed(dateStr));
 }
 
-export function getDailyDatePST(): string {
-  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+export function getDailyDatePST(now: Date = new Date()): string {
+  return now.toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
 }
 
 export function getDailyNumber(dateStr: string): number {

--- a/supabase/migrations/20260522000000_freeplay_in_progress_rows.sql
+++ b/supabase/migrations/20260522000000_freeplay_in_progress_rows.sql
@@ -1,0 +1,32 @@
+-- Promote free_play_sessions to a session-based lifecycle that mirrors
+-- daily_results: the row is created on /api/game/start with started_at = now()
+-- and completed_at = null, mutated on every word submission, and finalized
+-- (completed_at set) by /end or auto-finalized on time-limit expiry. This is
+-- what lets a free-play refresh resume the in-progress game from the server
+-- instead of restarting the timer.
+--
+-- Existing rows predate the session model and were inserted at game end
+-- only. Backfill started_at to a value that places the play window entirely
+-- before completed_at so historic rows present as already-finalized sessions
+-- to every read path. The unlimited-timer case (time_limit = 0) collapses to
+-- started_at = completed_at, which is harmless.
+
+alter table public.free_play_sessions
+  add column started_at timestamptz not null default now();
+
+alter table public.free_play_sessions
+  alter column completed_at drop default,
+  alter column completed_at drop not null;
+
+update public.free_play_sessions
+set started_at = completed_at - make_interval(secs => time_limit)
+where completed_at is not null;
+
+-- At most one in-progress free-play row per authenticated user. Anonymous
+-- rows (user_id null) are excluded because the table predates auth and
+-- legacy null rows shouldn't be uniqueness-constrained against each other.
+-- In practice GameContext signs the player in anonymously before /start
+-- runs, so every new in-progress row has user_id set.
+create unique index free_play_sessions_active_per_user
+  on public.free_play_sessions (user_id)
+  where completed_at is null and user_id is not null;


### PR DESCRIPTION
## What
Mid-game refresh during free play now resumes from server state (board, timer, found words) instead of restarting. `free_play_sessions` becomes a session table — row created at `/api/game/start`, mutated per word, finalized at `/end` or by the auto-expiry check on read — mirroring the daily timed lifecycle. A companion fix anchors `useTimer` and `TimerBar` to `game.startedAt`, which also closes the same restart loophole in the existing daily timed and gauntlet modes (those rows were already DB-backed but the client clock was restarting locally on every mount).

## Why this approach
Full parity with the daily flows means one consistent mental model: every timed mode is server-authoritative, and refresh is just a no-op visual re-render. Keeping the in-memory `GameController` in place alongside DB persistence would have meant two sources of truth that could diverge across deploys, so the free-play endpoints now read/write the DB directly under `requireAuth`. Anonymous Supabase sign-in already happens at app mount, so authenticated calls cover the existing anonymous-play UX.

## Follow-ups
- `server/session.ts` and `server/GameController.ts` are now unused for free play; safe to delete in a follow-up.
- Word *paths* aren't persisted server-side (only word strings), so a resumed game's in-game word list shows text without the board-replay path until `/results` recomputes them.

## Test plan
- [x] Type-check passes (`tsc` in client + server)
- [x] Migration applies cleanly to local supabase
- [x] Manual: start free-play 3:00 → 147s → hard refresh → resumed at 136s on same board (not 180s)
- [x] DB confirms in-progress row has `completed_at = null`; expired rows have it set
- [ ] Verify daily timed + gauntlet refresh also pick up the new client-clock anchor
- [ ] Verify challenge share/preview/me/standings exclude in-progress rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)