### PR TITLE
feat(multiplayer): run solo free play through the room

### DIFF
--- a/client/src/pages/multiplayer/MultiplayerRoomRoute.tsx
+++ b/client/src/pages/multiplayer/MultiplayerRoomRoute.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { GameState } from 'models';
 import { useGame } from '../../GameContext';
 import { InkButton } from '../../shared/components/InkButton';
 import { useMultiplayerRoom } from '../../shared/multiplayer/useMultiplayerRoom';
@@ -20,7 +19,7 @@ export function MultiplayerRoomRoute() {
   const { code: rawCode } = useParams<{ code: string }>();
   const code = (rawCode ?? '').toUpperCase();
   const navigate = useNavigate();
-  const { session, profileReady, game, createGame, startGame } = useGame();
+  const { session, profileReady } = useGame();
   const [precheck, setPrecheck] = useState<PrecheckState>('checking');
   // Lets the host reopen the just-finished board's scoresheet from the
   // lobby's "Last Round" card without leaving the room.
@@ -135,27 +134,13 @@ export function MultiplayerRoomRoute() {
     navigate('/');
   };
 
-  // Host pressing Start in the lobby. Solo (room of one) runs the
-  // established single-player free-play engine so challenge links,
-  // history persistence, and the rich solo results page all keep
-  // working untouched. With others present, the board runs through the
-  // room so everyone races the same letters live.
-  const handleStart = async () => {
-    if (!room) return;
-    const connected = room.players.filter((p) => p.connected).length;
-    if (connected <= 1) {
-      const cfg = room.nextConfig;
-      // `startGame` hits /api/game/start, which only accepts a session in
-      // Config state. A leftover game from a just-finished solo round (e.g.
-      // "Play again" routing back through the lobby) is Finished, so create a
-      // fresh session unless the current one is already startable.
-      if (!game || game.status !== GameState.Config) await createGame();
-      await startGame(cfg.durationSeconds, cfg.boardSize, cfg.minWordLength);
-      navigate('/game');
-      return;
-    }
-    startBoard();
-  };
+  // Host pressing Start in the lobby. Every round — solo or multi — runs
+  // through the room: the board, the shared "get ready" countdown, and the
+  // results all live on the room so the room is never dropped and recreated.
+  // Solo just happens to be a room of one; its results still persist to
+  // history and can be shared as an async challenge (handled server-side when
+  // the board ends), so nothing is lost by not diverting to a separate engine.
+  const handleStart = () => startBoard();
 
   const handleShare = async () => {
     const url = `${window.location.origin}/play/room/${code}`;
@@ -172,9 +157,6 @@ export function MultiplayerRoomRoute() {
     await copyToClipboard(url);
   };
 
-  if (precheck === 'checking' || !profileReady) {
-    return <LoadingScreen label="Connecting…" />;
-  }
   if (precheck === 'not-found' || errorReason === 'not-found') {
     return <NotFoundScreen code={code} onHome={() => navigate('/')} />;
   }
@@ -182,8 +164,15 @@ export function MultiplayerRoomRoute() {
     return <NotFoundScreen code={code} onHome={() => navigate('/')} variant="error" />;
   }
 
+  // One calm loader covers the whole pre-room phase (auth settling, room
+  // precheck, socket connect, first state). Plain free play should feel
+  // single-player, not like a multi-step "connecting → joining → reconnecting"
+  // handshake — so there's no per-stage copy. We only surface a reconnect
+  // notice on a genuine socket error with no room state to fall back on; once
+  // a room has loaded, a dropped socket keeps the last snapshot on screen
+  // instead of falling back here.
   if (!room) {
-    return <LoadingScreen label={status === 'connecting' ? 'Joining room…' : 'Reconnecting…'} />;
+    return <LoadingScreen reconnecting={status === 'error'} />;
   }
 
   if (room.status === 'playing') {
@@ -252,16 +241,23 @@ export function MultiplayerRoomRoute() {
   );
 }
 
-function LoadingScreen({ label }: { label: string }) {
+function LoadingScreen({ reconnecting = false }: { reconnecting?: boolean }) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]">
-      <div className="flex flex-col items-center gap-2">
-        <div
-          className="font-[family-name:var(--font-display)] italic"
-          style={{ fontSize: '1.4rem', fontWeight: 600 }}
-        >
-          {label}
-        </div>
+      <div className="flex flex-col items-center gap-3">
+        <span
+          className="inline-block rounded-full animate-pulse"
+          style={{ width: 14, height: 14, background: 'var(--logo-dot)' }}
+          aria-label="Loading"
+        />
+        {reconnecting && (
+          <div
+            className="text-caption uppercase tracking-[0.08em] text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+            style={{ fontWeight: 700 }}
+          >
+            Reconnecting…
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/multiplayer/RoomResults.tsx
+++ b/client/src/pages/multiplayer/RoomResults.tsx
@@ -10,7 +10,9 @@ import type {
 } from '../../shared/results/types';
 import { findWordPath } from '../../shared/utils/findWordPath';
 import { scoreWord } from '../../shared/utils/score';
-import { fetchRoomWords } from '../../shared/api/multiplayerApi';
+import { fetchRoomWords, shareRoomChallenge } from '../../shared/api/multiplayerApi';
+import { encodeGameLink } from '../../shared/utils/gameLink';
+import { useShareText } from '../results/hooks/useShareText';
 import { RoomResultsHero } from './RoomResultsHero';
 
 interface RoomResultsProps {
@@ -132,6 +134,24 @@ export function RoomResults({
     };
   }, [me, board, allWords]);
 
+  // Share the just-played board as an async challenge. The board's results
+  // are persisted as free_play_sessions when it ends, so the server can
+  // promote the caller's row into a challenge — recipients then play the same
+  // seeded board on their own time and land on the shared leaderboard, exactly
+  // like a solo free-play challenge. Minted lazily on tap so a results render
+  // never fires the request.
+  const { share, copied } = useShareText(async () => {
+    const minted = await shareRoomChallenge(room.code);
+    if (!minted) return 'Froggle';
+    return `Froggle challenge — ${encodeGameLink({
+      boardSize: minted.config.boardSize,
+      seed: minted.seed,
+      timer: minted.config.timeLimit,
+      minWordLength: minted.config.minWordLength,
+      challengeId: minted.challengeId,
+    })}`;
+  });
+
   const loadOpponent = async (id: string): Promise<LoadOpponentResult> => {
     const opp = room.players.find((p) => p.id === id);
     if (!opp || !board) return { ok: false, error: 'opponent-missing' };
@@ -171,6 +191,12 @@ export function RoomResults({
     );
   }
 
+  // A room of one is a single-player game under the hood — drop the
+  // competitive framing (no "you won" hero, no standings, no rank) so it reads
+  // like the solo results page. ResultsView already collapses standings for a
+  // roster of one; here we also swap the hero and offer Share + Play again.
+  const isSolo = roster.length <= 1;
+
   const isWinner = me.rank === 1 && outcome.rank1Count === 1 && !outcome.scoreless;
   const isTie = me.rank === 1 && outcome.rank1Count > 1 && !outcome.scoreless;
   const hero = (
@@ -206,18 +232,21 @@ export function RoomResults({
       standingsHeader="Standings"
       standingsShowBars
       compareSourceLabel="standings"
-      topbarLabel={`Room · ${room.code}`}
+      topbarLabel={isSolo ? 'Free Play' : `Room · ${room.code}`}
       topbarOnClose={onLeave}
-      soloHero={hero}
+      topbarOnShare={share}
+      topbarShareCopied={copied}
+      soloHero={isSolo ? undefined : hero}
       bottomActions={
         <BottomActions
           isHost={isHost}
           onStartNext={onStartNext}
           onReturnToLobby={onReturnToLobby}
           onBackToLobby={onBackToLobby}
+          nextLabel={isSolo ? 'Play again' : 'Next round'}
         />
       }
-      soloPlaceholderVariant="wait"
+      soloPlaceholderVariant="share"
     />
   );
 }
@@ -227,9 +256,18 @@ interface BottomActionsProps {
   onStartNext: () => void;
   onReturnToLobby: () => void;
   onBackToLobby: () => void;
+  /** Label for the host's primary action — "Next round" with others present,
+   *  "Play again" when solo. */
+  nextLabel?: string;
 }
 
-function BottomActions({ isHost, onStartNext, onReturnToLobby, onBackToLobby }: BottomActionsProps) {
+function BottomActions({
+  isHost,
+  onStartNext,
+  onReturnToLobby,
+  onBackToLobby,
+  nextLabel = 'Next round',
+}: BottomActionsProps) {
   if (!isHost) {
     // Non-hosts can't start the next round, but they shouldn't be stuck on
     // the scoresheet — give them a real, full-width button back to the
@@ -263,7 +301,7 @@ function BottomActions({ isHost, onStartNext, onReturnToLobby, onBackToLobby }: 
       />
       <ActionButton
         onClick={onStartNext}
-        label="Next round"
+        label={nextLabel}
         primary
         icon={
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/shared/api/gameApi.ts
+++ b/client/src/shared/api/gameApi.ts
@@ -11,7 +11,7 @@ export function getSessionId(): string | null {
   return sessionId;
 }
 
-async function sessionHeaders(): Promise<Record<string, string>> {
+export async function sessionHeaders(): Promise<Record<string, string>> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (sessionId) {
     headers['X-Session-Id'] = sessionId;

--- a/client/src/shared/api/multiplayerApi.ts
+++ b/client/src/shared/api/multiplayerApi.ts
@@ -1,5 +1,6 @@
 import type { GameConfig } from 'models';
 import type { MultiplayerRoom, PublicRoomsResponse } from 'models/multiplayer';
+import { sessionHeaders } from './gameApi';
 
 const API_URL = '/api';
 
@@ -28,6 +29,24 @@ export async function fetchPublicRooms(): Promise<PublicRoomsResponse> {
   const res = await fetch(`${API_URL}/multiplayer/public`);
   if (!res.ok) throw new Error(`fetchPublicRooms failed: ${res.status}`);
   return (await res.json()) as PublicRoomsResponse;
+}
+
+export interface RoomChallengeShare {
+  challengeId: string;
+  seed: number;
+  config: { boardSize: number; timeLimit: number; minWordLength: number };
+}
+
+/** Promote the caller's result on the room's most recent board into a
+ *  shareable async challenge. Returns null when there's nothing to share yet
+ *  (no finished board, or the caller has no recorded result). */
+export async function shareRoomChallenge(code: string): Promise<RoomChallengeShare | null> {
+  const res = await fetch(`${API_URL}/multiplayer/rooms/${encodeURIComponent(code)}/share`, {
+    method: 'POST',
+    headers: await sessionHeaders(),
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as RoomChallengeShare;
 }
 
 /** Every found-able word on the room's current board. Returns [] until the

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,7 +17,9 @@ import { feedbackRouter } from './routes/feedback.js';
 import { versionRouter } from './routes/version.js';
 import { multiplayerRouter } from './routes/multiplayer.js';
 import { attachMultiplayerSockets } from './multiplayer/sockets.js';
-import { startRoomCleanup } from './multiplayer/store.js';
+import { setBoardCompletionHandler, startRoomCleanup } from './multiplayer/store.js';
+import { persistRoomBoardResults } from './services/FreePlayService.js';
+import { getDb } from './db/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,6 +70,16 @@ app.get('*', (_req, res) => {
 
 startSessionCleanup();
 startRoomCleanup();
+
+// Persist finished room boards into the same free_play_sessions history as
+// solo free-play, so room games (solo or multi) show up in /history and can
+// be promoted to async challenges. Injected here to keep the in-memory room
+// store free of any database dependency.
+setBoardCompletionHandler((completion) =>
+  persistRoomBoardResults(getDb(), completion).catch((err) =>
+    console.error('Failed to persist room board results:', err),
+  ),
+);
 
 // Wrap Express in an HTTP server so Socket.io can attach to the same
 // port — the multiplayer namespace shares the listener with the REST

--- a/server/multiplayer/sockets.ts
+++ b/server/multiplayer/sockets.ts
@@ -120,7 +120,7 @@ export function attachMultiplayerSockets(io: Server): void {
     // The socket may have been torn down during the awaits above.
     if (socket.disconnected) return;
 
-    const result = joinRoom(hs.roomCode, hs.playerKey, displayName);
+    const result = joinRoom(hs.roomCode, hs.playerKey, displayName, userId);
     if (!result) {
       socket.emit('room:error', { reason: 'not-found' });
       socket.disconnect(true);

--- a/server/multiplayer/store.persistence.test.ts
+++ b/server/multiplayer/store.persistence.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createRoom,
+  endBoard,
+  getRoom,
+  joinRoom,
+  setBoardCompletionHandler,
+  startBoard,
+  type RoomBoardCompletion,
+} from './store.js';
+
+// The store defers a finished board's history write until the post-end grace
+// window closes, because submitWord keeps accepting a final in-flight word for
+// GRACE_PERIOD_MS after the board ends. These tests pin that timing: the write
+// must not fire at the instant of ending, it must capture a word that lands
+// during the grace window, and a fast next round must flush the pending write
+// (with the real words) exactly once before it resets per-player state.
+//
+// A grace-window submission is simulated by mutating the player record the way
+// submitWord does — the dictionary/path validity of submitWord is orthogonal
+// to the persistence timing under test here.
+
+describe('room board history persistence', () => {
+  let completions: RoomBoardCompletion[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    completions = [];
+    setBoardCompletionHandler((c) => {
+      completions.push(c);
+    });
+  });
+
+  afterEach(() => {
+    setBoardCompletionHandler(() => {});
+    vi.useRealTimers();
+  });
+
+  // Start a board and put the sole player in a known scored state, as if they
+  // had found one word during play.
+  function setupEndedBoard() {
+    const { code } = createRoom();
+    joinRoom(code, 'key-1', 'Alice', 'user-1');
+    startBoard(code, () => {});
+
+    const player = getRoom(code)!.players[0];
+    player.foundWords = ['HELLO'];
+    player.points = 1;
+    player.wordCount = 1;
+
+    endBoard(code);
+    return { code, player };
+  }
+
+  it('does not write at the instant the board ends', () => {
+    setupEndedBoard();
+    expect(completions).toHaveLength(0);
+  });
+
+  it('captures a word that lands during the grace window after the board ends', () => {
+    const { player } = setupEndedBoard();
+
+    // A final word arrives within the grace window — submitWord would accept it
+    // and mutate the player record after endBoard already ran.
+    player.foundWords = ['HELLO', 'WORLD'];
+    player.points = 2;
+    player.wordCount = 2;
+
+    vi.advanceTimersByTime(1000);
+
+    expect(completions).toHaveLength(1);
+    const me = completions[0].participants[0];
+    expect(me.userId).toBe('user-1');
+    expect(me.foundWords).toEqual(['HELLO', 'WORLD']);
+    expect(me.points).toBe(2);
+    expect(me.wordCount).toBe(2);
+  });
+
+  it('flushes the pending write before the next round resets player state', () => {
+    const { code, player } = setupEndedBoard();
+
+    // Host starts the next round before the grace timer fires. The pending
+    // write must flush with the finished board's real words, not the reset.
+    startBoard(code, () => {});
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].participants[0].foundWords).toEqual(['HELLO']);
+    // The new board has reset the player's per-board state.
+    expect(player.foundWords).toEqual([]);
+
+    // The original deferred timer must not fire a second (empty) write.
+    vi.advanceTimersByTime(1000);
+    expect(completions).toHaveLength(1);
+  });
+
+  it('writes exactly once per board after the grace window', () => {
+    setupEndedBoard();
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(1000);
+    expect(completions).toHaveLength(1);
+  });
+});

--- a/server/multiplayer/store.ts
+++ b/server/multiplayer/store.ts
@@ -99,9 +99,158 @@ interface RoomEntry {
   /** Bumped on every mutation so the cleanup sweep can purge idle rooms
    *  without holding active ones. */
   lastActivity: number;
+  /** Public player id → authenticated Supabase user id, for the players the
+   *  server could verify at join. Server-only (never broadcast) so a snapshot
+   *  can't leak a player's user id. Used to key persisted history rows when a
+   *  board ends. */
+  userIds: Map<string, string>;
+  /** The in-flight (or settled) persistence write for the most recently ended
+   *  board. The share endpoint awaits this so a challenge can be minted the
+   *  instant results appear, before the async insert would otherwise land.
+   *  Resolves only once the deferred write below has actually run. */
+  lastPersistence: Promise<void> | null;
+  /** Timer that runs the deferred history write after the post-end grace
+   *  window closes (see schedulePersistence). Cleared if the write is flushed
+   *  early. */
+  persistTimer: NodeJS.Timeout | null;
+  /** Runs the pending history write immediately and idempotently. startBoard
+   *  calls this before it resets per-player state so a fast next round can't
+   *  wipe an unpersisted board; null when no write is pending. */
+  flushPersistence: (() => void) | null;
 }
 
 const rooms = new Map<string, RoomEntry>();
+
+// ---------------------------------------------------------------------------
+// History persistence sink
+//
+// The store stays free of any DB dependency — index.ts wires the handler at
+// boot. When a board ends, the room hands its per-player results to the sink,
+// which writes them into the same free_play_sessions history as solo
+// free-play. That makes room games (solo or multi) appear in /history and
+// promotable to async challenges through the existing infrastructure.
+// ---------------------------------------------------------------------------
+
+/** A finished board's per-player results, handed to the persistence sink. */
+export interface RoomBoardCompletion {
+  seed: number;
+  board: string[][];
+  config: GameConfig;
+  startedAt: number;
+  endedAt: number;
+  participants: Array<{
+    userId: string;
+    foundWords: string[];
+    points: number;
+    wordCount: number;
+    longestWord: string;
+  }>;
+}
+
+type BoardCompletionHandler = (completion: RoomBoardCompletion) => Promise<void> | void;
+let boardCompletionHandler: BoardCompletionHandler | null = null;
+
+/** Register the sink that persists a finished board's results. Called once at
+ *  server boot — kept as an injected callback so the in-memory store never
+ *  imports the database layer. */
+export function setBoardCompletionHandler(handler: BoardCompletionHandler): void {
+  boardCompletionHandler = handler;
+}
+
+/** Await the persistence write for the room's most recently ended board (if
+ *  any). Lets the challenge-share endpoint guarantee the history row exists
+ *  before it tries to promote it. */
+export async function awaitBoardPersistence(code: string): Promise<void> {
+  const entry = getEntry(code);
+  if (entry?.lastPersistence) await entry.lastPersistence;
+}
+
+function longestOf(words: string[]): string {
+  let longest = '';
+  for (const w of words) if (w.length > longest.length) longest = w;
+  return longest;
+}
+
+// Persisting a finished board is deferred until the post-end grace window
+// closes. submitWord keeps accepting a valid word for GRACE_PERIOD_MS after a
+// board ends (so a final word already in flight when the timer fired still
+// counts toward the round) — snapshotting at the instant of ending would write
+// the history row and shared challenge before that word lands, leaving them a
+// word short of the live room results. The extra margin guarantees a word
+// accepted at the very edge of the grace window is included before we read.
+const PERSIST_DELAY_MS = GRACE_PERIOD_MS + 50;
+
+/** Snapshot the just-ended board's per-player results, keyed to each player's
+ *  authenticated user id. Players the server couldn't authenticate are skipped
+ *  — their scores still live in the room snapshot, they just don't write
+ *  history. Returns null when nobody has a row to persist. */
+function buildCompletion(entry: RoomEntry, board: MultiplayerBoard): RoomBoardCompletion | null {
+  const participants: RoomBoardCompletion['participants'] = [];
+  for (const id of board.participantIds) {
+    const userId = entry.userIds.get(id);
+    if (!userId) continue;
+    const player = entry.room.players.find((p) => p.id === id);
+    if (!player) continue;
+    participants.push({
+      userId,
+      foundWords: [...player.foundWords],
+      points: player.points,
+      wordCount: player.wordCount,
+      longestWord: longestOf(player.foundWords),
+    });
+  }
+  if (participants.length === 0) return null;
+  return {
+    seed: board.seed,
+    board: board.board,
+    config: board.config,
+    startedAt: board.startedAt,
+    endedAt: board.endedAt!,
+    participants,
+  };
+}
+
+/** Schedule the deferred history write for the board that just ended. The
+ *  write runs once the grace window closes, or earlier if flushed (e.g. by
+ *  startBoard before it resets player state). `lastPersistence` resolves only
+ *  after the write settles, so the share endpoint can await a real row. */
+function schedulePersistence(entry: RoomEntry): void {
+  // A prior board's write should already have flushed; clear any leftover
+  // timer defensively so two pending writes can't overlap.
+  if (entry.persistTimer) clearTimeout(entry.persistTimer);
+  entry.persistTimer = null;
+  entry.flushPersistence = null;
+
+  const handler = boardCompletionHandler;
+  const board = entry.room.currentBoard;
+  if (!handler || !board || board.endedAt === null) {
+    entry.lastPersistence = null;
+    return;
+  }
+
+  let settle!: () => void;
+  entry.lastPersistence = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  let done = false;
+  const flush = () => {
+    if (done) return;
+    done = true;
+    if (entry.persistTimer) clearTimeout(entry.persistTimer);
+    entry.persistTimer = null;
+    entry.flushPersistence = null;
+    const completion = buildCompletion(entry, board);
+    if (!completion) {
+      settle();
+      return;
+    }
+    Promise.resolve(handler(completion)).then(settle, settle);
+  };
+
+  entry.flushPersistence = flush;
+  entry.persistTimer = setTimeout(flush, PERSIST_DELAY_MS);
+}
 
 export interface CreateRoomOptions {
   config?: Partial<GameConfig>;
@@ -137,6 +286,10 @@ export function createRoom(options: CreateRoomOptions = {}): MultiplayerRoom {
     keyToPlayerId: new Map(),
     socketCounts: new Map(),
     lastActivity: Date.now(),
+    userIds: new Map(),
+    lastPersistence: null,
+    persistTimer: null,
+    flushPersistence: null,
   });
   return room;
 }
@@ -223,6 +376,7 @@ export function joinRoom(
   code: string,
   playerKey: string,
   displayName: string,
+  userId: string | null,
 ): { room: MultiplayerRoom; player: MultiplayerPlayer } | null {
   const entry = getEntry(code);
   if (!entry) return null;
@@ -235,6 +389,7 @@ export function joinRoom(
     existing.connected = true;
     existing.left = false; // rejoining clears the departed flag
     existing.displayName = displayName || existing.displayName;
+    if (userId) entry.userIds.set(existing.id, userId);
     // A reconnecting player may be the only live person in a room whose
     // host record is stale — make sure they can run it.
     ensureConnectedHost(room);
@@ -262,6 +417,7 @@ export function joinRoom(
 
   entry.keyToPlayerId.set(playerKey, player.id);
   entry.socketCounts.set(player.id, 1);
+  if (userId) entry.userIds.set(player.id, userId);
   room.players.push(player);
   // First player, or first to arrive after the previous host dropped while
   // alone (which leaves a stale disconnected host) — take the room over.
@@ -338,6 +494,9 @@ export function leaveRoom(code: string, playerId: string): MultiplayerRoom | nul
   // or the room is empty), tear it down so it doesn't linger.
   const livePlayers = room.players.filter((p) => !p.left);
   if (livePlayers.length === 0) {
+    // Flush any pending history write before the room (and its player data)
+    // is dropped, so the last board the departing player finished still lands.
+    entry.flushPersistence?.();
     if (entry.boardTimer) clearTimeout(entry.boardTimer);
     rooms.delete(room.code);
     clearRoomNudges(room.code);
@@ -398,6 +557,11 @@ export function startBoard(
   // otherwise create a board with an empty participant set that lands straight
   // on an empty results screen. Refuse it.
   if (!room.players.some((p) => p.connected)) return null;
+
+  // The previous board's history write may still be waiting out its grace
+  // window. Flush it now — the reset below zeroes per-player found words, so a
+  // deferred snapshot taken afterwards would persist an empty board.
+  entry.flushPersistence?.();
 
   const config = room.nextConfig;
   const seed = randomSeed();
@@ -473,6 +637,9 @@ export function endBoard(code: string): MultiplayerRoom | null {
   }
 
   updateLastRound(room);
+  // Defer the history write past the grace window — a final word may still
+  // land in submitWord for GRACE_PERIOD_MS after this point.
+  schedulePersistence(entry);
 
   touch(entry);
   return room;
@@ -731,6 +898,7 @@ export function startRoomCleanup(intervalMs = 15 * 60 * 1000): NodeJS.Timeout {
     for (const [code, entry] of rooms) {
       if (entry.lastActivity < cutoff) {
         if (entry.boardTimer) clearTimeout(entry.boardTimer);
+        if (entry.persistTimer) clearTimeout(entry.persistTimer);
         rooms.delete(code);
         clearRoomNudges(code);
       }

--- a/server/routes/multiplayer.ts
+++ b/server/routes/multiplayer.ts
@@ -1,11 +1,15 @@
 import { Router } from 'express';
 import {
+  awaitBoardPersistence,
   countPublicPlayers,
   createRoom,
   getEndedBoardWords,
   getRoom,
   listPublicRooms,
 } from '../multiplayer/store.js';
+import { requireAuth } from '../middleware/auth.js';
+import { getDb } from '../db/index.js';
+import { shareRoomBoardChallenge } from '../services/FreePlayService.js';
 
 export const multiplayerRouter = Router();
 
@@ -35,4 +39,35 @@ multiplayerRouter.get('/rooms/:code', (req, res) => {
     return;
   }
   res.json({ room });
+});
+
+// Promote the caller's result on the room's most recent board into a
+// shareable async challenge. The board's results are written to
+// free_play_sessions when it ends, so this reuses the exact same challenge
+// model (and recipient flow) as solo free-play — recipients play the same
+// seeded board on their own time and land on the shared leaderboard.
+multiplayerRouter.post('/rooms/:code/share', requireAuth, async (req, res) => {
+  const room = getRoom(req.params.code);
+  if (!room || !room.currentBoard || room.currentBoard.endedAt === null) {
+    res.status(409).json({ error: 'No finished board to share' });
+    return;
+  }
+  try {
+    // The board's history rows are written fire-and-forget when it ends; wait
+    // for that write so the row is promotable the instant results show.
+    await awaitBoardPersistence(req.params.code);
+    const board = room.currentBoard;
+    const shared = await shareRoomBoardChallenge(getDb(), req.userId!, {
+      seed: board.seed,
+      boardSize: board.config.boardSize,
+    });
+    if (!shared) {
+      res.status(404).json({ error: 'No result to share' });
+      return;
+    }
+    res.json(shared);
+  } catch (err) {
+    console.error('Failed to share room challenge:', err);
+    res.status(500).json({ error: 'Failed to share' });
+  }
 });

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -8,6 +8,7 @@ import { scoreWord } from 'engine/scoring.js';
 import { generateSeededBoard } from 'engine/board.js';
 import { randomSeed } from 'models/seedCode';
 import type { Database } from '../db/types.js';
+import type { RoomBoardCompletion } from '../multiplayer/store.js';
 import { dictionary } from './dictionary.js';
 import { getDailyDatePST } from './dailyConfig.js';
 import { scoreResult } from './DailyService.js';
@@ -446,6 +447,100 @@ export function buildFreePlayResults(session: FreePlaySession): {
   missedWords.sort((a, b) => b.score - a.score || b.word.length - a.word.length);
 
   return { board: session.board, foundWords, missedWords };
+}
+
+// ─── Multiplayer room → history bridge ────────────────────────────────────
+//
+// A finished room board persists one completed free_play_sessions row per
+// authenticated participant, so room games (solo or multi) appear in /history
+// and can be promoted to async challenges exactly like solo free-play. The
+// row shape lines up 1:1 with the solo session: board, found words, points,
+// config, and seed are all carried on the board.
+
+/** Persist a finished multiplayer board as one completed session row per
+ *  authenticated participant. challenge_id stays null — sharing promotes a
+ *  row to a challenge later, the same way solo free-play does. */
+export async function persistRoomBoardResults(
+  db: Kysely<Database>,
+  completion: RoomBoardCompletion,
+): Promise<void> {
+  if (completion.participants.length === 0) return;
+  const completedAt = new Date(completion.endedAt);
+  const startedAt = new Date(completion.startedAt);
+  const date = getDailyDatePST(completedAt);
+  const boardJson = JSON.stringify(completion.board);
+
+  await db
+    .insertInto('free_play_sessions')
+    .values(
+      completion.participants.map((p) => ({
+        id: crypto.randomUUID(),
+        user_id: p.userId,
+        date,
+        board: boardJson,
+        found_words: JSON.stringify(p.foundWords),
+        started_at: startedAt,
+        completed_at: completedAt,
+        points: p.points,
+        word_count: p.wordCount,
+        longest_word: p.longestWord,
+        time_limit: completion.config.durationSeconds,
+        board_size: completion.config.boardSize,
+        min_word_length: completion.config.minWordLength,
+        challenge_id: null,
+        seed: completion.seed,
+      })),
+    )
+    .execute();
+}
+
+export interface RoomChallengeShare {
+  challengeId: string;
+  seed: number;
+  config: { boardSize: number; timeLimit: number; minWordLength: number };
+}
+
+/** Promote the caller's persisted result for a specific room board into a
+ *  shareable challenge, reusing the same self-referential challenge_id model
+ *  as solo free-play (challenge id === originator session id). Idempotent:
+ *  re-sharing the same board returns the existing challenge id. Returns null
+ *  when the caller has no completed row for that board (an unauthenticated
+ *  player, or before the board's history write has landed). */
+export async function shareRoomBoardChallenge(
+  db: Kysely<Database>,
+  userId: string,
+  board: { seed: number; boardSize: number },
+): Promise<RoomChallengeShare | null> {
+  const row = await db
+    .selectFrom('free_play_sessions')
+    .select(['id', 'challenge_id', 'board_size', 'time_limit', 'min_word_length', 'seed'])
+    .where('user_id', '=', userId)
+    .where('seed', '=', board.seed)
+    .where('board_size', '=', board.boardSize)
+    .where('completed_at', 'is not', null)
+    .orderBy('completed_at', 'desc')
+    .limit(1)
+    .executeTakeFirst();
+  if (!row) return null;
+
+  const challengeId = row.challenge_id ?? row.id;
+  if (!row.challenge_id) {
+    await db
+      .updateTable('free_play_sessions')
+      .set({ challenge_id: row.id })
+      .where('id', '=', row.id)
+      .execute();
+  }
+
+  return {
+    challengeId,
+    seed: row.seed ?? board.seed,
+    config: {
+      boardSize: row.board_size,
+      timeLimit: row.time_limit,
+      minWordLength: row.min_word_length,
+    },
+  };
 }
 
 // Per-fetch salted hash payload for client-side instant validation.


### PR DESCRIPTION
**What** — Solo free play now runs entirely through the multiplayer room instead of diverting to the single-player engine, so the same room is reused across results → lobby / play again (never dropped and recreated), the selected config persists, the pre-board countdown plays even when alone, and the entry screen is one calm loader rather than a "connecting → joining → reconnecting" handshake.

**Why this approach** — Treating solo as a room of one unifies the flow, but a room is in-memory only; rather than lose history and challenges, finished room boards (solo or multi) now persist one completed `free_play_sessions` row per authenticated participant, keyed to the Supabase `user_id` already verified at the socket handshake (threaded through `joinRoom`, kept server-only). That makes room games show up in `/history` and lets a new `POST /rooms/:code/share` endpoint promote a board into an async challenge through the existing challenge infrastructure, so recipients play the same seeded board on their own time.

**Follow-ups** — The history write is deferred past the post-end grace window (and flushed before a next round resets state) so a final in-flight word isn't dropped from the persisted row; this is covered by `store.persistence.test.ts`. Share is wired for multiplayer results too (previously a dead icon) — each player shares their own board; restrict to solo if undesired.