### PR TITLE
fix(multiplayer): record all co-players in free-play history

### DIFF
--- a/server/multiplayer/store.persistence.test.ts
+++ b/server/multiplayer/store.persistence.test.ts
@@ -4,6 +4,7 @@ import {
   endBoard,
   getRoom,
   joinRoom,
+  leaveRoom,
   setBoardCompletionHandler,
   startBoard,
   type RoomBoardCompletion,
@@ -98,5 +99,33 @@ describe('room board history persistence', () => {
     vi.advanceTimersByTime(1000);
     vi.advanceTimersByTime(1000);
     expect(completions).toHaveLength(1);
+  });
+
+  it('attributes the round to the starting host even if the host leaves during the grace window', () => {
+    const { code } = createRoom();
+    joinRoom(code, 'key-1', 'Alice', 'user-1'); // first joiner becomes host
+    joinRoom(code, 'key-2', 'Bob', 'user-2');
+    startBoard(code, () => {});
+
+    const room = getRoom(code)!;
+    for (const p of room.players) {
+      p.foundWords = ['HELLO'];
+      p.points = 1;
+      p.wordCount = 1;
+    }
+    const originalHostId = room.hostId;
+
+    endBoard(code);
+
+    // The host leaves before the deferred write flushes; the store promotes a
+    // successor. The persisted attribution must still point at the host that
+    // ran the round, not the replacement.
+    leaveRoom(code, originalHostId);
+    expect(getRoom(code)!.hostId).not.toBe(originalHostId);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].hostUserId).toBe('user-1');
   });
 });

--- a/server/multiplayer/store.ts
+++ b/server/multiplayer/store.ts
@@ -121,6 +121,12 @@ interface RoomEntry {
    *  calls this before it resets per-player state so a fast next round can't
    *  wipe an unpersisted board; null when no write is pending. */
   flushPersistence: (() => void) | null;
+  /** Authenticated user id of the host that started the current board, captured
+   *  at start so the deferred history write attributes the round to whoever ran
+   *  it — not to a successor promoted during the post-end grace window (or by
+   *  the very departure that ended the round). Null when the host wasn't
+   *  authenticated. */
+  currentBoardHostUserId: string | null;
 }
 
 const rooms = new Map<string, RoomEntry>();
@@ -142,6 +148,12 @@ export interface RoomBoardCompletion {
   config: GameConfig;
   startedAt: number;
   endedAt: number;
+  /** Authenticated user id of the host that started this board, when the host
+   *  was signed in. The persistence layer makes this player the
+   *  originator/owner of the linked challenge, so a shared multiplayer board
+   *  attributes to whoever ran the round rather than an arbitrary row. Null
+   *  when the host wasn't authenticated. */
+  hostUserId: string | null;
   participants: Array<{
     userId: string;
     foundWords: string[];
@@ -210,6 +222,7 @@ function buildCompletion(entry: RoomEntry, board: MultiplayerBoard): RoomBoardCo
     config: board.config,
     startedAt: board.startedAt,
     endedAt: board.endedAt!,
+    hostUserId: entry.currentBoardHostUserId,
     participants,
   };
 }
@@ -294,6 +307,7 @@ export function createRoom(options: CreateRoomOptions = {}): MultiplayerRoom {
     lastPersistence: null,
     persistTimer: null,
     flushPersistence: null,
+    currentBoardHostUserId: null,
   });
   return room;
 }
@@ -593,6 +607,11 @@ export function startBoard(
   };
   room.currentBoard = board;
   room.status = 'playing';
+  // Capture the round's host now (the prior board's pending write already
+  // flushed above, so this can't clobber it). Reading it at the deferred write
+  // instead would misattribute the shared challenge to a successor promoted by
+  // host transfer during the grace window.
+  entry.currentBoardHostUserId = entry.userIds.get(room.hostId) ?? null;
 
   // Players who left during the previous round are gone for good — drop
   // them now that we're starting a fresh board so they don't carry into

--- a/server/services/FreePlayService.roomHistory.test.ts
+++ b/server/services/FreePlayService.roomHistory.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { Kysely } from 'kysely';
+import { persistRoomBoardResults } from './FreePlayService.js';
+import type { Database } from '../db/types.js';
+import type { RoomBoardCompletion } from '../multiplayer/store.js';
+
+// persistRoomBoardResults writes one free_play_sessions row per authenticated
+// participant. The behaviour under test is the linkage: a multiplayer board
+// must stamp every participant's row with one shared challenge_id (so each
+// player's history surfaces the others), and that challenge_id must be the
+// host's own row id — the self-referential originator model the rest of the
+// system keys owner/attribution off. A solo board stays unlinked like an
+// ordinary solo free-play session.
+
+type InsertedRow = {
+  id: string;
+  user_id: string;
+  challenge_id: string | null;
+  points: number;
+};
+
+// Minimal Kysely stand-in: captures the rows handed to .values(...). Only the
+// insertInto → values → execute chain persistRoomBoardResults uses is modelled.
+function fakeDb(): { db: Kysely<Database>; inserted: () => InsertedRow[] } {
+  let captured: InsertedRow[] = [];
+  const db = {
+    insertInto: () => ({
+      values: (rows: InsertedRow[]) => {
+        captured = rows;
+        return { execute: async () => {} };
+      },
+    }),
+  } as unknown as Kysely<Database>;
+  return { db, inserted: () => captured };
+}
+
+function completion(
+  userIds: string[],
+  hostUserId: string | null = userIds[0] ?? null,
+): RoomBoardCompletion {
+  return {
+    seed: 42,
+    board: [['A', 'B'], ['C', 'D']],
+    config: { durationSeconds: 60, boardSize: 2, minWordLength: 3 },
+    startedAt: 1_000,
+    endedAt: 61_000,
+    hostUserId,
+    participants: userIds.map((userId) => ({
+      userId,
+      foundWords: ['CAB'],
+      points: 1,
+      wordCount: 1,
+      longestWord: 'CAB',
+    })),
+  };
+}
+
+describe('persistRoomBoardResults', () => {
+  it('links every participant of a multiplayer board under one shared challenge_id', async () => {
+    const { db, inserted } = fakeDb();
+    await persistRoomBoardResults(db, completion(['user-1', 'user-2', 'user-3'], 'user-2'));
+
+    const rows = inserted();
+    expect(rows).toHaveLength(3);
+    const challengeIds = new Set(rows.map((r) => r.challenge_id));
+    expect(challengeIds.size).toBe(1);
+    const [shared] = challengeIds;
+    expect(shared).not.toBeNull();
+    // The challenge id is a real participant row's id — exactly one row is
+    // self-referential (id === challenge_id), and it's the host's row.
+    const ownerRows = rows.filter((r) => r.id === shared);
+    expect(ownerRows).toHaveLength(1);
+    expect(ownerRows[0].user_id).toBe('user-2');
+  });
+
+  it('falls back to the first participant as owner when the host was not authenticated', async () => {
+    const { db, inserted } = fakeDb();
+    await persistRoomBoardResults(db, completion(['user-1', 'user-2'], null));
+
+    const rows = inserted();
+    const [shared] = new Set(rows.map((r) => r.challenge_id));
+    const owner = rows.find((r) => r.id === shared);
+    expect(owner?.user_id).toBe('user-1');
+  });
+
+  it('collapses a duplicated signed-in player to one row per user (their best showing)', async () => {
+    const { db, inserted } = fakeDb();
+    // user-1 occupies two slots (two devices). The (user_id, challenge_id)
+    // unique index would reject the batch if both rows kept the shared id.
+    await persistRoomBoardResults(db, {
+      seed: 42,
+      board: [['A', 'B'], ['C', 'D']],
+      config: { durationSeconds: 60, boardSize: 2, minWordLength: 3 },
+      startedAt: 1_000,
+      endedAt: 61_000,
+      hostUserId: 'user-1',
+      participants: [
+        { userId: 'user-1', foundWords: ['CA'], points: 2, wordCount: 1, longestWord: 'CA' },
+        { userId: 'user-1', foundWords: ['CAB', 'DAB'], points: 5, wordCount: 2, longestWord: 'CAB' },
+        { userId: 'user-2', foundWords: ['DAB'], points: 3, wordCount: 1, longestWord: 'DAB' },
+      ],
+    });
+
+    const rows = inserted();
+    expect(rows).toHaveLength(2);
+    const userOneRows = rows.filter((r) => r.user_id === 'user-1');
+    expect(userOneRows).toHaveLength(1);
+    expect(userOneRows[0].points).toBe(5); // best of the two slots kept
+    // Still one linked challenge, owned by the host's surviving row.
+    const [shared] = new Set(rows.map((r) => r.challenge_id));
+    expect(shared).not.toBeNull();
+    expect(rows.find((r) => r.id === shared)?.user_id).toBe('user-1');
+  });
+
+  it('leaves a solo board unlinked so it behaves like a solo free-play session', async () => {
+    const { db, inserted } = fakeDb();
+    await persistRoomBoardResults(db, completion(['user-1']));
+
+    const rows = inserted();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].challenge_id).toBeNull();
+  });
+
+  it('writes nothing when no participant could be authenticated', async () => {
+    const { db, inserted } = fakeDb();
+    await persistRoomBoardResults(db, completion([]));
+    expect(inserted()).toHaveLength(0);
+  });
+});

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -458,8 +458,22 @@ export function buildFreePlayResults(session: FreePlaySession): {
 // config, and seed are all carried on the board.
 
 /** Persist a finished multiplayer board as one completed session row per
- *  authenticated participant. challenge_id stays null — sharing promotes a
- *  row to a challenge later, the same way solo free-play does. */
+ *  authenticated participant.
+ *
+ *  When two or more players played the board, every participant's row is
+ *  stamped with one shared challenge_id so they're linked as a single game:
+ *  the history endpoint then reports the real player count, ranks the field,
+ *  and routes each player into the standings view where they see everyone who
+ *  played — without this, each co-player only ever saw their own solo row.
+ *  The challenge id is the host's own row id, reusing the same self-referential
+ *  originator model as solo free-play: the host owns the board they set up, so
+ *  sharing it attributes to them and "new results" badges land on their row
+ *  when async recipients later play. If the host wasn't an authenticated
+ *  participant we fall back to the first participant so an owner row always
+ *  exists (the challenge endpoints key board/config and attribution off it).
+ *
+ *  A solo board keeps challenge_id null so it behaves exactly like a solo
+ *  free-play session — promotable to a self-referential challenge on share. */
 export async function persistRoomBoardResults(
   db: Kysely<Database>,
   completion: RoomBoardCompletion,
@@ -470,11 +484,41 @@ export async function persistRoomBoardResults(
   const date = getDailyDatePST(completedAt);
   const boardJson = JSON.stringify(completion.board);
 
+  // One signed-in account can hold two player slots (two devices / windows
+  // with distinct reconnect keys). Collapse to a single row per user — their
+  // best showing — so the shared challenge_id can't hit two rows for the same
+  // user and trip the (user_id, challenge_id) unique index, which would reject
+  // the whole batch and lose everyone's results.
+  const byUser = new Map<string, RoomBoardCompletion['participants'][number]>();
+  for (const p of completion.participants) {
+    const prev = byUser.get(p.userId);
+    if (
+      !prev ||
+      p.points > prev.points ||
+      (p.points === prev.points && p.wordCount > prev.wordCount)
+    ) {
+      byUser.set(p.userId, p);
+    }
+  }
+  const participants = [...byUser.values()];
+
+  // Mint row ids up front so a multiplayer board can point every row's
+  // challenge_id at the owner's row — making that row self-referential
+  // (id === challenge_id), exactly like a shared solo session's originator.
+  const rowIds = participants.map(() => crypto.randomUUID());
+  let challengeId: string | null = null;
+  if (participants.length > 1) {
+    const hostIdx = completion.hostUserId
+      ? participants.findIndex((p) => p.userId === completion.hostUserId)
+      : -1;
+    challengeId = rowIds[hostIdx >= 0 ? hostIdx : 0];
+  }
+
   await db
     .insertInto('free_play_sessions')
     .values(
-      completion.participants.map((p) => ({
-        id: crypto.randomUUID(),
+      participants.map((p, i) => ({
+        id: rowIds[i],
         user_id: p.userId,
         date,
         board: boardJson,
@@ -487,7 +531,7 @@ export async function persistRoomBoardResults(
         time_limit: completion.config.durationSeconds,
         board_size: completion.config.boardSize,
         min_word_length: completion.config.minWordLength,
-        challenge_id: null,
+        challenge_id: challengeId,
         seed: completion.seed,
       })),
     )


### PR DESCRIPTION
**What:** Link every authenticated participant of a finished multiplayer room board under one shared `challenge_id` so each player's free-play history surfaces the whole field — real player count, ranks, and the standings view — instead of showing only their own row as a solo game.

**Why:** Co-players' rows were written with `challenge_id: null`, and the history/standings machinery keys entirely off a shared `challenge_id`, so nobody could see who else played. The challenge is owned by the host that started the round, reusing the existing self-referential originator model (`id === challenge_id`) so the board is attributable on share and "new results" badges land correctly; the host id is captured at board start so a grace-window host transfer can't misattribute it, and falls back to the first participant when the host wasn't signed in. The same account occupying two slots (two devices) is collapsed to one best-scoring row so it can't trip the `(user_id, challenge_id)` unique index and fail the whole batch insert. New unit/store tests cover the linkage, host-as-owner with fallback, duplicate-player dedupe, solo non-linkage, and grace-window host departure.

**Follow-ups:** Unauthenticated guests still don't get history rows (no `user_id` to write against), so a guest who played live won't appear in anyone's standings — pre-existing and unchanged here.