### PR TITLE
fix(multiplayer): anchor countdown and timers to a synced server clock

### DIFF
--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -20,6 +20,14 @@ export const useTimer = (
   // started. Set once per in-progress game so an NTP resync mid-round can't
   // spike elapsed time and shrink the displayed clock.
   const localStartRef = useRef<number | null>(null);
+  // The startedAt this anchor was computed against. In multiplayer it can
+  // shift once shortly after mount, when the device→server clock offset
+  // finishes calibrating; re-anchoring on that change keeps a client that
+  // reached play before the first sync (e.g. a mid-round reconnect on a
+  // skewed clock) from holding a wrong elapsed value for the rest of the
+  // board. It only changes on a deliberate schedule correction, never per
+  // tick, so the NTP-jump protection above is preserved.
+  const anchoredStartedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (game && game.status === GameState.InProgress) {
@@ -29,17 +37,19 @@ export const useTimer = (
         return;
       }
 
-      // Anchor the countdown the first time we see this game in progress.
-      // A multiplayer reconnect passes an explicit initialElapsedMs; everyone
+      // Anchor the countdown the first time we see this game in progress (and
+      // re-anchor if startedAt is later corrected by clock sync). A
+      // multiplayer reconnect passes an explicit initialElapsedMs; everyone
       // else derives it from the server's startedAt so a page refresh resumes
-      // the existing countdown instead of restarting it. After this one-time
-      // read of the wall clock, all subsequent ticks use performance.now()
+      // the existing countdown instead of restarting it. After this read of
+      // the wall clock, all subsequent ticks use performance.now()
       // (monotonic), so an NTP resync mid-round (e.g. on Android) can't spike
       // elapsed time and shrink the displayed clock.
-      if (localStartRef.current === null) {
+      if (localStartRef.current === null || anchoredStartedAtRef.current !== game.startedAt) {
         const elapsedMs =
           initialElapsedMs > 0 ? initialElapsedMs : Math.max(0, Date.now() - game.startedAt);
         localStartRef.current = performance.now() - elapsedMs;
+        anchoredStartedAtRef.current = game.startedAt;
       }
       const localStart = localStartRef.current;
 
@@ -63,6 +73,7 @@ export const useTimer = (
     } else {
       // Reset local start when game is not in progress
       localStartRef.current = null;
+      anchoredStartedAtRef.current = null;
       setTimeRemaining(0);
     }
   }, [game, onTimeExpired]);

--- a/client/src/pages/game/components/TimerBar.tsx
+++ b/client/src/pages/game/components/TimerBar.tsx
@@ -9,10 +9,15 @@ export const TimerBar = ({ game }: TimerBarProps) => {
   const [remainingPercentage, setRemainingPercentage] = useState(100);
   // Anchor the local start time against the server-issued game.startedAt
   // so a refresh mid-play picks up where the bar was, instead of snapping
-  // back to 100%. The one-time wall-clock read mirrors useTimer's
-  // approach — subsequent ticks stay on performance.now() (monotonic) to
-  // avoid jumps from NTP sync on Android.
+  // back to 100%. The wall-clock read mirrors useTimer's approach —
+  // subsequent ticks stay on performance.now() (monotonic) to avoid jumps
+  // from NTP sync on Android.
   const localStartRef = useRef<number | null>(null);
+  // The startedAt this anchor was computed against. Re-anchor if it shifts —
+  // in multiplayer it can move once after mount when the device→server clock
+  // offset finishes calibrating, so a client that reached play before the
+  // first sync doesn't keep a skewed bar position. Mirrors useTimer.
+  const anchoredStartedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (game.config.durationSeconds <= 0) {
@@ -20,9 +25,10 @@ export const TimerBar = ({ game }: TimerBarProps) => {
       return;
     }
 
-    if (localStartRef.current === null) {
+    if (localStartRef.current === null || anchoredStartedAtRef.current !== game.startedAt) {
       const serverElapsedMs = Math.max(0, Date.now() - game.startedAt);
       localStartRef.current = performance.now() - serverElapsedMs;
+      anchoredStartedAtRef.current = game.startedAt;
     }
     const localStart = localStartRef.current;
 

--- a/client/src/pages/multiplayer/MultiplayerRoomRoute.tsx
+++ b/client/src/pages/multiplayer/MultiplayerRoomRoute.tsx
@@ -78,6 +78,7 @@ export function MultiplayerRoomRoute() {
     leaveRoom,
     nudgeHost,
     nudge,
+    clockOffsetMs,
   } = useMultiplayerRoom({
     roomCode: code,
     accessToken: session?.access_token,
@@ -183,6 +184,7 @@ export function MultiplayerRoomRoute() {
         <RoomPlay
           room={room}
           youId={youId}
+          clockOffsetMs={clockOffsetMs}
           onSubmitWord={submitWord}
           onFinishMyBoard={finishMyBoard}
           onAdvanceCountdown={advanceCountdown}

--- a/client/src/pages/multiplayer/RoomPlay.tsx
+++ b/client/src/pages/multiplayer/RoomPlay.tsx
@@ -12,6 +12,11 @@ import { LobbyPlayerStrip } from './LobbyPlayerStrip';
 interface RoomPlayProps {
   room: MultiplayerRoom;
   youId: string | null;
+  /** Estimated `serverClock − deviceClock`, in ms (see useMultiplayerRoom).
+   *  `board.startedAt` is stamped on the server clock; subtracting this offset
+   *  rebases it into the device's clock so countdown/timer math against
+   *  `Date.now()` is right even when the device clock is wrong. */
+  clockOffsetMs: number;
   onSubmitWord: (path: Position[]) => Promise<WordSubmitResult>;
   onFinishMyBoard: () => void;
   /** Fast-forward the pre-board countdown a step. Solo-only on the server, so
@@ -29,6 +34,7 @@ interface RoomPlayProps {
 export function RoomPlay({
   room,
   youId,
+  clockOffsetMs,
   onSubmitWord,
   onFinishMyBoard,
   onAdvanceCountdown,
@@ -36,6 +42,11 @@ export function RoomPlay({
 }: RoomPlayProps) {
   const { muted, toggleMute } = useGame();
   const board = room.currentBoard;
+  // The board's start instant rebased onto this device's clock, so every
+  // comparison below (and the play timer inside GamePage) can use the raw
+  // local `Date.now()` and still agree with the server's schedule even if the
+  // device clock is off. Null when there's no board yet.
+  const startedAtLocal = board ? board.startedAt - clockOffsetMs : 0;
   const me = useMemo(() => room.players.find((p) => p.id === youId) ?? null, [room, youId]);
   const [feedback, setFeedback] = useState<
     { type: FeedbackType; path: Position[]; bonus?: string | null } | null
@@ -107,7 +118,7 @@ export function RoomPlay({
 
   // True during the shared pre-board countdown. While counting the board
   // isn't InProgress yet, so neither timer in GamePage runs early.
-  const counting = !!board && me?.status === 'playing' && now < board.startedAt;
+  const counting = !!board && me?.status === 'playing' && now < startedAtLocal;
 
   // Run the wall-clock ticker only while it feeds a visible readout: the
   // countdown, or the spectator "time left" panel once the player is done.
@@ -124,7 +135,7 @@ export function RoomPlay({
     const live = !ended && !counting;
     return {
       board: board.board,
-      startedAt: board.startedAt,
+      startedAt: startedAtLocal,
       status: live ? GameState.InProgress : GameState.Finished,
       config: {
         durationSeconds: board.config.durationSeconds,
@@ -132,7 +143,7 @@ export function RoomPlay({
         minWordLength: board.config.minWordLength,
       },
     };
-  }, [board, me?.status, counting]);
+  }, [board, me?.status, counting, startedAtLocal]);
 
   const finishedRef = useRef(false);
   const onTimerExpire = useCallback(() => {
@@ -146,18 +157,18 @@ export function RoomPlay({
   }, [board?.startedAt]);
 
   // A player who reconnects mid-round sees the game flip to InProgress with a
-  // startedAt already in the past; hand the timer that elapsed time so it
-  // resumes the shared clock instead of restarting from full. For a player
-  // present from the countdown this is ~0. board.startedAt is the server's
-  // schedule — consistent with the countdown/spectator readouts above, which
-  // already compare it against the local clock.
-  const initialElapsedMs = board ? Math.max(0, Date.now() - board.startedAt) : 0;
+  // start already in the past; hand the timer that elapsed time so it resumes
+  // the shared clock instead of restarting from full. For a player present
+  // from the countdown this is ~0. startedAtLocal is the server's schedule
+  // rebased onto this device's clock — consistent with the countdown/spectator
+  // readouts above, which compare the same value against the local clock.
+  const initialElapsedMs = board ? Math.max(0, Date.now() - startedAtLocal) : 0;
   const timeRemaining = useTimer(game, onTimerExpire, initialElapsedMs);
 
   if (!board || !game || !me) return null;
 
   const isSpectating = me.status !== 'playing';
-  const countdownNum = Math.max(0, Math.ceil((board.startedAt - now) / 1000));
+  const countdownNum = Math.max(0, Math.ceil((startedAtLocal - now) / 1000));
   // Only a solo player (alone in the room, so also the host) may cut their own
   // countdown short — the server enforces the same, this just hides the tap
   // target when others are present and a shared countdown isn't ours to rush.
@@ -166,7 +177,7 @@ export function RoomPlay({
   const spectatorSecondsLeft =
     board.config.durationSeconds <= 0
       ? -1
-      : Math.max(0, Math.ceil((board.startedAt + board.config.durationSeconds * 1000 - now) / 1000));
+      : Math.max(0, Math.ceil((startedAtLocal + board.config.durationSeconds * 1000 - now) / 1000));
 
   return (
     <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">

--- a/client/src/shared/multiplayer/useMultiplayerRoom.ts
+++ b/client/src/shared/multiplayer/useMultiplayerRoom.ts
@@ -60,6 +60,11 @@ export interface UseMultiplayerRoomResult {
   /** Latest incoming nudge (host only) — `{ from, at }`, bumped each time
    *  someone nudges so the UI can surface a toast. Null until first nudge. */
   nudge: { from: string; at: number } | null;
+  /** Estimated `serverClock − deviceClock`, in ms. Add to `Date.now()` to get
+   *  the server's wall time. Lets timing (the pre-board countdown, the play
+   *  deadline) compare against the shared clock so a wrong device clock can't
+   *  distort it. 0 until the first sync round-trip completes. */
+  clockOffsetMs: number;
 }
 
 interface UseMultiplayerRoomOptions {
@@ -81,6 +86,13 @@ export function useMultiplayerRoom({
   const [status, setStatus] = useState<ConnectionStatus>('connecting');
   const [errorReason, setErrorReason] = useState<string | null>(null);
   const [nudge, setNudge] = useState<{ from: string; at: number } | null>(null);
+  const [clockOffsetMs, setClockOffsetMs] = useState(0);
+  // True once a time:sync probe has produced a measurement. Until then the
+  // room snapshot's `serverNow` seeds a coarse offset (so the countdown is
+  // right from the first snapshot, before any probe lands); after, the probes
+  // — which correct for round-trip latency — are authoritative and snapshots
+  // stop touching the offset.
+  const syncedByProbeRef = useRef(false);
   const socketRef = useRef<Socket | null>(null);
   const playerKeyRef = useRef<string>('');
 
@@ -96,6 +108,7 @@ export function useMultiplayerRoom({
     // the connect lets the transient mount cancel before any socket is
     // opened, so only one connection is ever made.
     let socket: Socket | null = null;
+    let cancelled = false;
     setStatus('connecting');
     setErrorReason(null);
 
@@ -111,7 +124,43 @@ export function useMultiplayerRoom({
       });
       socketRef.current = socket;
 
-      socket.on('connect', () => setStatus('connected'));
+      // Estimate the device→server clock offset with a short burst of timed
+      // round-trips (NTP-style: keep the sample with the lowest round-trip
+      // time, since that one has the least one-way asymmetry). Runs on every
+      // connect — a reconnect re-measures — and settles within ~1s, well
+      // before the host can start a board.
+      const syncClock = () => {
+        if (cancelled || !socket) return;
+        let bestRtt = Infinity;
+        let probes = 0;
+        const sample = () => {
+          if (cancelled || !socket || probes >= 3) return;
+          probes += 1;
+          const t0 = Date.now();
+          socket.timeout(3000).emit('time:sync', (err: Error | null, serverTime?: number) => {
+            if (cancelled) return;
+            if (!err && typeof serverTime === 'number') {
+              const t1 = Date.now();
+              const rtt = t1 - t0;
+              syncedByProbeRef.current = true;
+              if (rtt < bestRtt) {
+                bestRtt = rtt;
+                // Assume a symmetric round-trip: the server's reply reflects
+                // its clock at ~t0 + rtt/2, so the offset to add to a local
+                // timestamp is serverTime − (t0 + rtt/2).
+                setClockOffsetMs(serverTime - (t0 + rtt / 2));
+              }
+            }
+            setTimeout(sample, 150);
+          });
+        };
+        sample();
+      };
+
+      socket.on('connect', () => {
+        setStatus('connected');
+        syncClock();
+      });
       socket.on('disconnect', () => setStatus('closed'));
       socket.on('connect_error', () => {
         setStatus('error');
@@ -124,6 +173,13 @@ export function useMultiplayerRoom({
       socket.on('room:state', (broadcast: RoomStateBroadcast) => {
         setRoom(broadcast.room);
         setYouId(broadcast.youId);
+        // Seed a coarse clock offset from the snapshot's server timestamp so
+        // the countdown is computed correctly even on the very first snapshot
+        // (the one that may carry a freshly-started board), before the precise
+        // probe lands. Once a probe has measured, it owns the offset.
+        if (!syncedByProbeRef.current && typeof broadcast.serverNow === 'number') {
+          setClockOffsetMs(broadcast.serverNow - Date.now());
+        }
       });
       socket.on('room:nudge', (payload: { from: string }) => {
         setNudge({ from: payload?.from ?? 'A player', at: Date.now() });
@@ -131,6 +187,7 @@ export function useMultiplayerRoom({
     }, 0);
 
     return () => {
+      cancelled = true;
       clearTimeout(timer);
       if (socket) {
         socket.removeAllListeners();
@@ -209,5 +266,6 @@ export function useMultiplayerRoom({
     leaveRoom,
     nudgeHost,
     nudge,
+    clockOffsetMs,
   };
 }

--- a/models/multiplayer.ts
+++ b/models/multiplayer.ts
@@ -146,6 +146,13 @@ export interface RoomStateBroadcast {
    *  in `room.players` is theirs. Echoed so the server can confirm the
    *  player key was accepted. */
   youId: string;
+  /** Server wall-clock (`Date.now()`) at the moment this snapshot was
+   *  emitted. The client subtracts its own clock to seed a coarse
+   *  device→server offset immediately — so countdown/timer math is right
+   *  from the first snapshot, before the precise `time:sync` probe lands.
+   *  Carries the one-way send latency as error (~tens of ms); the probe
+   *  burst refines it. */
+  serverNow: number;
 }
 
 export interface WordSubmitPayload {

--- a/server/multiplayer/sockets.ts
+++ b/server/multiplayer/sockets.ts
@@ -51,12 +51,6 @@ interface SocketData {
   displayName: string;
 }
 
-function buildBroadcast(roomCode: string, youId: string): RoomStateBroadcast | null {
-  const room = getRoom(roomCode);
-  if (!room) return null;
-  return { room, youId };
-}
-
 /** The live sockets in one room. Resolved through Socket.io's own room
  *  membership index (every socket `join`s its room code) so this is O(room
  *  size), not O(all connected sockets across every room). */
@@ -78,9 +72,12 @@ function emitState(io: Server, roomCode: string): void {
   // Every connected socket gets the snapshot tailored to their own id —
   // the `youId` lets the client highlight themselves in the roster
   // without server-side bookkeeping.
+  // One timestamp for the whole fan-out so every recipient seeds its clock
+  // offset against the same instant.
+  const serverNow = Date.now();
   for (const socket of socketsInRoom(io, roomCode)) {
     const data = socket.data as Partial<SocketData>;
-    socket.emit('room:state', { room, youId: data.playerId } as RoomStateBroadcast);
+    socket.emit('room:state', { room, youId: data.playerId, serverNow } as RoomStateBroadcast);
   }
 }
 
@@ -97,6 +94,19 @@ export function attachMultiplayerSockets(io: Server): void {
   const ns = io.of('/multiplayer');
 
   ns.on('connection', async (socket) => {
+    // Clock sync. Registered first thing — before the auth / display-name /
+    // join awaits below — so the listener is up the instant the socket
+    // connects. The client probes this on its own 'connect' event; if we only
+    // attached the listener after those awaits, that first probe could land in
+    // the gap and be dropped, leaving the client on a 0 offset (a wrong device
+    // clock distorting the "get ready" countdown — a 30s-slow clock showed a
+    // 33s countdown) until a later probe happened to land. It just echoes the
+    // server's wall time and touches no room state, so answering before
+    // identity is resolved is safe.
+    socket.on('time:sync', (ack?: (serverTime: number) => void) => {
+      if (typeof ack === 'function') ack(Date.now());
+    });
+
     const hs = readHandshake(socket);
     if (!hs) {
       socket.emit('room:error', { reason: 'bad-handshake' });


### PR DESCRIPTION
**What** — The synchronous multiplayer pre-board countdown and play timer compared the server-stamped `startedAt` against the device's local clock, so a wrong device clock distorted them: a 30s-slow phone showed a ~33s countdown, and a fast clock skipped the countdown and briefly revealed the board before play.

**Why** — Each client now measures its device→server clock offset (NTP-style `time:sync` probes, seeded immediately by a `serverNow` timestamp added to every `room:state` snapshot) and rebases `startedAt` into the device's clock frame, so all timing is correct regardless of the device clock; the probe listener is registered before the join awaits so the first probe isn't dropped, and the monotonic timers re-anchor if the offset refines after they mount. Time zones are unaffected since `Date.now()` is UTC epoch — only an actually-wrong wall clock was ever at fault. Verified via `tsc` across client/server/models and formula simulations of the slow, fast, and reconnect scenarios (a live in-app run was blocked by port contention in the shared dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)