### PR TITLE
feat(multiplayer): tap to skip solo free-play countdown, trim timer presets

### DIFF
--- a/client/src/pages/multiplayer/LobbyRules.tsx
+++ b/client/src/pages/multiplayer/LobbyRules.tsx
@@ -25,7 +25,6 @@ const TIMER_OPTIONS: SegOption[] = [
   { value: 60, label: '1:00', sub: 'Sprint' },
   { value: 120, label: '2:00', sub: 'Standard' },
   { value: 180, label: '3:00', sub: 'Chill' },
-  { value: 300, label: '5:00', sub: 'Marathon' },
 ];
 
 const MIN_OPTIONS: SegOption[] = [

--- a/client/src/pages/multiplayer/MultiplayerRoomRoute.tsx
+++ b/client/src/pages/multiplayer/MultiplayerRoomRoute.tsx
@@ -70,6 +70,7 @@ export function MultiplayerRoomRoute() {
     updateNextConfig,
     setVisibility,
     startBoard,
+    advanceCountdown,
     endBoardForRoom: _endBoardForRoom,
     returnToLobby,
     submitWord,
@@ -184,6 +185,7 @@ export function MultiplayerRoomRoute() {
           youId={youId}
           onSubmitWord={submitWord}
           onFinishMyBoard={finishMyBoard}
+          onAdvanceCountdown={advanceCountdown}
           onLeave={handleLeave}
         />
       </>

--- a/client/src/pages/multiplayer/RoomPlay.tsx
+++ b/client/src/pages/multiplayer/RoomPlay.tsx
@@ -14,6 +14,9 @@ interface RoomPlayProps {
   youId: string | null;
   onSubmitWord: (path: Position[]) => Promise<WordSubmitResult>;
   onFinishMyBoard: () => void;
+  /** Fast-forward the pre-board countdown a step. Solo-only on the server, so
+   *  the tap target is only shown when the local player is alone in the room. */
+  onAdvanceCountdown: () => void;
   /** Exit the room entirely, mid-round, back to the main menu. */
   onLeave: () => void;
 }
@@ -23,7 +26,14 @@ interface RoomPlayProps {
 // without a leaderboard distraction. A shared "get ready" countdown plays
 // before the board goes live, and a Leave control is always available so a
 // player can bail out mid-round.
-export function RoomPlay({ room, youId, onSubmitWord, onFinishMyBoard, onLeave }: RoomPlayProps) {
+export function RoomPlay({
+  room,
+  youId,
+  onSubmitWord,
+  onFinishMyBoard,
+  onAdvanceCountdown,
+  onLeave,
+}: RoomPlayProps) {
   const { muted, toggleMute } = useGame();
   const board = room.currentBoard;
   const me = useMemo(() => room.players.find((p) => p.id === youId) ?? null, [room, youId]);
@@ -148,6 +158,11 @@ export function RoomPlay({ room, youId, onSubmitWord, onFinishMyBoard, onLeave }
 
   const isSpectating = me.status !== 'playing';
   const countdownNum = Math.max(0, Math.ceil((board.startedAt - now) / 1000));
+  // Only a solo player (alone in the room, so also the host) may cut their own
+  // countdown short — the server enforces the same, this just hides the tap
+  // target when others are present and a shared countdown isn't ours to rush.
+  const canAdvanceCountdown =
+    room.players.filter((p) => p.connected).length <= 1 && room.hostId === youId;
   const spectatorSecondsLeft =
     board.config.durationSeconds <= 0
       ? -1
@@ -164,7 +179,11 @@ export function RoomPlay({ room, youId, onSubmitWord, onFinishMyBoard, onLeave }
         </div>
 
         {counting ? (
-          <CountdownView size={board.board.length} count={countdownNum} />
+          <CountdownView
+            size={board.board.length}
+            count={countdownNum}
+            onAdvance={canAdvanceCountdown ? onAdvanceCountdown : undefined}
+          />
         ) : isSpectating ? (
           <SpectatorView board={board.board} secondsLeft={spectatorSecondsLeft} />
         ) : (
@@ -210,7 +229,17 @@ function LeaveButton({ onClick }: { onClick: () => void }) {
 // where the real one will appear and nothing jumps when play begins. The
 // tiles are intentionally blank — a letter preview would let players scout
 // the board before the clock starts.
-function CountdownView({ size, count }: { size: number; count: number }) {
+function CountdownView({
+  size,
+  count,
+  onAdvance,
+}: {
+  size: number;
+  count: number;
+  /** When set (solo player), the board area becomes a tap target that pulls
+   *  the countdown forward a step, so the round can start sooner. */
+  onAdvance?: () => void;
+}) {
   return (
     <div
       className="w-full max-w-[500px] mx-auto flex flex-col items-center"
@@ -247,8 +276,25 @@ function CountdownView({ size, count }: { size: number; count: number }) {
             >
               {count > 0 ? count : 'Go!'}
             </div>
+            {onAdvance && count > 0 && (
+              <div
+                className="text-caption text-[color:var(--ink-muted)] font-[family-name:var(--font-structure)]"
+                style={{ fontWeight: 600 }}
+              >
+                Tap to start sooner
+              </div>
+            )}
           </div>
         </div>
+        {onAdvance && count > 0 && (
+          <button
+            type="button"
+            onClick={onAdvance}
+            aria-label="Start sooner"
+            className="absolute inset-0 bg-transparent border-0 cursor-pointer"
+            style={{ WebkitTapHighlightColor: 'transparent' }}
+          />
+        )}
       </div>
     </div>
   );

--- a/client/src/shared/multiplayer/useMultiplayerRoom.ts
+++ b/client/src/shared/multiplayer/useMultiplayerRoom.ts
@@ -40,6 +40,9 @@ export interface UseMultiplayerRoomResult {
   setVisibility: (visibility: RoomVisibility) => void;
   /** Host-only: start the next board with the current `nextConfig`. */
   startBoard: () => void;
+  /** Solo only: fast-forward the pre-board countdown one step so play starts
+   *  sooner. No-ops server-side once a second player is connected. */
+  advanceCountdown: () => void;
   /** Host-only: forcibly end the active board (skips remaining time). */
   endBoardForRoom: () => void;
   /** Host-only: return the room to lobby state from results. */
@@ -149,6 +152,9 @@ export function useMultiplayerRoom({
   const startBoard = useCallback(() => {
     socketRef.current?.emit('board:start');
   }, []);
+  const advanceCountdown = useCallback(() => {
+    socketRef.current?.emit('board:advance-countdown');
+  }, []);
   const endBoardForRoom = useCallback(() => {
     socketRef.current?.emit('board:end');
   }, []);
@@ -195,6 +201,7 @@ export function useMultiplayerRoom({
     updateNextConfig,
     setVisibility,
     startBoard,
+    advanceCountdown,
     endBoardForRoom,
     returnToLobby,
     submitWord,

--- a/server/multiplayer/sockets.ts
+++ b/server/multiplayer/sockets.ts
@@ -17,6 +17,7 @@ import type {
 } from 'models/multiplayer';
 import type { GameConfig, Position } from 'models';
 import {
+  advanceCountdown,
   disconnectPlayer,
   endBoard,
   getRoom,
@@ -160,6 +161,14 @@ export function attachMultiplayerSockets(io: Server): void {
       if (!room || room.hostId !== data.playerId) return;
       const started = startBoard(data.roomCode, () => emitState(io, data.roomCode));
       if (started) emitState(io, data.roomCode);
+    });
+
+    socket.on('board:advance-countdown', () => {
+      const data = socket.data as SocketData;
+      const advanced = advanceCountdown(data.roomCode, data.playerId, () =>
+        emitState(io, data.roomCode),
+      );
+      if (advanced) emitState(io, data.roomCode);
     });
 
     socket.on(

--- a/server/multiplayer/store.ts
+++ b/server/multiplayer/store.ts
@@ -29,7 +29,7 @@ const ROOM_CODE_LENGTH = 5;
 const ROOM_TTL_MS = 6 * 60 * 60 * 1000; // 6h after last activity → purged
 
 const DEFAULT_CONFIG: GameConfig = {
-  durationSeconds: 180,
+  durationSeconds: 60,
   boardSize: 4,
   minWordLength: 3,
 };
@@ -40,6 +40,10 @@ const GRACE_PERIOD_MS = 500;
 // a live board with no warning. The play window (duration) begins at
 // startedAt, so the countdown doesn't eat into anyone's time.
 const COUNTDOWN_MS = 3000;
+// A solo player can fast-forward their own pre-board countdown a step at a
+// time (tap to start sooner); each advance pulls the start — and the matching
+// auto-end — this much earlier.
+const COUNTDOWN_STEP_MS = 1000;
 
 /** Clamp untrusted config to supported bounds. Kept loose — the lobby UI
  *  surfaces the same presets as solo free-play — but it's the single
@@ -618,6 +622,47 @@ export function startBoard(
 
   touch(entry);
   return { room, board };
+}
+
+/** Pull the pre-board countdown earlier by one step so a solo player can start
+ *  their own round sooner. Solo-only: rushing a shared countdown isn't one
+ *  player's call, so this no-ops the moment a second player is connected. The
+ *  auto-end timer is re-pinned to the new start, keeping the play window equal
+ *  to the configured duration. Returns the room when it advanced, else null. */
+export function advanceCountdown(
+  code: string,
+  playerId: string,
+  onAutoEnd: (room: MultiplayerRoom) => void,
+): MultiplayerRoom | null {
+  const entry = getEntry(code);
+  if (!entry) return null;
+  const room = entry.room;
+  const board = room.currentBoard;
+  if (room.status !== 'playing' || !board) return null;
+  if (room.hostId !== playerId) return null;
+  // Solo only — a second connected player means the countdown is shared and no
+  // single player gets to cut it short.
+  if (room.players.filter((p) => p.connected).length > 1) return null;
+  const now = Date.now();
+  if (now >= board.startedAt) return null; // countdown already elapsed
+
+  // Clamp so play never starts in the past.
+  board.startedAt = Math.max(now, board.startedAt - COUNTDOWN_STEP_MS);
+
+  // Re-pin the auto-end to the new start so the play window is unchanged.
+  if (entry.boardTimer) clearTimeout(entry.boardTimer);
+  entry.boardTimer = null;
+  if (board.config.durationSeconds > 0) {
+    const endAt = board.startedAt + board.config.durationSeconds * 1000;
+    entry.boardTimer = setTimeout(() => {
+      endBoard(code);
+      const fresh = getEntry(code);
+      if (fresh) onAutoEnd(fresh.room);
+    }, Math.max(0, endAt - now));
+  }
+
+  touch(entry);
+  return room;
 }
 
 export function endBoard(code: string): MultiplayerRoom | null {


### PR DESCRIPTION
**What** — A solo free-play player can now tap the "get ready" countdown to start sooner; each tap pulls the board start (and its matching auto-end) one second earlier. Also removes the 5:00 timer preset and defaults new rooms to 4×4 / 1:00 / 3-letter minimum.

**Why** — The countdown is server-authoritative (`board.startedAt`), so advancing it there keeps every client consistent and lets the solo-only rule be enforced server-side — the moment a second player connects, the shared countdown is no one player's to rush. One second per tap matches "go a little faster sometimes," and the auto-end timer is re-pinned to the new start so the play window stays the configured duration.

**Follow-ups** — None; verified in the running app (tapping drops the countdown 3→2→1 and starts the board at ~349ms vs ~3096ms baseline) and `tsc` passes in both workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)