### PR TITLE
fix(daily): uncap landing streak from the 30-day history window

### DIFF
--- a/server/services/DailyService.streak.test.ts
+++ b/server/services/DailyService.streak.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { computeStreak } from './DailyService.js';
+
+const LAUNCH = '2026-01-01';
+
+// Helper: build a Set of the N calendar dates ending at `end` (inclusive),
+// i.e. an unbroken run of played days.
+function consecutiveEndingAt(end: string, count: number): Set<string> {
+  const dates = new Set<string>();
+  let cursor = end;
+  for (let i = 0; i < count; i++) {
+    dates.add(cursor);
+    cursor = addDays(cursor, -1);
+  }
+  return dates;
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00Z');
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+describe('computeStreak', () => {
+  it('counts a played-today streak including today', () => {
+    const today = '2026-05-30';
+    const played = consecutiveEndingAt(today, 5);
+    expect(computeStreak(played, today, LAUNCH)).toBe(5);
+  });
+
+  it('does not break the streak when today has not been played yet', () => {
+    const today = '2026-05-30';
+    // 5-day run ending yesterday; today absent.
+    const played = consecutiveEndingAt(addDays(today, -1), 5);
+    expect(computeStreak(played, today, LAUNCH)).toBe(5);
+  });
+
+  // Regression guard: the streak must NOT be clamped to the 30-day history
+  // window. Before the fix it walked a 30-entry array and capped at 29/30.
+  it('counts streaks longer than the 30-day history window', () => {
+    const today = '2026-05-30';
+    const played = consecutiveEndingAt(today, 45);
+    expect(computeStreak(played, today, LAUNCH)).toBe(45);
+  });
+
+  it('counts a 100-day streak without capping', () => {
+    const today = '2026-05-30';
+    const played = consecutiveEndingAt(today, 100);
+    expect(computeStreak(played, today, LAUNCH)).toBe(100);
+  });
+
+  it('stops at the first prior gap', () => {
+    const today = '2026-05-30';
+    // Played today and the two days before, then a gap.
+    const played = new Set([
+      '2026-05-30',
+      '2026-05-29',
+      '2026-05-28',
+      // gap on 2026-05-27
+      '2026-05-26',
+      '2026-05-25',
+    ]);
+    expect(computeStreak(played, today, LAUNCH)).toBe(3);
+  });
+
+  it('returns 0 when neither today nor yesterday was played', () => {
+    const today = '2026-05-30';
+    const played = consecutiveEndingAt(addDays(today, -2), 5);
+    expect(computeStreak(played, today, LAUNCH)).toBe(0);
+  });
+
+  it('returns 0 for an empty play history', () => {
+    expect(computeStreak(new Set(), '2026-05-30', LAUNCH)).toBe(0);
+  });
+
+  it('never walks past launchDate even if earlier dates are present', () => {
+    const today = '2026-01-03';
+    // Played every day including two days before launch, which should be
+    // ignored — the streak is bounded at launchDate.
+    const played = new Set([
+      '2026-01-03',
+      '2026-01-02',
+      '2026-01-01', // launch
+      '2025-12-31',
+      '2025-12-30',
+    ]);
+    expect(computeStreak(played, today, LAUNCH)).toBe(3);
+  });
+});

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -212,6 +212,26 @@ function maxDate(a: string, b: string): string {
   return a >= b ? a : b;
 }
 
+// Consecutive played days ending at today, walking backward over real
+// calendar dates. Today being unplayed does not break the streak (the user
+// may not have played yet); the first prior gap ends it. Bounded only by
+// launchDate, never by the history window — so a 100-day streak reads as 100,
+// not as the window ceiling. This is the regression guard against the
+// "streak caps at the window size" bug; keep it independent of windowDays.
+export function computeStreak(
+  playedDates: Set<string>,
+  today: string,
+  launchDate: string,
+): number {
+  let streak = 0;
+  let cursor = playedDates.has(today) ? today : addDays(today, -1);
+  while (cursor >= launchDate && playedDates.has(cursor)) {
+    streak++;
+    cursor = addDays(cursor, -1);
+  }
+  return streak;
+}
+
 function stampTierFor(rank: number, totalPlayers: number): StampTier {
   if (rank === 1) return 'first';
   if (rank === 2) return 'second';
@@ -379,22 +399,18 @@ export async function getDailyStats(
   // only make sense for the timed mode), but the streak signal reflects
   // every form of daily engagement so users aren't punished for choosing
   // a mode that doesn't have streak semantics of its own.
+  //
+  // Played dates are queried from launchDate (not windowStart) so the streak
+  // can run longer than the 30-day history window. The history grid below
+  // stays windowed; only the streak walk needs the full play history.
   const playedDates = await getUserPlayedDatesAcrossModes(
     db,
     userId,
-    windowStart,
+    launchDate,
     windowEnd,
   );
 
-  // Walk backwards from today; today missing is not a break yet.
-  let currentStreak = 0;
-  for (let i = days.length - 1; i >= 0; i--) {
-    const day = days[i];
-    const played = playedDates.has(day.date);
-    if (i === days.length - 1 && !played) continue;
-    if (!played) break;
-    currentStreak++;
-  }
+  const currentStreak = computeStreak(playedDates, today, launchDate);
 
   // streakDays: last 7 PST days ending at today, oldest-to-newest.
   // Slicing the tail of `days` works because days is already in that order


### PR DESCRIPTION
**What** — The landing-page streak capped at 29 (pre-play) / 30 (post-play) because it counted played days by walking the 30-entry history-window array.

**Why** — The streak now queries played dates from `launchDate` instead of `windowStart`, so it reflects the user's full play history; the history grid, averages, and rankings stay windowed at 30 days. The walk is extracted into a pure `computeStreak()` helper (per the server rule that calculations are named helpers, not inline reductions) and covered by unit tests, including >30-day and 100-day runs that guard against the cap returning.

**Follow-ups** — None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)