### PR TITLE
fix(gauntlet): register ties in per-round ranks

### DIFF
--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -379,8 +379,11 @@ export interface RankedRow {
 }
 
 // Per-round ranks across all finalized rows on the date. Used to render
-// per-round leaderboards and to feed the aggregate. Tiebreak mirrors
-// timed daily: points desc, word_count desc, completed_at asc.
+// per-round leaderboards and to feed the aggregate. Ranked on points
+// alone so equal points share a place (1, 1, 3), matching timed daily
+// and the canonical competition-rank rule in ranking.ts: a tie is an
+// equal score, full stop — never broken by word count or finish time.
+// The aggregate applies its own tiebreaks for final standings.
 export async function getGauntletRoundRanks(
   db: Kysely<Database>,
   date: string,
@@ -396,7 +399,7 @@ export async function getGauntletRoundRanks(
           'points',
           'word_count',
           'completed_at',
-          sql<number>`rank() over (partition by ${eb.ref('round_index')} order by ${eb.ref('points')} desc, ${eb.ref('word_count')} desc, ${eb.ref('completed_at')} asc)`.as('rank'),
+          sql<number>`rank() over (partition by ${eb.ref('round_index')} order by ${eb.ref('points')} desc)`.as('rank'),
         ])
         .where('date', '=', date)
         .where('ended_at', 'is not', null),


### PR DESCRIPTION
**What** — Daily gauntlet per-round ranks now rank on points alone, so players with equal points share a rank (1, 1, 3) instead of being split apart.

**Why** — The per-round `rank()` SQL broke ties with secondary keys (`word_count desc, completed_at asc`), contradicting the canonical rule in `ranking.ts` and timed daily, where a tie is an equal score, full stop. The shared per-round ranks now flow into the aggregate rank sum, letting true ties register, while the aggregate keeps its own deliberate tiebreakers (rank sum → best single round → earliest finish) for final standings. Ranks are computed live per request, so past gauntlet days display correctly too — no backfill needed.

**Follow-ups** — None. Existing aggregation unit tests pass unchanged; the SQL ranking has no DB-backed test harness in this workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)