### PR TITLE
feat(daily-summary): include yesterday's player feedback with display names

### DIFF
--- a/.github/workflows/daily-summary-email.yml
+++ b/.github/workflows/daily-summary-email.yml
@@ -5,6 +5,8 @@ name: Daily Summary Email
 #
 # Required repo secrets:
 #   SUPABASE_PROJECT_REF_PROD, SUPABASE_DB_PASSWORD_PROD — existing
+#   SUPABASE_URL_PROD             — Supabase project URL (for display-name lookup)
+#   SUPABASE_SECRET_KEY_PROD      — Supabase service role key (for display-name lookup)
 #   RESEND_API_KEY                — Resend API key
 #   DAILY_SUMMARY_FROM_EMAIL      — verified Resend sender address
 #   DAILY_SUMMARY_RECIPIENT_EMAIL — destination address
@@ -38,6 +40,8 @@ jobs:
         run: npm run email:daily-summary
         env:
           DATABASE_URL: postgres://postgres.${{ secrets.SUPABASE_PROJECT_REF_PROD }}:${{ secrets.SUPABASE_DB_PASSWORD_PROD }}@aws-1-us-east-1.pooler.supabase.com:6543/postgres
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY_PROD }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           DAILY_SUMMARY_FROM_EMAIL: ${{ secrets.DAILY_SUMMARY_FROM_EMAIL }}
           DAILY_SUMMARY_RECIPIENT_EMAIL: ${{ secrets.DAILY_SUMMARY_RECIPIENT_EMAIL }}

--- a/scripts/sendDailySummary.ts
+++ b/scripts/sendDailySummary.ts
@@ -9,13 +9,16 @@
 //
 // Required env vars:
 //   DATABASE_URL                — Supabase Postgres connection string
+//   SUPABASE_URL                — Supabase project URL (for display-name lookup)
+//   SUPABASE_SECRET_KEY         — Supabase service role key (for display-name lookup)
 //   RESEND_API_KEY              — Resend API key
 //   DAILY_SUMMARY_FROM_EMAIL    — verified sender address
 //   DAILY_SUMMARY_RECIPIENT_EMAIL — where to deliver the summary
 //
 // Usage:
-//   DATABASE_URL=... RESEND_API_KEY=... DAILY_SUMMARY_FROM_EMAIL=... \
-//     DAILY_SUMMARY_RECIPIENT_EMAIL=... npx tsx scripts/sendDailySummary.ts
+//   DATABASE_URL=... SUPABASE_URL=... SUPABASE_SECRET_KEY=... RESEND_API_KEY=... \
+//     DAILY_SUMMARY_FROM_EMAIL=... DAILY_SUMMARY_RECIPIENT_EMAIL=... \
+//     npx tsx scripts/sendDailySummary.ts
 
 import { Kysely, PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
@@ -25,12 +28,64 @@ import {
   getDailySummary,
   getYesterdayPST,
   type DailySummary,
+  type FeedbackEntry,
 } from '../server/services/DailySummaryService.js';
 
 function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`${name} environment variable is not set`);
   return value;
+}
+
+function formatFeedbackTime(createdAt: Date): string {
+  return createdAt.toLocaleTimeString('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function describeAuthor(entry: FeedbackEntry): string {
+  if (!entry.userId) return 'anonymous';
+  return entry.displayName ?? 'Anonymous';
+}
+
+function renderFeedbackText(feedback: FeedbackEntry[]): string {
+  if (feedback.length === 0) return 'Feedback: (none)';
+  const lines = ['Feedback:'];
+  for (const entry of feedback) {
+    lines.push(`  [${formatFeedbackTime(entry.createdAt)} PST · ${describeAuthor(entry)}]`);
+    for (const line of entry.message.split('\n')) {
+      lines.push(`    ${line}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function renderFeedbackHtml(feedback: FeedbackEntry[]): string {
+  if (feedback.length === 0) {
+    return `<p style="margin:0;color:#555">No feedback submitted yesterday.</p>`;
+  }
+  const items = feedback
+    .map((entry) => {
+      const who = escapeHtml(describeAuthor(entry));
+      const message = escapeHtml(entry.message).replace(/\n/g, '<br>');
+      return `<li style="margin:0 0 12px">
+        <div style="font-size:12px;color:#777">${formatFeedbackTime(entry.createdAt)} PST · ${who}</div>
+        <div style="white-space:pre-wrap">${message}</div>
+      </li>`;
+    })
+    .join('');
+  return `<ul style="margin:0;padding:0;list-style:none">${items}</ul>`;
 }
 
 function renderText(summary: DailySummary): string {
@@ -41,6 +96,8 @@ function renderText(summary: DailySummary): string {
     `Zen daily players:      ${summary.zenDailyPlayers}`,
     `Zen daily active time:  ${formatActiveDuration(summary.zenDailyActiveSeconds)}`,
     `Free play games:        ${summary.freePlayGames}`,
+    '',
+    renderFeedbackText(summary.feedback),
   ].join('\n');
 }
 
@@ -50,12 +107,14 @@ function renderHtml(summary: DailySummary): string {
   return `<div style="font-family:system-ui,-apple-system,sans-serif">
   <h2 style="margin:0 0 12px">Froggle daily summary</h2>
   <p style="margin:0 0 16px;color:#555">For ${summary.date} (PST)</p>
-  <table style="border-collapse:collapse">
+  <table style="border-collapse:collapse;margin-bottom:24px">
     ${row('Timed daily players', summary.timedDailyPlayers)}
     ${row('Zen daily players', summary.zenDailyPlayers)}
     ${row('Zen daily active time', formatActiveDuration(summary.zenDailyActiveSeconds))}
     ${row('Free play games', summary.freePlayGames)}
   </table>
+  <h3 style="margin:0 0 8px">Feedback</h3>
+  ${renderFeedbackHtml(summary.feedback)}
 </div>`;
 }
 

--- a/server/services/DailySummaryService.ts
+++ b/server/services/DailySummaryService.ts
@@ -1,5 +1,14 @@
-import type { Kysely } from 'kysely';
+import { sql, type Kysely } from 'kysely';
 import type { Database } from '../db/types.js';
+import { getDisplayNames } from './displayNames.js';
+
+export interface FeedbackEntry {
+  id: string;
+  userId: string | null;
+  displayName: string | null;
+  message: string;
+  createdAt: Date;
+}
 
 export interface DailySummary {
   date: string;
@@ -7,6 +16,7 @@ export interface DailySummary {
   zenDailyPlayers: number;
   zenDailyActiveSeconds: number;
   freePlayGames: number;
+  feedback: FeedbackEntry[];
 }
 
 // Returns aggregate engagement counts for a single PST calendar date.
@@ -19,7 +29,7 @@ export async function getDailySummary(
   db: Kysely<Database>,
   date: string,
 ): Promise<DailySummary> {
-  const [timedRow, zenRow, freePlayRow] = await Promise.all([
+  const [timedRow, zenRow, freePlayRow, feedbackRows] = await Promise.all([
     db
       .selectFrom('daily_results')
       .select((eb) => eb.fn.countAll<number>().as('players'))
@@ -38,7 +48,24 @@ export async function getDailySummary(
       .select((eb) => eb.fn.countAll<number>().as('games'))
       .where('date', '=', date)
       .executeTakeFirstOrThrow(),
+    // feedback.created_at is timestamptz; match rows whose PST calendar date equals `date`.
+    db
+      .selectFrom('feedback')
+      .select(['id', 'user_id', 'message', 'created_at'])
+      .where(
+        sql<string>`(created_at at time zone 'America/Los_Angeles')::date::text`,
+        '=',
+        date,
+      )
+      .orderBy('created_at', 'asc')
+      .execute(),
   ]);
+
+  const userIds = feedbackRows
+    .map((row) => row.user_id)
+    .filter((id): id is string => id !== null);
+  const displayNames =
+    userIds.length > 0 ? await getDisplayNames(userIds) : new Map<string, string>();
 
   return {
     date,
@@ -46,6 +73,13 @@ export async function getDailySummary(
     zenDailyPlayers: Number(zenRow.players),
     zenDailyActiveSeconds: Number(zenRow.active_seconds ?? 0),
     freePlayGames: Number(freePlayRow.games),
+    feedback: feedbackRows.map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      displayName: row.user_id ? displayNames.get(row.user_id) ?? null : null,
+      message: row.message,
+      createdAt: row.created_at,
+    })),
   };
 }
 


### PR DESCRIPTION
## What
Folds yesterday's player feedback into the existing morning daily-summary email. Each entry shows the submission time (PST), the author's display name, and the message body. Empty days render as "No feedback submitted yesterday." so the section's presence confirms the section ran.

## Why
Feedback rows previously required a manual DB query to read. Keeping triage in the morning email avoids standing up a separate workflow and is a smaller blast radius than a new admin route. Display names resolve via the existing `getDisplayNames` helper rather than direct SQL against `auth.users` — Supabase's auth schema isn't a stable public contract, and the helper already handles moderation/caching.

## Follow-ups
- Workflow now requires two new GH secrets (`SUPABASE_URL_PROD`, `SUPABASE_SECRET_KEY_PROD`) — already added and verified via a manual workflow_dispatch run on this branch.
- Moderation-locked users render as `Tasty (aka B.D.)` (same as leaderboards); switch to raw `display_name` at `DailySummaryService.ts:67` if that's not the right treatment for an internal digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)