### PR TITLE
Add daily gauntlet history browsing

### DIFF
--- a/client/src/pages/daily/types.ts
+++ b/client/src/pages/daily/types.ts
@@ -7,6 +7,11 @@ export type DailyState = "completed" | "missed" | "unplayed";
 export interface DailyEntry {
   puzzleNumber: number;
   date: Date;
+  /** Canonical ISO `YYYY-MM-DD`. When set, the timeline picker uses it for
+   *  selection/keys instead of re-deriving from `date` via toISOString() —
+   *  which drifts to the adjacent day for UTC+13/+14/-12 viewers since the
+   *  local-noon `date` crosses the UTC boundary. */
+  iso?: string;
   state: DailyState;
   points?: number;
   wordsFound?: number;

--- a/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletResultsRoute.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import type { GauntletStatsDay, GauntletStatsResponse } from 'models/gauntlet';
 import { useGame } from '../../GameContext';
 import {
   fetchGauntletLeaderboard,
-  fetchGauntletStatus,
+  fetchGauntletStats,
+  fetchGauntletStatusForDate,
   type GauntletLeaderboardResponse,
   type GauntletStatusResponse,
 } from '../../shared/api/gauntletApi';
+import type { DailyEntry } from '../daily/types';
+import { DateChip } from '../../shared/components/DateChip';
+import { DateTimelinePicker } from '../../shared/components/DateTimelinePicker';
+import { IconAction } from '../../shared/components/IconAction';
+import { formatDateLabel } from '../../shared/utils/formatDate';
 import { InkButton } from '../../shared/components/InkButton';
 import {
   RankSumExplainer,
@@ -14,110 +21,203 @@ import {
   StandingsLeaderboard,
 } from './components';
 
+function getTodayPST(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+}
+
+// Folds the gauntlet's three states onto the picker's completed/missed/
+// unplayed display. Only fully-completed days are tappable (disableMissed),
+// so a partial day reads the same as one that was never played.
+function adaptDay(day: GauntletStatsDay, todayDate: string): DailyEntry {
+  const state =
+    day.state === 'completed'
+      ? 'completed'
+      : day.date === todayDate
+        ? 'unplayed'
+        : 'missed';
+  return {
+    puzzleNumber: day.puzzleNumber,
+    date: new Date(day.date + 'T12:00:00'),
+    iso: day.date,
+    state,
+    points: day.points ?? undefined,
+    wordsFound: day.wordsFound ?? undefined,
+    stampTier: null,
+    playersCount: day.playersCount,
+    config: { boardSize: 5, minWordLength: 4, timeLimit: 0 },
+  };
+}
+
 // Aggregate end screen. Shows the player's per-round ranks, the rank-sum
-// score, and how that placed them in today's gauntlet field. Each round
+// score, and how that placed them in the day's gauntlet field. Each round
 // row is click-through to the per-round results so the player can compare
-// words, see missed words, and re-read the modifier rule.
+// words, see missed words, and re-read the modifier rule. The date chip
+// opens a timeline picker for browsing past gauntlets.
 export function GauntletResultsRoute() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { authReady } = useGame();
+  const todayDate = getTodayPST();
+  const targetDate = searchParams.get('date') ?? todayDate;
+
   const [status, setStatus] = useState<GauntletStatusResponse | null>(null);
   const [leaderboard, setLeaderboard] = useState<GauntletLeaderboardResponse | null>(null);
+  const [stats, setStats] = useState<GauntletStatsResponse | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
 
   useEffect(() => {
     if (!authReady) return;
     let cancelled = false;
+    setLoaded(false);
+    setStatus(null);
     (async () => {
       const [s, lb] = await Promise.all([
-        fetchGauntletStatus().catch(() => null),
-        fetchGauntletLeaderboard(
-          new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' }),
-        ).catch(() => null),
+        fetchGauntletStatusForDate(targetDate).catch(() => null),
+        fetchGauntletLeaderboard(targetDate).catch(() => null),
       ]);
       if (cancelled) return;
-      if (s) setStatus(s);
+      setStatus(s);
       setLeaderboard(lb);
+      setLoaded(true);
     })();
     return () => {
       cancelled = true;
     };
+  }, [authReady, targetDate]);
+
+  useEffect(() => {
+    if (!authReady) return;
+    fetchGauntletStats()
+      .then(setStats)
+      .catch(() => {
+        // Non-fatal: picker falls back to empty entries.
+      });
   }, [authReady]);
 
-  if (!status) {
+  const pickerEntries: DailyEntry[] = useMemo(
+    () => stats?.days.map((d) => adaptDay(d, todayDate)) ?? [],
+    [stats, todayDate],
+  );
+
+  const handleChangeDate = (iso: string) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('date', iso);
+    setSearchParams(next, { replace: true });
+  };
+
+  const puzzleNumber =
+    status?.puzzleNumber ??
+    stats?.days.find((d) => d.date === targetDate)?.puzzleNumber ??
+    0;
+  const entry = status?.entry ?? null;
+  const completed = entry?.state === 'completed';
+
+  if (!loaded) {
     return (
       <div className="fixed inset-0 flex items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)]" />
     );
   }
 
-  const { entry } = status;
-  if (entry.state !== 'completed') {
-    return (
-      <div className="fixed inset-0 flex flex-col items-center justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] p-6 gap-4 text-center">
-        <p className="text-small text-[color:var(--ink-muted)]">
-          Finish all three rounds to see your gauntlet standings.
-        </p>
-        <InkButton onClick={() => navigate('/daily/gauntlet')}>Back to gauntlet</InkButton>
-      </div>
-    );
-  }
-
   return (
-    <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
-      <div className="w-full max-w-[360px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px] gap-3">
-        <div className="flex items-center">
-          <button
-            type="button"
-            onClick={() => navigate('/')}
-            className="bg-transparent border-none text-small text-[color:var(--ink-muted)] hover:text-[color:var(--ink)] cursor-pointer py-1.5 pr-2 font-[family-name:var(--font-ui)] transition-colors duration-200"
-            style={{ fontWeight: 500, WebkitTapHighlightColor: 'transparent' }}
+    <>
+      <div className="fixed inset-0 flex items-start justify-center bg-[var(--surface-panel)] text-[color:var(--ink)] font-[family-name:var(--font-ui)] overflow-y-auto">
+        <div className="w-full max-w-[360px] min-h-full flex flex-col px-[22px] pt-[24px] pb-[22px] gap-3">
+          <header
+            className="grid items-center gap-2 shrink-0"
+            style={{ gridTemplateColumns: '32px 1fr 32px' }}
           >
-            ← Home
-          </button>
+            <IconAction onClick={() => navigate('/')} label="Home">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 11l9-8 9 8" />
+                <path d="M5 10v10h14V10" />
+                <path d="M9 20v-6h6v6" />
+              </svg>
+            </IconAction>
+            <div className="flex justify-center min-w-0">
+              <DateChip
+                label={`Gauntlet #${puzzleNumber} · ${formatDateLabel(targetDate)}`}
+                onClick={() => setDatePickerOpen(true)}
+              />
+            </div>
+            <span aria-hidden />
+          </header>
+
+          {completed && entry ? (
+            <>
+              <div className="text-center">
+                <div
+                  className="text-caption uppercase tracking-[0.08em] text-[color:var(--ink-soft)] leading-none mb-2 font-[family-name:var(--font-structure)]"
+                  style={{ fontWeight: 700 }}
+                >
+                  Standings
+                </div>
+                <div
+                  className="text-display-sm italic leading-[1.05] tracking-[-0.015em] font-[family-name:var(--font-display)]"
+                  style={{ fontWeight: 500 }}
+                >
+                  {entry.aggregateRank !== null ? `#${entry.aggregateRank}` : '—'}
+                </div>
+                <div className="mt-1 text-small text-[color:var(--ink-muted)]">
+                  of {entry.totalPlayersCompleted.toLocaleString()} players · rank-sum{' '}
+                  <span
+                    className="font-[family-name:var(--font-structure)] text-[color:var(--ink)]"
+                    style={{ fontWeight: 700 }}
+                  >
+                    {entry.aggregateRankSum ?? '—'}
+                  </span>
+                </div>
+              </div>
+
+              <RankSumExplainer />
+
+              <div className="flex flex-col">
+                {entry.rounds.map((summary, index) => (
+                  <RoundSummaryRow
+                    key={`agg-round-${index}`}
+                    index={index}
+                    summary={summary}
+                    onView={() =>
+                      navigate(
+                        `/daily/gauntlet/round/${index}/results?from=standings&date=${targetDate}`,
+                      )
+                    }
+                  />
+                ))}
+              </div>
+
+              {leaderboard && leaderboard.aggregate.length > 0 && (
+                <StandingsLeaderboard leaderboard={leaderboard} />
+              )}
+            </>
+          ) : (
+            <div className="flex-1 flex flex-col items-center justify-center p-6 gap-4 text-center">
+              <p className="text-small text-[color:var(--ink-muted)]">
+                {targetDate === todayDate
+                  ? 'Finish all three rounds to see your gauntlet standings.'
+                  : "You didn't finish this gauntlet. Pick another day to see its standings."}
+              </p>
+              {targetDate === todayDate && (
+                <InkButton onClick={() => navigate('/daily/gauntlet')}>
+                  Back to gauntlet
+                </InkButton>
+              )}
+            </div>
+          )}
         </div>
-
-        <div className="text-center">
-          <div
-            className="text-caption uppercase tracking-[0.08em] text-[color:var(--ink-soft)] leading-none mb-2 font-[family-name:var(--font-structure)]"
-            style={{ fontWeight: 700 }}
-          >
-            Gauntlet #{status.puzzleNumber} · Standings
-          </div>
-          <div
-            className="text-display-sm italic leading-[1.05] tracking-[-0.015em] font-[family-name:var(--font-display)]"
-            style={{ fontWeight: 500 }}
-          >
-            {entry.aggregateRank !== null ? `#${entry.aggregateRank}` : '—'}
-          </div>
-          <div className="mt-1 text-small text-[color:var(--ink-muted)]">
-            of {entry.totalPlayersCompleted.toLocaleString()} players · rank-sum{' '}
-            <span
-              className="font-[family-name:var(--font-structure)] text-[color:var(--ink)]"
-              style={{ fontWeight: 700 }}
-            >
-              {entry.aggregateRankSum ?? '—'}
-            </span>
-          </div>
-        </div>
-
-        <RankSumExplainer />
-
-        <div className="flex flex-col">
-          {entry.rounds.map((summary, index) => (
-            <RoundSummaryRow
-              key={`agg-round-${index}`}
-              index={index}
-              summary={summary}
-              onView={() =>
-                navigate(`/daily/gauntlet/round/${index}/results?from=standings`)
-              }
-            />
-          ))}
-        </div>
-
-        {leaderboard && leaderboard.aggregate.length > 0 && (
-          <StandingsLeaderboard leaderboard={leaderboard} />
-        )}
       </div>
-    </div>
+      <DateTimelinePicker
+        open={datePickerOpen}
+        onClose={() => setDatePickerOpen(false)}
+        onSelect={(iso) => {
+          setDatePickerOpen(false);
+          handleChangeDate(iso);
+        }}
+        entries={pickerEntries}
+        selectedDate={targetDate}
+        todayDate={todayDate}
+        disableMissed
+      />
+    </>
   );
 }

--- a/client/src/pages/dailyGauntlet/GauntletRoundResultsRoute.tsx
+++ b/client/src/pages/dailyGauntlet/GauntletRoundResultsRoute.tsx
@@ -29,6 +29,12 @@ export function GauntletRoundResultsRoute() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromStandings = searchParams.get('from') === 'standings';
+  const todayDate = new Date().toLocaleDateString('en-CA', {
+    timeZone: 'America/Los_Angeles',
+  });
+  const targetDate = searchParams.get('date') ?? todayDate;
+  // Carries the browsed date forward through round-to-round navigation.
+  const dateQuery = `&date=${targetDate}`;
   const { authReady, displayName } = useGame();
   const roundIndex = Number(round);
   const [result, setResult] = useState<GauntletRoundResultResponse | null>(null);
@@ -39,12 +45,9 @@ export function GauntletRoundResultsRoute() {
     if (!authReady || !Number.isFinite(roundIndex)) return;
     let cancelled = false;
     (async () => {
-      const today = new Date().toLocaleDateString('en-CA', {
-        timeZone: 'America/Los_Angeles',
-      });
       const [r, lb] = await Promise.all([
-        fetchGauntletRoundResult(today, roundIndex),
-        fetchGauntletLeaderboard(today).catch(() => null),
+        fetchGauntletRoundResult(targetDate, roundIndex),
+        fetchGauntletLeaderboard(targetDate).catch(() => null),
       ]);
       if (cancelled) return;
       setResult(r);
@@ -54,15 +57,18 @@ export function GauntletRoundResultsRoute() {
     return () => {
       cancelled = true;
     };
-  }, [authReady, roundIndex]);
+  }, [authReady, roundIndex, targetDate]);
 
   // Same render-time navigate guard as the play route — the redirect
   // is deferred to an effect so it doesn't fire during render.
   useEffect(() => {
     if (loaded && !result) {
-      navigate('/daily/gauntlet', { replace: true });
+      navigate(
+        fromStandings ? `/daily/gauntlet/results?date=${targetDate}` : '/daily/gauntlet',
+        { replace: true },
+      );
     }
-  }, [loaded, result, navigate]);
+  }, [loaded, result, navigate, fromStandings, targetDate]);
 
   if (!loaded || !result) {
     return (
@@ -130,10 +136,7 @@ export function GauntletRoundResultsRoute() {
       ];
 
   const loadOpponent = async (userId: string): Promise<LoadOpponentResult> => {
-    const today = new Date().toLocaleDateString('en-CA', {
-      timeZone: 'America/Los_Angeles',
-    });
-    const cmp = await fetchGauntletCompare(today, roundIndex, userId);
+    const cmp = await fetchGauntletCompare(targetDate, roundIndex, userId);
     if (!cmp.ok) return { ok: false, error: cmp.error };
     return {
       ok: true,
@@ -153,11 +156,13 @@ export function GauntletRoundResultsRoute() {
   // the next round is unstarted by definition, so it goes to confirm.
   const advance = () => {
     if (isLastRound) {
-      navigate('/daily/gauntlet/results');
+      navigate(
+        fromStandings ? `/daily/gauntlet/results?date=${targetDate}` : '/daily/gauntlet/results',
+      );
       return;
     }
     if (fromStandings) {
-      navigate(`/daily/gauntlet/round/${roundIndex + 1}/results?from=standings`);
+      navigate(`/daily/gauntlet/round/${roundIndex + 1}/results?from=standings${dateQuery}`);
       return;
     }
     navigate(`/daily/gauntlet/round/${roundIndex + 1}`);
@@ -167,7 +172,7 @@ export function GauntletRoundResultsRoute() {
   // to the standings page; from the mid-play flow, X exits to home and
   // the secondary action stays "Home" as well.
   const onClose = () =>
-    fromStandings ? navigate('/daily/gauntlet/results') : navigate('/');
+    fromStandings ? navigate(`/daily/gauntlet/results?date=${targetDate}`) : navigate('/');
 
   // For the rare-letters round, surface the per-cell point values on
   // the preview board so a player reading their results can match a

--- a/client/src/shared/api/gauntletApi.ts
+++ b/client/src/shared/api/gauntletApi.ts
@@ -4,6 +4,7 @@ import type {
   GauntletModifier,
   GauntletRoundConfig,
   GauntletRoundKind,
+  GauntletStatsResponse,
 } from 'models/gauntlet';
 import { supabase } from '../supabase';
 
@@ -51,6 +52,27 @@ export interface GauntletStatusResponse {
 export async function fetchGauntletStatus(): Promise<GauntletStatusResponse> {
   const res = await fetch(`${API_URL}/daily/gauntlet`, { headers: await authHeaders() });
   if (!res.ok) throw new Error('Failed to fetch gauntlet status');
+  return res.json();
+}
+
+// Standings payload for an arbitrary date — used by the results page to
+// render historic gauntlets browsed through the date picker.
+export async function fetchGauntletStatusForDate(
+  date: string,
+): Promise<GauntletStatusResponse> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/${date}/status`, {
+    headers: await authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch gauntlet status');
+  return res.json();
+}
+
+// Per-day gauntlet history that populates the standings date picker.
+export async function fetchGauntletStats(): Promise<GauntletStatsResponse> {
+  const res = await fetch(`${API_URL}/daily/gauntlet/stats`, {
+    headers: await authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch gauntlet stats');
   return res.json();
 }
 

--- a/client/src/shared/components/DateTimelinePicker.tsx
+++ b/client/src/shared/components/DateTimelinePicker.tsx
@@ -187,7 +187,9 @@ export function DateTimelinePicker({
                   {group.label}
                 </div>
                 {group.entries.map((entry) => {
-                  const iso = entry.date.toISOString().slice(0, 10);
+                  // Prefer the canonical ISO when provided — re-deriving from
+                  // the local-noon `date` drifts a day for UTC+13/+14/-12.
+                  const iso = entry.iso ?? entry.date.toISOString().slice(0, 10);
                   return (
                     <DayCard
                       key={iso}

--- a/models/gauntlet.ts
+++ b/models/gauntlet.ts
@@ -72,3 +72,27 @@ export interface GauntletEntry {
   aggregateRank: number | null;
   totalPlayersCompleted: number;
 }
+
+// One day of gauntlet history for the standings date picker. `points` and
+// `wordsFound` are the sums across the three rounds (completed days only);
+// the aggregate rank + rank-sum mirror the standings headline so the picker
+// can preview a day's outcome. `state` is the true gauntlet state — the
+// client maps it onto the picker's completed/missed/unplayed display.
+export interface GauntletStatsDay {
+  date: string;
+  puzzleNumber: number;
+  state: GauntletState;
+  roundsCompleted: number;
+  points: number | null;
+  wordsFound: number | null;
+  aggregateRank: number | null;
+  aggregateRankSum: number | null;
+  totalPlayersCompleted: number;
+  playersCount: number;
+}
+
+export interface GauntletStatsResponse {
+  windowStart: string;
+  windowEnd: string;
+  days: GauntletStatsDay[];
+}

--- a/server/routes/dailyGauntlet.ts
+++ b/server/routes/dailyGauntlet.ts
@@ -11,6 +11,7 @@ import { cachePrivate, noStore } from '../httpCache.js';
 import { dictionary } from '../services/dictionary.js';
 import { getDailyDatePST } from '../services/dailyConfig.js';
 import {
+  DAILY_GAUNTLET_LAUNCH_DATE,
   getDailyGauntletNumber,
   prepareAllGauntletRounds,
   prepareGauntletRound,
@@ -18,6 +19,7 @@ import {
 import {
   aggregateFromRoundRanks,
   endGauntletRound,
+  getDailyGauntletStats,
   getGauntletRoundRanks,
   getGauntletRoundSession,
   getGauntletStatus,
@@ -68,6 +70,50 @@ dailyGauntletRouter.get('/', requireAuth, async (req, res) => {
     res.json({
       date,
       puzzleNumber: getDailyGauntletNumber(date),
+      ...status,
+    });
+  } catch (err) {
+    console.error('Failed to fetch gauntlet status:', err);
+    res.status(500).json({ error: 'Failed to fetch gauntlet status' });
+  }
+});
+
+// Per-day gauntlet history for the standings date picker. Single literal
+// segment, so it must be registered before the `/:date/...` routes below.
+dailyGauntletRouter.get('/stats', requireAuth, async (req, res) => {
+  try {
+    const stats = await getDailyGauntletStats(getDb(), req.userId!, {
+      launchDate: DAILY_GAUNTLET_LAUNCH_DATE,
+      today: getDailyDatePST(),
+    });
+    // The window always includes today, whose state is still mutable, so the
+    // whole payload must skip the cache — otherwise the picker can keep
+    // showing today as not-completed for the TTL after the player finishes.
+    noStore(res);
+    res.json(stats);
+  } catch (err) {
+    console.error('Failed to fetch gauntlet stats:', err);
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+});
+
+// Status (hub payload) for an arbitrary date — powers historic standings.
+// Same shape as `/` (today) but lets the results page render past gauntlets.
+dailyGauntletRouter.get('/:date/status', requireAuth, async (req, res) => {
+  try {
+    const status = await getGauntletStatus(getDb(), req.userId!, req.params.date);
+    // Today's state is still mutable (the player may finish more rounds
+    // mid-session), so it must not be cached — otherwise a `partial` snapshot
+    // fetched before finishing can mask the completed standings until the TTL
+    // expires. Past dates are immutable (starts are gated to today).
+    if (req.params.date === getDailyDatePST()) {
+      noStore(res);
+    } else {
+      cachePrivate(res, 60);
+    }
+    res.json({
+      date: req.params.date,
+      puzzleNumber: getDailyGauntletNumber(req.params.date),
       ...status,
     });
   } catch (err) {

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -11,6 +11,8 @@ import {
   type GauntletRoundKind,
   type GauntletRoundSummary,
   type GauntletState,
+  type GauntletStatsDay,
+  type GauntletStatsResponse,
 } from 'models/gauntlet';
 import type { Database } from '../db/types.js';
 import { dictionary } from './dictionary.js';
@@ -628,4 +630,104 @@ export async function getGauntletStatus(
     upcomingConfigs,
     roundKinds,
   };
+}
+
+// ─── History for the standings date picker ───────────────────────────────
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00Z');
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function maxDate(a: string, b: string): string {
+  return a >= b ? a : b;
+}
+
+// Per-day gauntlet history over a lookback window. Mirrors getDailyZenStats
+// in shape so the client can reuse the timeline picker, but folds the three
+// per-round rows into a single per-day summary. Aggregate rank + rank-sum
+// are resolved only for days the player finished all three rounds.
+export async function getDailyGauntletStats(
+  db: Kysely<Database>,
+  userId: string,
+  config: { launchDate: string; today: string; windowDays?: number },
+): Promise<GauntletStatsResponse> {
+  const { launchDate, today, windowDays = 30 } = config;
+  const windowStart = maxDate(addDays(today, -(windowDays - 1)), launchDate);
+  const windowEnd = today;
+
+  const userRows = await db
+    .selectFrom('daily_gauntlet_results')
+    .select(['date', 'points', 'word_count', 'ended_at'])
+    .where('user_id', '=', userId)
+    .where('date', '>=', windowStart)
+    .where('date', '<=', windowEnd)
+    .execute();
+
+  // Distinct players who engaged with the gauntlet on each day.
+  const playerCountRows = await db
+    .selectFrom('daily_gauntlet_results')
+    .select((eb) => ['date', eb.fn.count(eb.ref('user_id')).distinct().as('players')])
+    .where('date', '>=', windowStart)
+    .where('date', '<=', windowEnd)
+    .groupBy('date')
+    .execute();
+  const playersByDate = new Map<string, number>();
+  for (const row of playerCountRows) playersByDate.set(row.date, Number(row.players));
+
+  interface DayAccum {
+    endedRounds: number;
+    points: number;
+    words: number;
+  }
+  const byDate = new Map<string, DayAccum>();
+  for (const r of userRows) {
+    const acc = byDate.get(r.date) ?? { endedRounds: 0, points: 0, words: 0 };
+    if (r.ended_at) acc.endedRounds += 1;
+    acc.points += Number(r.points);
+    acc.words += Number(r.word_count);
+    byDate.set(r.date, acc);
+  }
+
+  // Aggregate standing only matters for days the player finished all three
+  // rounds — compute the rank for those days and pull the player out of it.
+  const completedDates = [...byDate.entries()]
+    .filter(([, acc]) => acc.endedRounds >= GAUNTLET_ROUND_COUNT)
+    .map(([date]) => date);
+  const aggregateByDate = new Map<
+    string,
+    { rank: number | null; rankSum: number | null; total: number }
+  >();
+  for (const date of completedDates) {
+    const aggregate = await getGauntletAggregate(db, date);
+    const mine = aggregate.find((a) => a.userId === userId);
+    aggregateByDate.set(date, {
+      rank: mine?.aggregateRank ?? null,
+      rankSum: mine?.rankSum ?? null,
+      total: aggregate.length,
+    });
+  }
+
+  const days: GauntletStatsDay[] = [];
+  for (let d = windowStart; d <= windowEnd; d = addDays(d, 1)) {
+    const acc = byDate.get(d);
+    const completed = !!acc && acc.endedRounds >= GAUNTLET_ROUND_COUNT;
+    const state: GauntletState = completed ? 'completed' : acc ? 'partial' : 'unplayed';
+    const agg = aggregateByDate.get(d);
+    days.push({
+      date: d,
+      puzzleNumber: getDailyGauntletNumber(d),
+      state,
+      roundsCompleted: acc?.endedRounds ?? 0,
+      points: completed ? acc!.points : null,
+      wordsFound: completed ? acc!.words : null,
+      aggregateRank: completed ? (agg?.rank ?? null) : null,
+      aggregateRankSum: completed ? (agg?.rankSum ?? null) : null,
+      totalPlayersCompleted: agg?.total ?? 0,
+      playersCount: playersByDate.get(d) ?? 0,
+    });
+  }
+
+  return { windowStart, windowEnd, days };
 }


### PR DESCRIPTION
Adds daily gauntlet stats and dated status endpoints so completed gauntlets can be browsed from the standings page. Updates the aggregate results UI with a date picker, carries selected dates through per-round results and compare flows, and reuses the shared timeline picker for gauntlet history. Also adds canonical ISO date support to daily timeline entries to avoid timezone drift when deriving picker keys.