### PR TITLE
perf(gauntlet): batch display-name lookup and dedupe ranking query

### DIFF
--- a/server/routes/dailyGauntlet.ts
+++ b/server/routes/dailyGauntlet.ts
@@ -16,8 +16,8 @@ import {
   prepareGauntletRound,
 } from '../services/dailyGauntletConfig.js';
 import {
+  aggregateFromRoundRanks,
   endGauntletRound,
-  getGauntletAggregate,
   getGauntletRoundRanks,
   getGauntletRoundSession,
   getGauntletStatus,
@@ -271,10 +271,8 @@ dailyGauntletRouter.get('/:date/leaderboard', requireAuth, async (req, res) => {
   try {
     const db = getDb();
     const date = req.params.date;
-    const [perRound, aggregate] = await Promise.all([
-      getGauntletRoundRanks(db, date),
-      getGauntletAggregate(db, date),
-    ]);
+    const perRound = await getGauntletRoundRanks(db, date);
+    const aggregate = aggregateFromRoundRanks(perRound, GAUNTLET_ROUND_COUNT);
 
     // Display names resolved in one pass against the union of users
     // appearing in either list. Cached helper so repeated calls within

--- a/server/services/displayNames.ts
+++ b/server/services/displayNames.ts
@@ -1,3 +1,5 @@
+import { sql } from 'kysely';
+import { getDb } from '../db/index.js';
 import { getSupabaseAdmin } from '../supabaseAdmin.js';
 import { renderPublicName } from './nameModeration.js';
 
@@ -70,12 +72,81 @@ export async function getDisplayName(userId: string): Promise<string> {
   );
 }
 
+// Single SQL round-trip against auth.users for any IDs not already cached.
+// The previous implementation fanned out one Supabase Auth admin HTTP call
+// per user, which dominated latency on multi-user views (gauntlet/daily
+// leaderboards) and scaled linearly with player count.
+interface AuthUserRow {
+  id: string;
+  raw_user_meta_data: Record<string, unknown> | null;
+  raw_app_meta_data: Record<string, unknown> | null;
+}
+
+async function fetchUserStatesBatch(userIds: string[]): Promise<Map<string, UserState>> {
+  const out = new Map<string, UserState>();
+  if (userIds.length === 0) return out;
+  try {
+    const result = await sql<AuthUserRow>`
+      select id::text as id, raw_user_meta_data, raw_app_meta_data
+      from auth.users
+      where id = any(${userIds}::uuid[])
+    `.execute(getDb());
+    for (const row of result.rows) {
+      out.set(row.id, {
+        displayName: normalizeDisplayName(row.raw_user_meta_data?.display_name),
+        lockedUntilMs: parseLockedUntil(
+          (row.raw_app_meta_data as { nameLockedUntil?: unknown } | null)?.nameLockedUntil,
+        ),
+      });
+    }
+  } catch {
+    // Leave `out` empty; caller treats missing IDs as Anonymous below.
+  }
+  return out;
+}
+
 export async function getDisplayNames(userIds: string[]): Promise<Map<string, string>> {
   const uniqueIds = Array.from(new Set(userIds));
-  const entries = await Promise.all(
-    uniqueIds.map(async (userId) => [userId, await getDisplayName(userId)] as const),
-  );
-  return new Map(entries);
+  const now = Date.now();
+  const result = new Map<string, string>();
+  const toFetch: string[] = [];
+
+  for (const id of uniqueIds) {
+    const cached = cache.get(id);
+    if (cached && cached.expiresAt > now) {
+      result.set(
+        id,
+        renderPublicName(
+          id,
+          cached.displayName,
+          { strikes: 0, lockedUntilMs: cached.lockedUntilMs },
+          now,
+        ),
+      );
+    } else {
+      if (cached) cache.delete(id);
+      toFetch.push(id);
+    }
+  }
+
+  if (toFetch.length > 0) {
+    const fetched = await fetchUserStatesBatch(toFetch);
+    for (const id of toFetch) {
+      const state = fetched.get(id) ?? { displayName: ANONYMOUS, lockedUntilMs: null };
+      cache.set(id, { ...state, expiresAt: now + USER_TTL_MS });
+      result.set(
+        id,
+        renderPublicName(
+          id,
+          state.displayName,
+          { strikes: 0, lockedUntilMs: state.lockedUntilMs },
+          now,
+        ),
+      );
+    }
+  }
+
+  return result;
 }
 
 export function invalidateDisplayName(userId: string): void {


### PR DESCRIPTION
## What

Two perf fixes for the daily-gauntlet standings endpoint, which felt slow even at ~3 players:

- **Batch display-name lookup.** Replace per-user `auth.admin.getUserById` HTTP fanout with a single SQL select against `auth.users` keyed by `id = any($1::uuid[])`. Local bench (N=5, cold cache): median 37ms → 0.8ms; bigger absolute win in prod where Supabase Auth latency is higher.
- **Dedupe gauntlet ranking query.** The leaderboard route was running the same window function twice (once directly, once inside `getGauntletAggregate`). Now fetches ranks once and derives the aggregate in-memory via `aggregateFromRoundRanks`.

## Why

The display-name fanout was the dominant cost on the standings page and scaled linearly with player count — a latent O(players) HTTP-call problem worth fixing before the table grows.

## Follow-ups

I also added a tuned partial composite index in this branch initially, but EXPLAIN ANALYZE against 50k synthetic rows showed the planner picks the existing `(date, round_index)` index regardless and execution time was identical — so I dropped that migration. The leaderboard route's `Cache-Control: private, max-age=30` is also worth a second look (briefly suspected during testing of caching one-player snapshots during active play), but no change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)