### PR TITLE
feat(landing): add podium badge to gauntlet daily card

### DIFF
--- a/client/src/pages/landing/components/GauntletDailyCard.tsx
+++ b/client/src/pages/landing/components/GauntletDailyCard.tsx
@@ -1,5 +1,6 @@
 import type { GauntletEntry } from 'models/gauntlet';
 import { StatusIcon } from '../../../shared/components/StatusIcon';
+import { RankBadge, type PodiumRank } from './RankBadge';
 
 interface GauntletDailyCardProps {
   entry: GauntletEntry | null;
@@ -19,6 +20,13 @@ export function GauntletDailyCard({ entry, onPlay }: GauntletDailyCardProps) {
       : entry && entry.state === 'partial'
       ? 'in-progress'
       : 'unplayed';
+  const podium: PodiumRank | null =
+    state === 'completed' &&
+    (entry?.aggregateRank === 1 ||
+      entry?.aggregateRank === 2 ||
+      entry?.aggregateRank === 3)
+      ? entry.aggregateRank
+      : null;
 
   return (
     <div className="flex items-stretch w-full rounded-2xl bg-[var(--surface-card)] border border-[var(--ink-border-subtle)] shadow-[var(--shadow-card)] overflow-hidden font-[family-name:var(--font-ui)]">
@@ -37,6 +45,7 @@ export function GauntletDailyCard({ entry, onPlay }: GauntletDailyCardProps) {
             >
               Gauntlet
             </span>
+            {podium && <RankBadge rank={podium} />}
             {state !== 'unplayed' && <StatusIcon state={state} />}
           </div>
           <HintLine state={state} entry={entry} completedRounds={completedRounds} />


### PR DESCRIPTION
**What** — Show the gold/silver/bronze `RankBadge` next to the Gauntlet label on the landing page daily card when the player's aggregate rank is 1st, 2nd, or 3rd.

**Why** — The timed and zen daily cards already show this podium badge; the gauntlet card only had the text rank readout, so this brings it to visual parity using the same shared `RankBadge` component and podium tokens.

**Follow-ups** — None. The existing `Rank #N · rank-sum M` text line is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)