### PR TITLE
fix(client): avoid refresh work during active play

### DIFF
--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -132,12 +132,12 @@ interface GameContextValue {
   // mid-game refresh doesn't strand the player on the landing screen.
   freePlayHydrated: boolean;
 
-  // Lets a route-local timed run (e.g. a gauntlet round, whose session
-  // lives outside this context) suppress the stale-tab build-mismatch
-  // reload while its timer is live, so a deploy mid-run can't reload the
-  // page out from under the player. Call on mount of the live run and
-  // invoke the returned unregister fn on teardown.
-  registerActiveTimedRun: () => () => void;
+  // Lets a route-local run (a gauntlet round or zen play, whose session
+  // lives outside this context) suppress the stale-tab refresh and
+  // build-mismatch reload while it's on screen, so a deploy or cache poll
+  // mid-run can't reload or swap the board out from under the player. Call
+  // on mount of the live run and invoke the returned unregister fn on teardown.
+  registerActiveRun: () => () => void;
 
   // Profile
   displayName: string;
@@ -433,25 +433,18 @@ export function GameProvider({ children }: { children: ReactNode }) {
       !!cachedDailyTimedSession && !cachedDailyTimedSession.ended_at;
   }, [cachedDailyTimedSession]);
 
-  // True while a zen daily run is live. Zen is untimed and lives entirely in
-  // cachedDailyZenSession — it never populates the free-play `game` object or
-  // the timed-daily ref above — so without this it slips past every isRunActive
-  // gate and the refresh keeps swapping cachedDailyZen under the player.
-  const zenInProgressRef = useRef(false);
-  useEffect(() => {
-    zenInProgressRef.current =
-      !!cachedDailyZenSession && !cachedDailyZenSession.ended_at;
-  }, [cachedDailyZenSession]);
-
-  // Ref-counted registry for route-local timed runs (gauntlet rounds) that
-  // need the reload suppressed but keep their session outside this context.
+  // Ref-counted registry for route-local runs that need the refresh/reload
+  // suppressed but keep their session outside this context: gauntlet rounds
+  // (timed) and zen play (untimed). Gated from the play route — not the
+  // persisted session row — so it clears the moment the player leaves the
+  // board, even when the session stays unended (zen can sit open all day).
   // A count (not a boolean) so overlapping registrants — and React's
   // StrictMode double-invoke in dev — can't prematurely clear the guard.
-  const activeTimedRunsRef = useRef(0);
-  const registerActiveTimedRun = useCallback(() => {
-    activeTimedRunsRef.current += 1;
+  const activeRunsRef = useRef(0);
+  const registerActiveRun = useCallback(() => {
+    activeRunsRef.current += 1;
     return () => {
-      activeTimedRunsRef.current = Math.max(0, activeTimedRunsRef.current - 1);
+      activeRunsRef.current = Math.max(0, activeRunsRef.current - 1);
     };
   }, []);
 
@@ -465,9 +458,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
     const isRunActive = () =>
       timedDailyInProgressRef.current ||
-      zenInProgressRef.current ||
       gameStatusRef.current === GameState.InProgress ||
-      activeTimedRunsRef.current > 0;
+      activeRunsRef.current > 0;
 
     // Benign refetch of the public daily/zen puzzles so the board and landing
     // match today. It only swaps cached data — it never reloads — so it is safe
@@ -776,7 +768,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       theme, toggleTheme,
       session, authReady,
       freePlayHydrated,
-      registerActiveTimedRun,
+      registerActiveRun,
       displayName, profileReady, nameProfile, updateDisplayName,
     }}>
       <div data-theme={theme} className="contents">

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -341,16 +341,19 @@ export function GameProvider({ children }: { children: ReactNode }) {
   // public daily are both available. The session row handles mid-game
   // resume after a reload (same as zen daily); the result row is what
   // unlocks the "See result" affordance on the confirm page.
+  const cachedDailyDate = cachedDaily?.date ?? null;
+  const cachedDailyZenDate = cachedDailyZen?.date ?? null;
+
   useEffect(() => {
-    if (!authReady || !cachedDaily) return;
+    if (!authReady || !cachedDailyDate) return;
     let cancelled = false;
     setDailyResultLoaded(false);
     setCachedDailyResult(null);
 
     (async () => {
       const [result, session] = await Promise.all([
-        fetchDailyResult(cachedDaily.date).catch(() => null),
-        fetchDailyTimedSession(cachedDaily.date).catch(() => null),
+        fetchDailyResult(cachedDailyDate).catch(() => null),
+        fetchDailyTimedSession(cachedDailyDate).catch(() => null),
       ]);
       if (cancelled) return;
       if (result) setCachedDailyResult(result);
@@ -363,7 +366,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [authReady, cachedDaily]);
+  }, [authReady, cachedDailyDate]);
 
   // Fetch public zen puzzle data immediately. The authenticated session row
   // is loaded separately below once auth is ready.
@@ -382,11 +385,11 @@ export function GameProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (!authReady || !cachedDailyZen) return;
+    if (!authReady || !cachedDailyZenDate) return;
     let cancelled = false;
     setDailyZenLoaded(false);
 
-    fetchDailyZenSession(cachedDailyZen.date)
+    fetchDailyZenSession(cachedDailyZenDate)
       .then((session) => {
         if (!cancelled) setCachedDailyZenSession(session);
       })
@@ -400,7 +403,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [authReady, cachedDailyZen]);
+  }, [authReady, cachedDailyZenDate]);
 
   // Mobile browsers freeze backgrounded tabs (bfcache) and resume them with
   // their old in-memory state — yesterday's daily, an outdated JS bundle, etc.
@@ -412,8 +415,8 @@ export function GameProvider({ children }: { children: ReactNode }) {
   // server's build ID against the one we booted with and reload a stale bundle.
   // The reload lives only on those transitions — never on the interval — so a
   // deploy can't reload a page out from under a user sitting on it. Both passes
-  // are suppressed while a timed daily run is live so they can't swap the board
-  // or reload mid-run.
+  // are suppressed while any run is live so they can't swap cached data or
+  // reload mid-play.
   const baselineBuildIdRef = useRef<string | null>(null);
   const gameStatusRef = useRef<GameState | null>(null);
   useEffect(() => {
@@ -438,7 +441,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
   const registerActiveTimedRun = useCallback(() => {
     activeTimedRunsRef.current += 1;
     return () => {
-      activeTimedRunsRef.current -= 1;
+      activeTimedRunsRef.current = Math.max(0, activeTimedRunsRef.current - 1);
     };
   }, []);
 
@@ -450,14 +453,18 @@ export function GameProvider({ children }: { children: ReactNode }) {
       })
       .catch(() => {});
 
+    const isRunActive = () =>
+      timedDailyInProgressRef.current ||
+      gameStatusRef.current === GameState.InProgress ||
+      activeTimedRunsRef.current > 0;
+
     // Benign refetch of the public daily/zen puzzles so the board and landing
     // match today. It only swaps cached data — it never reloads — so it is safe
-    // to run on a timer. Suppressed while a timed daily is live: swapping
-    // cachedDaily re-runs the session-fetch effect and around midnight loads
-    // tomorrow's empty session, so GameRoute sees no active game and bounces the
-    // player home mid-run.
+    // to run on a timer while idle. Suppressed while any run is live: swapping
+    // cached data can cascade through global context consumers and make the game
+    // surface look like it refreshed under the player.
     const refreshDailyCaches = () => {
-      if (timedDailyInProgressRef.current) return;
+      if (isRunActive()) return;
       fetchDaily()
         .then((info) => setCachedDaily(info))
         .catch(() => {});
@@ -468,15 +475,10 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
     const checkFreshness = () => {
       if (document.hidden) return;
-      if (timedDailyInProgressRef.current) return;
+      if (isRunActive()) return;
 
       refreshDailyCaches();
 
-      // Don't reload out from under an in-progress run: free play (tracked
-      // here via game.status) or a route-local timed run such as a gauntlet
-      // round (tracked via the registry). The cache refetch above is harmless
-      // to both, so only the version reload is gated here.
-      if (gameStatusRef.current === GameState.InProgress || activeTimedRunsRef.current > 0) return;
       fetch('/api/version')
         .then((r) => r.json())
         .then((d) => {

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -433,6 +433,16 @@ export function GameProvider({ children }: { children: ReactNode }) {
       !!cachedDailyTimedSession && !cachedDailyTimedSession.ended_at;
   }, [cachedDailyTimedSession]);
 
+  // True while a zen daily run is live. Zen is untimed and lives entirely in
+  // cachedDailyZenSession — it never populates the free-play `game` object or
+  // the timed-daily ref above — so without this it slips past every isRunActive
+  // gate and the refresh keeps swapping cachedDailyZen under the player.
+  const zenInProgressRef = useRef(false);
+  useEffect(() => {
+    zenInProgressRef.current =
+      !!cachedDailyZenSession && !cachedDailyZenSession.ended_at;
+  }, [cachedDailyZenSession]);
+
   // Ref-counted registry for route-local timed runs (gauntlet rounds) that
   // need the reload suppressed but keep their session outside this context.
   // A count (not a boolean) so overlapping registrants — and React's
@@ -455,6 +465,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
     const isRunActive = () =>
       timedDailyInProgressRef.current ||
+      zenInProgressRef.current ||
       gameStatusRef.current === GameState.InProgress ||
       activeTimedRunsRef.current > 0;
 

--- a/client/src/pages/dailyGauntlet/GauntletPlayRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletPlayRoute.tsx
@@ -26,7 +26,7 @@ export function GauntletPlayRoute() {
   const { round } = useParams<{ round: string }>();
   const navigate = useNavigate();
   const roundIndex = Number(round);
-  const { authReady, muted, toggleMute, registerActiveTimedRun } = useGame();
+  const { authReady, muted, toggleMute, registerActiveRun } = useGame();
 
   const [session, setSession] = useState<GauntletRoundSession | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -47,8 +47,8 @@ export function GauntletPlayRoute() {
   const roundLive = !!session && !session.endedAt;
   useEffect(() => {
     if (!roundLive) return;
-    return registerActiveTimedRun();
-  }, [roundLive, registerActiveTimedRun]);
+    return registerActiveRun();
+  }, [roundLive, registerActiveRun]);
 
   // Initial session load. The confirm route should have already called
   // startGauntletRound; if it didn't, the GET returns null and we bounce.

--- a/client/src/pages/dailyZen/ZenGameRoute.tsx
+++ b/client/src/pages/dailyZen/ZenGameRoute.tsx
@@ -43,6 +43,7 @@ export function ZenGameRoute() {
     handleSubmitZenWord,
     lastZenModeChoice,
     setLastZenModeChoice,
+    registerActiveRun,
   } = useGame();
 
   const [showEndConfirm, setShowEndConfirm] = useState(false);
@@ -125,6 +126,18 @@ export function ZenGameRoute() {
   useEffect(() => {
     if (session?.ended_at) navigate('/daily/zen/results', { replace: true });
   }, [session?.ended_at, navigate]);
+
+  // While the zen board is live on screen, keep GameContext's stale-tab
+  // refresh from swapping cachedDailyZen (or reloading on a deploy) under the
+  // player. Gated here, not on the persisted session — an unfinished zen
+  // session sits unended all day, so a session-row guard would wrongly
+  // suppress refresh even after the player leaves the board. Cleanup on
+  // unmount (back to home) clears it. Mirrors the gauntlet round registry.
+  const zenLive = !!session && !session.ended_at;
+  useEffect(() => {
+    if (!zenLive) return;
+    return registerActiveRun();
+  }, [zenLive, registerActiveRun]);
 
   const handleStart = useCallback(async (choice: ZenModeChoice) => {
     if (!cachedDailyZen || starting) return;


### PR DESCRIPTION
## Summary
- skip daily/zen cache refresh and stale-build checks while any play run is active
- cover free play, timed daily, and route-registered timed runs with one guard
- make daily/zen session fetch effects depend on date instead of cache object identity

## Why
The new foreground freshness logic refreshed cached daily/zen data every 90s, and on focus before the free-play/gauntlet guard. That global context churn could make the game surface appear to refresh while someone was playing.

## Verification
- `npm run build --workspace=client`
- `npm test`