### PR TITLE
Unify ranking, submission, and session-expiry across play modes

### DIFF
--- a/client/src/pages/multiplayer/RoomResults.tsx
+++ b/client/src/pages/multiplayer/RoomResults.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { MultiplayerRoom } from 'models/multiplayer';
+import { assignCompetitionRanks } from 'models/ranking';
 import { ActionButton } from '../../shared/results/components/ActionButton';
 import { Standings } from '../../shared/results/components/Standings';
 import { ResultsView } from '../../shared/results/ResultsView';
@@ -423,23 +424,13 @@ function rankByPoints(
   }[],
 ): RankedPlayer[] {
   const sorted = [...players].sort((a, b) => b.points - a.points);
-  const ranked: RankedPlayer[] = [];
-  let lastPoints = Infinity;
-  let lastRank = 0;
-  sorted.forEach((p, i) => {
-    if (p.points !== lastPoints) {
-      lastRank = i + 1;
-      lastPoints = p.points;
-    }
-    ranked.push({
-      id: p.id,
-      displayName: p.displayName,
-      rank: lastRank,
-      points: p.points,
-      wordCount: p.wordCount,
-      foundWords: p.foundWords,
-      left: p.left,
-    });
-  });
-  return ranked;
+  return assignCompetitionRanks(sorted, (p) => p.points).map(({ item: p, rank }) => ({
+    id: p.id,
+    displayName: p.displayName,
+    rank,
+    points: p.points,
+    wordCount: p.wordCount,
+    foundWords: p.foundWords,
+    left: p.left,
+  }));
 }

--- a/engine/package.json
+++ b/engine/package.json
@@ -14,7 +14,9 @@
     "./gauntletScoring": "./gauntletScoring.ts",
     "./gauntletScoring.js": "./gauntletScoring.ts",
     "./solver": "./solver.ts",
-    "./solver.js": "./solver.ts"
+    "./solver.js": "./solver.ts",
+    "./submission": "./submission.ts",
+    "./submission.js": "./submission.ts"
   },
   "private": true,
   "dependencies": {

--- a/engine/submission.test.ts
+++ b/engine/submission.test.ts
@@ -60,24 +60,24 @@ describe('validateSubmission', () => {
     }
   });
 
-  it('rejects a non-adjacent path as invalid', () => {
+  it('rejects a non-adjacent path as invalid, with no derived word', () => {
     const result = validateSubmission([at(0, 0), at(2, 2)], ctx());
     expect(result).toEqual({ valid: false, reason: 'invalid' });
   });
 
-  it('rejects a word below the minimum length as invalid', () => {
+  it('rejects a word below the minimum length as invalid, surfacing the word', () => {
     const result = validateSubmission(CAT, ctx({ minWordLength: 4 }));
-    expect(result).toEqual({ valid: false, reason: 'invalid' });
+    expect(result).toEqual({ valid: false, reason: 'invalid', word: 'CAT' });
   });
 
-  it('rejects a path that spells a non-dictionary word as invalid', () => {
+  it('rejects a path that spells a non-dictionary word as invalid, surfacing the word', () => {
     // A(0,1) → O(1,1) → G(2,2): a connected path, but "AOG" is not a word.
     const result = validateSubmission([at(0, 1), at(1, 1), at(2, 2)], ctx());
-    expect(result).toEqual({ valid: false, reason: 'invalid' });
+    expect(result).toEqual({ valid: false, reason: 'invalid', word: 'AOG' });
   });
 
-  it('rejects a duplicate of an already-found word as repeat', () => {
+  it('rejects a duplicate of an already-found word as repeat, surfacing the word', () => {
     const result = validateSubmission(CAT, ctx({ foundWords: ['CAT'] }));
-    expect(result).toEqual({ valid: false, reason: 'repeat' });
+    expect(result).toEqual({ valid: false, reason: 'repeat', word: 'CAT' });
   });
 });

--- a/engine/submission.test.ts
+++ b/engine/submission.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { Position } from 'models';
+import { scoreWord } from './scoring.js';
+import { validateSubmission, type SubmissionContext } from './submission.js';
+
+// 3x3 fixture board:
+//   C A T
+//   X O S
+//   D O G
+const BOARD = [
+  ['C', 'A', 'T'],
+  ['X', 'O', 'S'],
+  ['D', 'O', 'G'],
+];
+const DICTIONARY = new Set(['cat', 'cats', 'dog']);
+
+const at = (row: number, col: number): Position => ({ row, col });
+const CAT = [at(0, 0), at(0, 1), at(0, 2)];
+const CATS = [at(0, 0), at(0, 1), at(0, 2), at(1, 2)];
+
+// Sums word count as a sentinel aggregate; lets us assert the injected scorer
+// receives nextWords and its result is passed through untouched.
+const countingScore = (words: string[]) => ({
+  points: words.length,
+  wordCount: words.length,
+  longestWord: words.reduce((a, b) => (b.length > a.length ? b : a), ''),
+});
+
+function ctx(overrides: Partial<SubmissionContext> = {}): SubmissionContext {
+  return {
+    board: BOARD,
+    foundWords: [],
+    boardSize: 3,
+    minWordLength: 3,
+    dictionary: DICTIONARY,
+    score: countingScore,
+    ...overrides,
+  };
+}
+
+describe('validateSubmission', () => {
+  it('accepts a valid word and returns score, nextWords, and the injected aggregate', () => {
+    const result = validateSubmission(CATS, ctx());
+    expect(result).toEqual({
+      valid: true,
+      word: 'CATS',
+      score: scoreWord('CATS'),
+      nextWords: ['CATS'],
+      aggregate: { points: 1, wordCount: 1, longestWord: 'CATS' },
+    });
+  });
+
+  it('appends to existing foundWords for the aggregate', () => {
+    const result = validateSubmission(CATS, ctx({ foundWords: ['CAT'] }));
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.nextWords).toEqual(['CAT', 'CATS']);
+      expect(result.aggregate.wordCount).toBe(2);
+    }
+  });
+
+  it('rejects a non-adjacent path as invalid', () => {
+    const result = validateSubmission([at(0, 0), at(2, 2)], ctx());
+    expect(result).toEqual({ valid: false, reason: 'invalid' });
+  });
+
+  it('rejects a word below the minimum length as invalid', () => {
+    const result = validateSubmission(CAT, ctx({ minWordLength: 4 }));
+    expect(result).toEqual({ valid: false, reason: 'invalid' });
+  });
+
+  it('rejects a path that spells a non-dictionary word as invalid', () => {
+    // A(0,1) → O(1,1) → G(2,2): a connected path, but "AOG" is not a word.
+    const result = validateSubmission([at(0, 1), at(1, 1), at(2, 2)], ctx());
+    expect(result).toEqual({ valid: false, reason: 'invalid' });
+  });
+
+  it('rejects a duplicate of an already-found word as repeat', () => {
+    const result = validateSubmission(CAT, ctx({ foundWords: ['CAT'] }));
+    expect(result).toEqual({ valid: false, reason: 'repeat' });
+  });
+});

--- a/engine/submission.test.ts
+++ b/engine/submission.test.ts
@@ -33,6 +33,7 @@ function ctx(overrides: Partial<SubmissionContext> = {}): SubmissionContext {
     boardSize: 3,
     minWordLength: 3,
     dictionary: DICTIONARY,
+    scoreWord,
     score: countingScore,
     ...overrides,
   };

--- a/engine/submission.ts
+++ b/engine/submission.ts
@@ -1,0 +1,68 @@
+import type { Position } from 'models';
+import { isValidPath } from './adjacency.js';
+import { isValidWord } from './dictionary.js';
+import { scoreWord } from './scoring.js';
+
+export interface SubmissionAggregate {
+  points: number;
+  wordCount: number;
+  longestWord: string;
+}
+
+export interface SubmissionContext {
+  board: string[][];
+  foundWords: string[];
+  boardSize: number;
+  minWordLength: number;
+  dictionary: Set<string>;
+  // Injected so callers supply the scoring rule (plain vs gauntlet modifier);
+  // the engine stays agnostic to which mode it is validating for.
+  score: (words: string[]) => SubmissionAggregate;
+}
+
+export type SubmissionResult =
+  | { valid: false; reason: 'invalid' | 'repeat' }
+  | {
+      valid: true;
+      word: string;
+      score: number;
+      nextWords: string[];
+      aggregate: SubmissionAggregate;
+    };
+
+// The trust-but-verify core shared by every mode's word submission: validate the
+// path, derive the word from the stored board, enforce the length floor,
+// dictionary-check it, reject duplicates, then score. Pure — callers own session
+// loading, persistence, and any per-mode bookkeeping around this.
+export function validateSubmission(
+  path: Position[],
+  ctx: SubmissionContext,
+): SubmissionResult {
+  if (!isValidPath(path, ctx.boardSize)) {
+    return { valid: false, reason: 'invalid' };
+  }
+
+  const word = path
+    .map((pos) => ctx.board[pos.row][pos.col])
+    .join('')
+    .toUpperCase();
+
+  if (word.length < ctx.minWordLength) {
+    return { valid: false, reason: 'invalid' };
+  }
+  if (!isValidWord(ctx.dictionary, word.toLowerCase())) {
+    return { valid: false, reason: 'invalid' };
+  }
+  if (ctx.foundWords.some((w) => w.toUpperCase() === word)) {
+    return { valid: false, reason: 'repeat' };
+  }
+
+  const nextWords = [...ctx.foundWords, word];
+  return {
+    valid: true,
+    word,
+    score: scoreWord(word),
+    nextWords,
+    aggregate: ctx.score(nextWords),
+  };
+}

--- a/engine/submission.ts
+++ b/engine/submission.ts
@@ -1,7 +1,6 @@
 import type { Position } from 'models';
 import { isValidPath } from './adjacency.js';
 import { isValidWord } from './dictionary.js';
-import { scoreWord } from './scoring.js';
 
 export interface SubmissionAggregate {
   points: number;
@@ -15,8 +14,11 @@ export interface SubmissionContext {
   boardSize: number;
   minWordLength: number;
   dictionary: Set<string>;
-  // Injected so callers supply the scoring rule (plain vs gauntlet modifier);
-  // the engine stays agnostic to which mode it is validating for.
+  // Both scorers are injected so callers supply the scoring rule (plain vs
+  // gauntlet modifier); the engine stays agnostic to which mode it validates
+  // for. `scoreWord` is the per-word value shown to the player; `score` builds
+  // the aggregate persisted alongside the row.
+  scoreWord: (word: string) => number;
   score: (words: string[]) => SubmissionAggregate;
 }
 
@@ -61,7 +63,7 @@ export function validateSubmission(
   return {
     valid: true,
     word,
-    score: scoreWord(word),
+    score: ctx.scoreWord(word),
     nextWords,
     aggregate: ctx.score(nextWords),
   };

--- a/engine/submission.ts
+++ b/engine/submission.ts
@@ -23,7 +23,12 @@ export interface SubmissionContext {
 }
 
 export type SubmissionResult =
-  | { valid: false; reason: 'invalid' | 'repeat' }
+  // `word` is present on failures that occur after the word was derived
+  // (length, dictionary, duplicate) so callers that surface the rejected word
+  // — e.g. the multiplayer "not a word" toast — can read it; it is absent when
+  // the path itself was invalid (nothing to derive). Callers that don't expose
+  // it simply ignore the field.
+  | { valid: false; reason: 'invalid' | 'repeat'; word?: string }
   | {
       valid: true;
       word: string;
@@ -50,13 +55,13 @@ export function validateSubmission(
     .toUpperCase();
 
   if (word.length < ctx.minWordLength) {
-    return { valid: false, reason: 'invalid' };
+    return { valid: false, reason: 'invalid', word };
   }
   if (!isValidWord(ctx.dictionary, word.toLowerCase())) {
-    return { valid: false, reason: 'invalid' };
+    return { valid: false, reason: 'invalid', word };
   }
   if (ctx.foundWords.some((w) => w.toUpperCase() === word)) {
-    return { valid: false, reason: 'repeat' };
+    return { valid: false, reason: 'repeat', word };
   }
 
   const nextWords = [...ctx.foundWords, word];

--- a/models/package.json
+++ b/models/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./index.ts",
     "./seedCode": "./seedCode.ts",
+    "./ranking": "./ranking.ts",
     "./zenRanks": "./zenRanks.ts",
     "./gauntlet": "./gauntlet.ts",
     "./multiplayer": "./multiplayer.ts"

--- a/models/ranking.test.ts
+++ b/models/ranking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { assignCompetitionRanks } from './ranking.js';
+import { assignCompetitionRanks } from 'models/ranking';
 
 // Characterization: locks the current standard-competition-rank behavior
 // ("1, 1, 3" — equal scores share a rank, the next distinct score skips the

--- a/models/ranking.ts
+++ b/models/ranking.ts
@@ -3,10 +3,12 @@
 // already be in non-increasing score order — rank is derived by comparing each
 // item's score to the one before it.
 //
-// This lives in one place so the daily leaderboard, the free-play challenge
-// standings, and the history-badge rank all agree on what a tie means. A tie is
-// equal score, full stop; we deliberately do not break it by completion time or
-// word count, so two players who see the same number also see the same place.
+// This lives in models/ — importable by both server and client — so the daily
+// leaderboard, the free-play challenge standings, the zen leaderboard, the
+// live multiplayer results, and the history-badge rank all agree on what a tie
+// means. A tie is equal score, full stop; we deliberately do not break it by
+// completion time or word count, so two players who see the same number also
+// see the same place.
 export function assignCompetitionRanks<T>(
   sorted: readonly T[],
   scoreOf: (item: T) => number,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
         "client"
       ],
       "devDependencies": {
+        "@testcontainers/postgresql": "^12.0.2",
         "autoprefixer": "^10.4.27",
         "concurrently": "^9.2.1",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.1",
+        "testcontainers": "^12.0.2",
         "vitest": "^4.1.5"
       }
     },
@@ -597,6 +599,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1060,6 +1069,58 @@
         "node": ">=12"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1208,6 +1269,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
@@ -1236,6 +1318,72 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2716,6 +2864,16 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testcontainers/postgresql": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-12.0.2.tgz",
+      "integrity": "sha512-dHBi6H2+op11hd2EwSdsEKJpf0BTHvtOkNoh/CBLxFrla1kTIqsm3se4CuMma7+yraIdEblW91sSaH9xeV6UOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^12.0.2"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -2933,6 +3091,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -3096,6 +3277,43 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -3235,6 +3453,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -3300,6 +3531,27 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "is-stream": "^4.0.0",
+        "lazystream": "^1.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -3323,6 +3575,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3345,6 +3607,20 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -3406,6 +3682,140 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -3428,6 +3838,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/better-opn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
@@ -3439,6 +3859,58 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/body-parser": {
@@ -3543,6 +4015,61 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/bytes": {
@@ -3673,6 +4200,13 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/client": {
       "resolved": "client",
       "link": true
@@ -3711,6 +4245,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/compress-commons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -3784,6 +4335,13 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3799,6 +4357,48 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/create-require": {
@@ -3940,6 +4540,113 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/docker-compose": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
+      "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4"
+      },
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4008,6 +4715,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine": {
@@ -4266,6 +4983,36 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4344,6 +5091,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -4478,6 +5232,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4553,6 +5314,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {
@@ -4725,6 +5499,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4861,6 +5656,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -4889,6 +5697,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4980,6 +5795,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/lightningcss": {
@@ -5254,6 +6115,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5441,6 +6316,29 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/models": {
       "resolved": "models",
       "link": true
@@ -5450,6 +6348,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -5484,6 +6390,16 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5536,6 +6452,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/open": {
@@ -5920,6 +6846,74 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5931,6 +6925,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -6074,6 +7079,78 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -6158,6 +7235,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -6589,6 +7676,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -6596,6 +7690,46 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/stackback": {
@@ -6646,6 +7780,28 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -6777,6 +7933,108 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/testcontainers": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.0.2.tgz",
+      "integrity": "sha512-UNkC3cSGrsNyyDShaES1/tUHqPNQiH7aUXBPYMO2iAY4tdCI2uVdEagBCrLN0RQ1qxDPWU733OuEaDNQs0vanw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^8.0.0",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^5.0.0",
+        "get-port": "^7.2.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.7",
+        "undici": "^8.3.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -6835,6 +8093,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/toidentifier": {
@@ -7409,6 +8677,13 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -7434,6 +8709,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -7509,6 +8794,13 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -8222,6 +9514,13 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -8277,6 +9576,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -8327,6 +9642,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "server": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@testcontainers/postgresql": "^12.0.2",
     "autoprefixer": "^10.4.27",
     "concurrently": "^9.2.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.1",
+    "testcontainers": "^12.0.2",
     "vitest": "^4.1.5"
   }
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -24,3 +24,15 @@ export function getDb(): Kysely<Database> {
   }
   return db;
 }
+
+// Test-only: tear down the singleton pool and clear it so the next getDb()
+// rebuilds. Integration tests bind getDb() to a throwaway container via
+// DATABASE_URL; they must close this pool BEFORE stopping the container,
+// otherwise pg raises an uncaught "terminating connection" error when the
+// server shuts down underneath the still-open client.
+export async function resetDb(): Promise<void> {
+  if (db) {
+    await db.destroy();
+    db = null;
+  }
+}

--- a/server/multiplayer/store.ts
+++ b/server/multiplayer/store.ts
@@ -9,10 +9,9 @@
 
 import { randomUUID } from 'node:crypto';
 import { generateSeededBoard } from 'engine/board.js';
-import { isValidPath } from 'engine/adjacency.js';
-import { isValidWord } from 'engine/dictionary.js';
 import { findAllWords } from 'engine/solver.js';
 import { scoreWord } from 'engine/scoring.js';
+import { validateSubmission } from 'engine/submission.js';
 import { hashWord, generateSalt, type Position, type GameConfig } from 'models';
 import { randomSeed } from 'models/seedCode';
 import type {
@@ -23,6 +22,7 @@ import type {
   RoomVisibility,
 } from 'models/multiplayer';
 import { dictionary } from '../services/dictionary.js';
+import { scoreResult } from '../services/DailyService.js';
 
 const ROOM_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no 0/1/I/O ambiguity
 const ROOM_CODE_LENGTH = 5;
@@ -904,30 +904,28 @@ export function submitWord(
     return { outcome: { valid: false, reason: 'expired' }, room };
   }
 
-  if (!isValidPath(path, board.config.boardSize)) {
-    return { outcome: { valid: false, reason: 'invalid' }, room };
+  // The validate/derive/dedupe/score middle is the shared engine core; the
+  // multiplayer-specific gating (lobby/countdown/grace) above and the in-memory
+  // mutation below stay here. The rejected word is surfaced so the client can
+  // show it in the "not a word" toast.
+  const result = validateSubmission(path, {
+    board: board.board,
+    foundWords: player.foundWords,
+    boardSize: board.config.boardSize,
+    minWordLength: board.config.minWordLength,
+    dictionary,
+    scoreWord,
+    score: scoreResult,
+  });
+  if (!result.valid) {
+    return { outcome: { valid: false, word: result.word, reason: result.reason }, room };
   }
-  const word = path
-    .map((p) => board.board[p.row]?.[p.col] ?? '')
-    .join('')
-    .toUpperCase();
 
-  if (word.length < board.config.minWordLength) {
-    return { outcome: { valid: false, word, reason: 'invalid' }, room };
-  }
-  if (!isValidWord(dictionary, word.toLowerCase())) {
-    return { outcome: { valid: false, word, reason: 'invalid' }, room };
-  }
-  if (player.foundWords.some((w) => w.toUpperCase() === word)) {
-    return { outcome: { valid: false, word, reason: 'repeat' }, room };
-  }
-
-  const score = scoreWord(word);
-  player.foundWords.push(word);
-  player.points += score;
-  player.wordCount += 1;
+  player.foundWords.push(result.word);
+  player.points = result.aggregate.points;
+  player.wordCount = result.aggregate.wordCount;
   touch(entry);
-  return { outcome: { valid: true, word, score }, room };
+  return { outcome: { valid: true, word: result.word, score: result.score }, room };
 }
 
 export function markPlayerFinished(

--- a/server/multiplayer/submitWord.test.ts
+++ b/server/multiplayer/submitWord.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { findAllWords } from 'engine/solver.js';
+import { scoreWord } from 'engine/scoring.js';
+import { dictionary } from '../services/dictionary.js';
+import { createRoom, getRoom, joinRoom, startBoard, submitWord } from './store.js';
+
+// In-memory characterization of multiplayer submitWord. The validate/derive/
+// dedupe/score middle now delegates to the shared engine core; these lock the
+// outcomes (including the rejected-word surfaced for the client toast) and the
+// in-memory player-aggregate update.
+describe('multiplayer submitWord (characterization)', () => {
+  // Starts a board and bypasses the pre-board countdown so words can land.
+  function liveBoard() {
+    const { code } = createRoom();
+    joinRoom(code, 'key-1', 'Alice', 'user-1');
+    startBoard(code, () => {});
+    const room = getRoom(code)!;
+    const player = room.players[0];
+    const board = room.currentBoard!;
+    board.startedAt = Date.now() - 1000; // past the countdown
+    player.status = 'playing';
+    const words = findAllWords(board.board, dictionary, board.config.minWordLength)
+      .sort((a, b) => a.word.length - b.word.length);
+    return { code, player, board, words };
+  }
+
+  it('accepts a valid word and updates the player aggregate', () => {
+    const { code, player, words } = liveBoard();
+    const short = words[0];
+    const long = words[words.length - 1];
+
+    const r1 = submitWord(code, player.id, short.path);
+    expect(r1?.outcome).toEqual({ valid: true, word: short.word, score: scoreWord(short.word) });
+    const r2 = submitWord(code, player.id, long.path);
+    expect(r2?.outcome).toEqual({ valid: true, word: long.word, score: scoreWord(long.word) });
+
+    expect(player.foundWords).toEqual([short.word, long.word]);
+    expect(player.points).toBe(scoreWord(short.word) + scoreWord(long.word));
+    expect(player.wordCount).toBe(2);
+  });
+
+  it('rejects a duplicate with reason "repeat" and surfaces the word', () => {
+    const { code, player, words } = liveBoard();
+    submitWord(code, player.id, words[0].path);
+    const dup = submitWord(code, player.id, words[0].path);
+    expect(dup?.outcome).toEqual({ valid: false, word: words[0].word, reason: 'repeat' });
+  });
+
+  it('rejects a non-adjacent path as invalid with no derived word', () => {
+    const { code, player, board } = liveBoard();
+    const last = board.config.boardSize - 1;
+    const res = submitWord(code, player.id, [{ row: 0, col: 0 }, { row: last, col: last }]);
+    expect(res?.outcome).toEqual({ valid: false, reason: 'invalid' });
+  });
+});

--- a/server/routes/freeplay.ts
+++ b/server/routes/freeplay.ts
@@ -8,7 +8,7 @@ import { cachePrivate } from '../httpCache.js';
 import { dictionary } from '../services/dictionary.js';
 import { getDisplayNames } from '../services/displayNames.js';
 import { computeChallengeNewResults } from '../services/FreePlayService.js';
-import { assignCompetitionRanks } from '../services/ranking.js';
+import { assignCompetitionRanks } from 'models/ranking';
 import { getDailyConfig } from '../services/dailyConfig.js';
 
 export const freeplayRouter = Router();

--- a/server/routes/leaderboard.ts
+++ b/server/routes/leaderboard.ts
@@ -4,7 +4,7 @@ import { getDb } from '../db/index.js';
 import { scoreWords } from '../services/DailyService.js';
 import { getDailyNumber } from '../services/dailyConfig.js';
 import { getDisplayNames } from '../services/displayNames.js';
-import { assignCompetitionRanks } from '../services/ranking.js';
+import { assignCompetitionRanks } from 'models/ranking';
 import { cachePrivate } from '../httpCache.js';
 
 export const leaderboardRouter = Router();

--- a/server/services/DailyGauntletService.test.ts
+++ b/server/services/DailyGauntletService.test.ts
@@ -54,9 +54,10 @@ describe('aggregateFromRoundRanks', () => {
     expect(out[1].aggregateRank).toBe(2);
   });
 
-  it('tiebreaks rank-sum ties on best single-round rank', () => {
-    // Both 'a' and 'b' have rank-sum 6, but 'a' has a 1st-place round
-    // while 'b' has no rank better than 2. Specialist wins.
+  it('shares a rank for an equal rank-sum; best single-round rank only orders the display', () => {
+    // Both 'a' and 'b' have rank-sum 6. 'a' has a 1st-place round while 'b'
+    // has no rank better than 2, so 'a' sorts ahead — but the equal rank-sum
+    // means they SHARE the aggregate rank rather than being split.
     const ranked: RankedRow[] = [
       row('a', 0, 1, '2026-05-21T12:00:00Z'),
       row('a', 1, 2, '2026-05-21T12:05:00Z'),
@@ -66,14 +67,14 @@ describe('aggregateFromRoundRanks', () => {
       row('b', 2, 2, '2026-05-21T12:10:00Z'),
     ];
     const out = aggregateFromRoundRanks(ranked, 3);
-    expect(out.map((e) => e.userId)).toEqual(['a', 'b']);
+    expect(out.map((e) => e.userId)).toEqual(['a', 'b']); // display order
     expect(out[0].aggregateRank).toBe(1);
-    expect(out[1].aggregateRank).toBe(2);
+    expect(out[1].aggregateRank).toBe(1); // tie on rank-sum → shared rank
   });
 
-  it('tiebreaks identical rank-sum + best-single on earliest last-finish', () => {
-    // 'a' and 'b' identical rank-sum (6) and best (2). 'a' finished round
-    // 2 earlier, so it places first.
+  it('shares a rank for an equal rank-sum; last-finish only orders the display', () => {
+    // 'a' and 'b' identical rank-sum (6) and best (2). 'a' finished round 2
+    // earlier, so it sorts first — but they still share the aggregate rank.
     const ranked: RankedRow[] = [
       row('a', 0, 2, '2026-05-21T12:00:00Z'),
       row('a', 1, 2, '2026-05-21T12:05:00Z'),
@@ -83,12 +84,14 @@ describe('aggregateFromRoundRanks', () => {
       row('b', 2, 2, '2026-05-21T12:15:00Z'),
     ];
     const out = aggregateFromRoundRanks(ranked, 3);
-    expect(out.map((e) => e.userId)).toEqual(['a', 'b']);
+    expect(out.map((e) => e.userId)).toEqual(['a', 'b']); // display order
+    expect(out[0].aggregateRank).toBe(1);
+    expect(out[1].aggregateRank).toBe(1); // tie on rank-sum → shared rank
   });
 
-  it('dense-ranks true ties (same rank-sum, best, and last-finish)', () => {
-    // Identical on all three keys → dense rank assigns same number to
-    // both; the next distinct player gets the next sequential rank.
+  it('competition-ranks rank-sum ties: equal share a place, the next distinct skips the gap (1,1,3)', () => {
+    // 'a' and 'b' both rank-sum 3; 'c' rank-sum 15. a & b share rank 1; c gets
+    // rank 3 (the gap left by the tie is skipped).
     const ranked: RankedRow[] = [
       row('a', 0, 1, '2026-05-21T12:00:00Z'),
       row('a', 1, 1, '2026-05-21T12:05:00Z'),
@@ -104,8 +107,6 @@ describe('aggregateFromRoundRanks', () => {
     const byUser = new Map(out.map((e) => [e.userId, e.aggregateRank]));
     expect(byUser.get('a')).toBe(1);
     expect(byUser.get('b')).toBe(1);
-    // Dense rank: the next distinct group takes index+1, not "rank after
-    // skipping ties". For 'c' that's position 3 (zero-indexed 2 → +1).
     expect(byUser.get('c')).toBe(3);
   });
 

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -309,7 +309,7 @@ export async function submitGauntletWord(
     scoreWord: (w) => scoreGauntletWord(w, session.modifier),
     score: (words) => scoreGauntletResult(words, session.modifier),
   });
-  if (!result.valid) return result;
+  if (!result.valid) return { valid: false, reason: result.reason };
 
   await db
     .updateTable('daily_gauntlet_results')

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -1,7 +1,6 @@
 import { sql, type Kysely } from 'kysely';
-import { isValidPath } from 'engine/adjacency.js';
-import { isValidWord } from 'engine/dictionary.js';
 import { scoreGauntletWord } from 'engine/gauntletScoring.js';
+import { validateSubmission } from 'engine/submission.js';
 import type { Position } from 'models';
 import { assignCompetitionRanks } from 'models/ranking';
 import {
@@ -301,35 +300,24 @@ export async function submitGauntletWord(
   if (!session) return { valid: false, reason: 'not_started' };
   if (session.endedAt) return { valid: false, reason: 'ended' };
 
-  if (!isValidPath(path, session.config.boardSize)) {
-    return { valid: false, reason: 'invalid' };
-  }
-
-  const word = path
-    .map((pos) => session.board[pos.row][pos.col])
-    .join('')
-    .toUpperCase();
-
-  if (word.length < session.config.minWordLength) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (!isValidWord(dictionary, word.toLowerCase())) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (session.foundWords.some((w) => w.toUpperCase() === word)) {
-    return { valid: false, reason: 'repeat' };
-  }
-
-  const nextWords = [...session.foundWords, word];
-  const { points, wordCount, longestWord } = scoreGauntletResult(nextWords, session.modifier);
+  const result = validateSubmission(path, {
+    board: session.board,
+    foundWords: session.foundWords,
+    boardSize: session.config.boardSize,
+    minWordLength: session.config.minWordLength,
+    dictionary,
+    scoreWord: (w) => scoreGauntletWord(w, session.modifier),
+    score: (words) => scoreGauntletResult(words, session.modifier),
+  });
+  if (!result.valid) return result;
 
   await db
     .updateTable('daily_gauntlet_results')
     .set({
-      found_words: JSON.stringify(nextWords),
-      points,
-      word_count: wordCount,
-      longest_word: longestWord,
+      found_words: JSON.stringify(result.nextWords),
+      points: result.aggregate.points,
+      word_count: result.aggregate.wordCount,
+      longest_word: result.aggregate.longestWord,
     })
     .where('user_id', '=', userId)
     .where('date', '=', date)
@@ -337,11 +325,7 @@ export async function submitGauntletWord(
     .where('ended_at', 'is', null)
     .execute();
 
-  return {
-    valid: true,
-    word,
-    score: scoreGauntletWord(word, session.modifier),
-  };
+  return { valid: true, word: result.word, score: result.score };
 }
 
 export async function endGauntletRound(

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -16,6 +16,7 @@ import {
 } from 'models/gauntlet';
 import type { Database } from '../db/types.js';
 import { dictionary } from './dictionary.js';
+import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
 import {
   getDailyGauntletNumber,
   prepareGauntletRound,
@@ -130,14 +131,18 @@ function isExpired(
   session: { startedAt: Date; config: { timeLimit: number } },
   now: Date,
 ): boolean {
-  const elapsed = Math.floor((now.getTime() - session.startedAt.getTime()) / 1000);
-  return elapsed > session.config.timeLimit + TIMED_GAUNTLET_GRACE_SECONDS;
+  return isTimedSessionExpired(
+    session.startedAt,
+    session.config.timeLimit,
+    TIMED_GAUNTLET_GRACE_SECONDS,
+    now,
+  );
 }
 
 function expiryInstant(
   session: { startedAt: Date; config: { timeLimit: number } },
 ): Date {
-  return new Date(session.startedAt.getTime() + session.config.timeLimit * 1000);
+  return timedExpiryInstant(session.startedAt, session.config.timeLimit);
 }
 
 async function autoFinalizeIfExpired(

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -3,6 +3,7 @@ import { isValidPath } from 'engine/adjacency.js';
 import { isValidWord } from 'engine/dictionary.js';
 import { scoreGauntletWord } from 'engine/gauntletScoring.js';
 import type { Position } from 'models';
+import { assignCompetitionRanks } from 'models/ranking';
 import {
   GAUNTLET_ROUND_COUNT,
   type GauntletEntry,
@@ -465,36 +466,30 @@ export function aggregateFromRoundRanks(
     });
   }
 
+  // best single-round rank, then earliest last-finish, order the displayed
+  // list among players who share a rank-sum — but they do NOT split the rank.
   entries.sort((a, b) => {
     if (a.rankSum !== b.rankSum) return a.rankSum - b.rankSum;
     if (a.bestSingleRank !== b.bestSingleRank) return a.bestSingleRank - b.bestSingleRank;
     return a.lastFinishedAt.getTime() - b.lastFinishedAt.getTime();
   });
 
-  // Dense-rank by (rankSum, bestSingleRank, lastFinishedAt) so tied
-  // players share a rank. The trio is unique enough in practice that
-  // pure ties are rare, but keeping dense-rank semantics avoids
-  // surprising the player who is "tied for 3rd" with a 4th-place display.
-  let lastKey = '';
-  let lastRank = 0;
-  for (let i = 0; i < entries.length; i++) {
-    const e = entries[i];
-    const key = `${e.rankSum}|${e.bestSingleRank}|${e.lastFinishedAt.getTime()}`;
-    if (key !== lastKey) {
-      lastRank = i + 1;
-      lastKey = key;
-    }
-    e.aggregateRank = lastRank;
+  // Rank on rank-sum alone via the shared competition-rank helper: players with
+  // an equal rank-sum share a place (1, 1, 3), the same tie rule the per-round
+  // ranks and every other leaderboard use. The sort keys above only fix the
+  // display order within a tie; they no longer break the rank.
+  for (const { item, rank } of assignCompetitionRanks(entries, (e) => e.rankSum)) {
+    item.aggregateRank = rank;
   }
 
   return entries;
 }
 
 // Aggregate ranks across all 3 rounds. Only includes players who have
-// finalized all three rounds. Tiebreak order:
-//   primary:    rankSum asc (lower = better — the gauntlet "score")
-//   secondary:  best single-round rank (rewards specialists when tied)
-//   tertiary:   last-round completed_at asc (earliest finisher wins)
+// finalized all three rounds. Placement is by rankSum asc (lower = better —
+// the gauntlet "score"); players with an equal rankSum share a rank. Best
+// single-round rank, then earliest last-finish, only order the display within
+// a tie — they do not split the rank.
 export async function getGauntletAggregate(
   db: Kysely<Database>,
   date: string,

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -5,6 +5,7 @@ import { validateSubmission } from 'engine/submission.js';
 import type { Database } from '../db/types.js';
 import { dictionary } from './dictionary.js';
 import { getDailyConfig, type DailyConfig } from './dailyConfig.js';
+import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
 
 export interface ScoredResult {
   points: number;
@@ -509,12 +510,16 @@ function isExpired(
   session: { started_at: Date; time_limit: number },
   now: Date,
 ): boolean {
-  const elapsed = Math.floor((now.getTime() - session.started_at.getTime()) / 1000);
-  return elapsed > session.time_limit + TIMED_DAILY_GRACE_SECONDS;
+  return isTimedSessionExpired(
+    session.started_at,
+    session.time_limit,
+    TIMED_DAILY_GRACE_SECONDS,
+    now,
+  );
 }
 
 function expiryInstant(session: { started_at: Date; time_limit: number }): Date {
-  return new Date(session.started_at.getTime() + session.time_limit * 1000);
+  return timedExpiryInstant(session.started_at, session.time_limit);
 }
 
 async function autoFinalizeIfExpired(

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -609,6 +609,7 @@ export async function submitTimedDailyWord(
     boardSize: config.boardSize,
     minWordLength: config.minWordLength,
     dictionary,
+    scoreWord,
     score: scoreResult,
   });
   if (!result.valid) return result;

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -612,7 +612,7 @@ export async function submitTimedDailyWord(
     scoreWord,
     score: scoreResult,
   });
-  if (!result.valid) return result;
+  if (!result.valid) return { valid: false, reason: result.reason };
 
   await db
     .updateTable('daily_results')

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -1,8 +1,7 @@
 import { sql, type Kysely } from 'kysely';
 import type { Position } from 'models';
-import { isValidPath } from 'engine/adjacency.js';
-import { isValidWord } from 'engine/dictionary.js';
 import { scoreWord } from 'engine/scoring.js';
+import { validateSubmission } from 'engine/submission.js';
 import type { Database } from '../db/types.js';
 import { dictionary } from './dictionary.js';
 import { getDailyConfig, type DailyConfig } from './dailyConfig.js';
@@ -604,42 +603,30 @@ export async function submitTimedDailyWord(
   if (session.ended_at) return { valid: false, reason: 'ended' };
 
   const config = getDailyConfig(date);
-  if (!isValidPath(path, config.boardSize)) {
-    return { valid: false, reason: 'invalid' };
-  }
-
-  const word = path
-    .map((pos) => session.board[pos.row][pos.col])
-    .join('')
-    .toUpperCase();
-
-  if (word.length < config.minWordLength) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (!isValidWord(dictionary, word.toLowerCase())) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (session.found_words.some((w) => w.toUpperCase() === word)) {
-    return { valid: false, reason: 'repeat' };
-  }
-
-  const nextWords = [...session.found_words, word];
-  const { points, wordCount, longestWord } = scoreResult(nextWords);
+  const result = validateSubmission(path, {
+    board: session.board,
+    foundWords: session.found_words,
+    boardSize: config.boardSize,
+    minWordLength: config.minWordLength,
+    dictionary,
+    score: scoreResult,
+  });
+  if (!result.valid) return result;
 
   await db
     .updateTable('daily_results')
     .set({
-      found_words: JSON.stringify(nextWords),
-      points,
-      word_count: wordCount,
-      longest_word: longestWord,
+      found_words: JSON.stringify(result.nextWords),
+      points: result.aggregate.points,
+      word_count: result.aggregate.wordCount,
+      longest_word: result.aggregate.longestWord,
     })
     .where('user_id', '=', userId)
     .where('date', '=', date)
     .where('ended_at', 'is', null)
     .execute();
 
-  return { valid: true, word, score: scoreWord(word) };
+  return { valid: true, word: result.word, score: result.score };
 }
 
 // Player-triggered finalize. Caps the recorded completion at

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -160,7 +160,7 @@ export async function submitWord(
     scoreWord,
     score: scoreResult,
   });
-  if (!result.valid) return result;
+  if (!result.valid) return { valid: false, reason: result.reason };
 
   // Gap-capped active-time accumulation: credit min(elapsed, CAP) seconds
   // for the gap since the last word submission. The cap prevents long

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -1,5 +1,6 @@
 import { sql, type Kysely } from 'kysely';
 import type { Position } from 'models';
+import { assignCompetitionRanks } from 'models/ranking';
 import { isValidPath } from 'engine/adjacency.js';
 import { isValidWord } from 'engine/dictionary.js';
 import { scoreWord } from 'engine/scoring.js';
@@ -518,8 +519,18 @@ export async function getZenLeaderboard(
       isCompetitive: e.isCompetitive,
     }));
 
-  const byPoints = [...ranked].sort((a, b) => b.points - a.points || b.wordCount - a.wordCount);
-  const byWords = [...ranked].sort((a, b) => b.wordCount - a.wordCount || b.points - a.points);
+  // Competition ranking: players with equal scores share a rank. The secondary
+  // sort key still orders the displayed list (so equal-point players appear in
+  // a stable order), but it does not split their rank — two players who see the
+  // same number see the same place, matching the daily/free-play leaderboards.
+  const byPoints = assignCompetitionRanks(
+    [...ranked].sort((a, b) => b.points - a.points || b.wordCount - a.wordCount),
+    (e) => e.points,
+  );
+  const byWords = assignCompetitionRanks(
+    [...ranked].sort((a, b) => b.wordCount - a.wordCount || b.points - a.points),
+    (e) => e.wordCount,
+  );
 
   let currentPlayer: ZenLeaderboardCurrentPlayer | null = null;
   if (requestingUserId) {
@@ -531,9 +542,9 @@ export async function getZenLeaderboard(
       let rank: number | null = null;
       let ranked = false;
       if (myRow.isCompetitive && !myRow.inProgress) {
-        const idx = byPoints.findIndex((e) => e.userId === requestingUserId);
-        if (idx >= 0) {
-          rank = idx + 1;
+        const entry = byPoints.find(({ item }) => item.userId === requestingUserId);
+        if (entry) {
+          rank = entry.rank;
           ranked = true;
         }
       }
@@ -562,16 +573,16 @@ export async function getZenLeaderboard(
     inProgressCount: inProgressPlayers.length,
     avgScore,
     rankings: {
-      points: byPoints.map((e, i) => ({
-        rank: i + 1,
+      points: byPoints.map(({ item: e, rank }) => ({
+        rank,
         userId: e.userId,
         displayName: e.displayName,
         points: e.points,
         wordCount: e.wordCount,
         longestWord: e.longestWord,
       })),
-      words: byWords.map((e, i) => ({
-        rank: i + 1,
+      words: byWords.map(({ item: e, rank }) => ({
+        rank,
         userId: e.userId,
         displayName: e.displayName,
         points: e.points,

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -157,6 +157,7 @@ export async function submitWord(
     boardSize: config.boardSize,
     minWordLength: config.minWordLength,
     dictionary,
+    scoreWord,
     score: scoreResult,
   });
   if (!result.valid) return result;

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -1,10 +1,9 @@
 import { sql, type Kysely } from 'kysely';
 import type { Position } from 'models';
 import { assignCompetitionRanks } from 'models/ranking';
-import { isValidPath } from 'engine/adjacency.js';
-import { isValidWord } from 'engine/dictionary.js';
 import { scoreWord } from 'engine/scoring.js';
 import { findAllWords } from 'engine/solver.js';
+import { validateSubmission } from 'engine/submission.js';
 import type { Database } from '../db/types.js';
 import { dictionary } from './dictionary.js';
 import { getDisplayNames } from './displayNames.js';
@@ -152,28 +151,15 @@ export async function submitWord(
   if (session.ended_at) return { valid: false, reason: 'ended' };
 
   const config = getDailyZenConfig(date);
-
-  if (!isValidPath(path, config.boardSize)) {
-    return { valid: false, reason: 'invalid' };
-  }
-
-  const word = path
-    .map((pos) => session.board[pos.row][pos.col])
-    .join('')
-    .toUpperCase();
-
-  if (word.length < config.minWordLength) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (!isValidWord(dictionary, word.toLowerCase())) {
-    return { valid: false, reason: 'invalid' };
-  }
-  if (session.found_words.some((w) => w.toUpperCase() === word)) {
-    return { valid: false, reason: 'repeat' };
-  }
-
-  const nextWords = [...session.found_words, word];
-  const { points, wordCount, longestWord } = scoreResult(nextWords);
+  const result = validateSubmission(path, {
+    board: session.board,
+    foundWords: session.found_words,
+    boardSize: config.boardSize,
+    minWordLength: config.minWordLength,
+    dictionary,
+    score: scoreResult,
+  });
+  if (!result.valid) return result;
 
   // Gap-capped active-time accumulation: credit min(elapsed, CAP) seconds
   // for the gap since the last word submission. The cap prevents long
@@ -189,11 +175,11 @@ export async function submitWord(
   await db
     .updateTable('daily_zen_results')
     .set({
-      found_words: JSON.stringify(nextWords),
+      found_words: JSON.stringify(result.nextWords),
       last_active_at: now,
-      points,
-      word_count: wordCount,
-      longest_word: longestWord,
+      points: result.aggregate.points,
+      word_count: result.aggregate.wordCount,
+      longest_word: result.aggregate.longestWord,
       active_seconds: sql<number>`active_seconds + ${creditSec}`,
     })
     .where('user_id', '=', userId)
@@ -201,7 +187,7 @@ export async function submitWord(
     .where('ended_at', 'is', null)
     .execute();
 
-  return { valid: true, word, score: scoreWord(word) };
+  return { valid: true, word: result.word, score: result.score };
 }
 
 export async function endSession(

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -320,7 +320,7 @@ export async function submitFreePlayWord(
       scoreWord,
       score: scoreResult,
     });
-    if (!result.valid) return result;
+    if (!result.valid) return { valid: false, reason: result.reason };
 
     const updated = await trx
       .updateTable('free_play_sessions')

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -11,6 +11,7 @@ import type { RoomBoardCompletion } from '../multiplayer/store.js';
 import { dictionary } from './dictionary.js';
 import { getDailyDatePST } from './dailyConfig.js';
 import { scoreResult } from './DailyService.js';
+import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
 
 // Counts challenge participants whose completions are unseen by the
 // originator. A row counts as "unseen" when it isn't the originator's
@@ -131,13 +132,16 @@ function isExpired(
   session: { started_at: Date; time_limit: number },
   now: Date,
 ): boolean {
-  if (session.time_limit <= 0) return false;
-  const elapsed = Math.floor((now.getTime() - session.started_at.getTime()) / 1000);
-  return elapsed > session.time_limit + FREE_PLAY_GRACE_SECONDS;
+  return isTimedSessionExpired(
+    session.started_at,
+    session.time_limit,
+    FREE_PLAY_GRACE_SECONDS,
+    now,
+  );
 }
 
 function expiryInstant(session: { started_at: Date; time_limit: number }): Date {
-  return new Date(session.started_at.getTime() + session.time_limit * 1000);
+  return timedExpiryInstant(session.started_at, session.time_limit);
 }
 
 const SESSION_COLUMNS = [

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -1,11 +1,10 @@
 import crypto from 'crypto';
 import type { Kysely } from 'kysely';
 import { generateSalt, hashWord, type Position } from 'models';
-import { isValidPath } from 'engine/adjacency.js';
-import { isValidWord } from 'engine/dictionary.js';
 import { findAllWords } from 'engine/solver.js';
 import { scoreWord } from 'engine/scoring.js';
 import { generateSeededBoard } from 'engine/board.js';
+import { validateSubmission } from 'engine/submission.js';
 import { randomSeed } from 'models/seedCode';
 import type { Database } from '../db/types.js';
 import type { RoomBoardCompletion } from '../multiplayer/store.js';
@@ -312,35 +311,24 @@ export async function submitFreePlayWord(
       return { valid: false, reason: 'expired' };
     }
 
-    if (!isValidPath(path, session.board_size)) {
-      return { valid: false, reason: 'invalid' };
-    }
+    const result = validateSubmission(path, {
+      board: session.board,
+      foundWords: session.found_words,
+      boardSize: session.board_size,
+      minWordLength: session.min_word_length,
+      dictionary,
+      scoreWord,
+      score: scoreResult,
+    });
+    if (!result.valid) return result;
 
-    const word = path
-      .map((pos) => session.board[pos.row][pos.col])
-      .join('')
-      .toUpperCase();
-
-    if (word.length < session.min_word_length) {
-      return { valid: false, reason: 'invalid' };
-    }
-    if (!isValidWord(dictionary, word.toLowerCase())) {
-      return { valid: false, reason: 'invalid' };
-    }
-    if (session.found_words.some((w) => w.toUpperCase() === word)) {
-      return { valid: false, reason: 'repeat' };
-    }
-
-    const nextWords = [...session.found_words, word];
-    const { points, wordCount, longestWord } = scoreResult(nextWords);
-
-    const result = await trx
+    const updated = await trx
       .updateTable('free_play_sessions')
       .set({
-        found_words: JSON.stringify(nextWords),
-        points,
-        word_count: wordCount,
-        longest_word: longestWord,
+        found_words: JSON.stringify(result.nextWords),
+        points: result.aggregate.points,
+        word_count: result.aggregate.wordCount,
+        longest_word: result.aggregate.longestWord,
       })
       .where('id', '=', session.id)
       .where('completed_at', 'is', null)
@@ -350,11 +338,11 @@ export async function submitFreePlayWord(
     // update landing (e.g. /end ran in another connection that beat the
     // lock), the update affects zero rows. Don't claim the word was
     // accepted in that case.
-    if (Number(result.numUpdatedRows ?? 0) === 0) {
+    if (Number(updated.numUpdatedRows ?? 0) === 0) {
       return { valid: false, reason: 'ended' };
     }
 
-    return { valid: true, word, score: scoreWord(word) };
+    return { valid: true, word: result.word, score: result.score };
   });
 }
 

--- a/server/services/dailyLifecycle.characterization.test.ts
+++ b/server/services/dailyLifecycle.characterization.test.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from 'crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { scoreWord } from 'engine/scoring.js';
+import { dockerAvailable, startTestDb, type TestDb } from '../test/pgHarness.js';
+import { boardWithWords } from '../test/fixtures.js';
+import { getDailyConfig } from './dailyConfig.js';
+import {
+  endTimedDailySession,
+  getTimedDailySession,
+  startTimedDailySession,
+  submitTimedDailyWord,
+} from './DailyService.js';
+
+// Legacy date → fixed config (5x5, minWordLength 4, 120s). submit derives its
+// config from getDailyConfig(date), so the fixture board must match this.
+const DATE = '2026-04-15';
+const config = getDailyConfig(DATE);
+
+// Characterization of the timed-daily submit + finalize lifecycle as it
+// behaves today, ahead of the Level-A extraction. These assertions must keep
+// passing identically after submitTimedDailyWord/endTimedDailySession are
+// reimplemented on the shared session core.
+describe.runIf(dockerAvailable())('timed daily lifecycle (characterization, DB)', () => {
+  let h: TestDb;
+  beforeAll(async () => {
+    h = await startTestDb();
+  }, 180_000);
+  afterAll(async () => {
+    await h?.stop();
+  });
+  beforeEach(async () => {
+    await h.truncateAll();
+  });
+
+  it('accepts a valid word and updates points/wordCount/longestWord', async () => {
+    const { board, words } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startTimedDailySession(h.db, userId, DATE, board, config);
+
+    const short = words[0];
+    const long = words[words.length - 1];
+
+    const r1 = await submitTimedDailyWord(h.db, userId, DATE, short.path);
+    expect(r1).toMatchObject({ valid: true, word: short.word, score: scoreWord(short.word) });
+
+    const r2 = await submitTimedDailyWord(h.db, userId, DATE, long.path);
+    expect(r2).toMatchObject({ valid: true, word: long.word });
+
+    const session = await getTimedDailySession(h.db, userId, DATE);
+    expect(session?.found_words).toEqual([short.word, long.word]);
+    expect(session?.points).toBe(scoreWord(short.word) + scoreWord(long.word));
+    expect(session?.word_count).toBe(2);
+    expect(session?.longest_word).toBe(long.word);
+  });
+
+  it('rejects a duplicate submission with reason "repeat"', async () => {
+    const { board, words } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startTimedDailySession(h.db, userId, DATE, board, config);
+
+    await submitTimedDailyWord(h.db, userId, DATE, words[0].path);
+    const dup = await submitTimedDailyWord(h.db, userId, DATE, words[0].path);
+    expect(dup).toEqual({ valid: false, reason: 'repeat' });
+  });
+
+  it('rejects a sub-minimum-length path with reason "invalid"', async () => {
+    const { board, words } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startTimedDailySession(h.db, userId, DATE, board, config);
+
+    // A single cell derives a one-letter "word", below minWordLength.
+    const res = await submitTimedDailyWord(h.db, userId, DATE, [words[0].path[0]]);
+    expect(res).toEqual({ valid: false, reason: 'invalid' });
+  });
+
+  it('player finalize on a fresh session stamps ended_at at ~now (below the cap)', async () => {
+    const { board } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    const started = await startTimedDailySession(h.db, userId, DATE, board, config);
+
+    const before = Date.now();
+    const ended = await endTimedDailySession(h.db, userId, DATE);
+    const after = Date.now();
+
+    expect(ended?.ended_at).not.toBeNull();
+    const endedMs = ended!.ended_at!.getTime();
+    expect(endedMs).toBeGreaterThanOrEqual(before - 1000);
+    expect(endedMs).toBeLessThanOrEqual(after + 1000);
+    // Below the hard cap of started_at + time_limit.
+    expect(endedMs).toBeLessThan(started.started_at.getTime() + config.timeLimit * 1000);
+  });
+
+  it('auto-finalizes an expired session on read, capped at started_at + time_limit', async () => {
+    const { board } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startTimedDailySession(h.db, userId, DATE, board, config);
+
+    // Backdate the start so the session is well past time_limit + grace.
+    const pastStart = new Date(Date.now() - (config.timeLimit + 60) * 1000);
+    await h.db
+      .updateTable('daily_results')
+      .set({ started_at: pastStart })
+      .where('user_id', '=', userId)
+      .where('date', '=', DATE)
+      .execute();
+
+    const session = await getTimedDailySession(h.db, userId, DATE);
+    expect(session?.ended_at).not.toBeNull();
+    // Capped exactly at started_at + time_limit, not "now".
+    expect(session!.ended_at!.getTime()).toBe(pastStart.getTime() + config.timeLimit * 1000);
+  });
+});

--- a/server/services/freePlayLifecycle.characterization.test.ts
+++ b/server/services/freePlayLifecycle.characterization.test.ts
@@ -80,4 +80,31 @@ describe.runIf(dockerAvailable())('free-play lifecycle (characterization, DB)', 
     const res = await submitFreePlayWord(h.db, userId, [words[0].path[0]]);
     expect(res).toEqual({ valid: false, reason: 'invalid' });
   });
+
+  it('auto-finalizes an expired session on submit, capped at started_at + time_limit', async () => {
+    const { board, words } = boardWithWords(BOARD_SIZE, MIN_WORD_LENGTH);
+    const userId = randomUUID();
+    await start(userId, board);
+
+    // Backdate the start so the 120s session is well past time_limit + grace.
+    const pastStart = new Date(Date.now() - (120 + 30) * 1000);
+    await h.db
+      .updateTable('free_play_sessions')
+      .set({ started_at: pastStart })
+      .where('user_id', '=', userId)
+      .where('completed_at', 'is', null)
+      .execute();
+
+    const res = await submitFreePlayWord(h.db, userId, words[0].path);
+    expect(res).toEqual({ valid: false, reason: 'expired' });
+
+    const row = await h.db
+      .selectFrom('free_play_sessions')
+      .select(['completed_at'])
+      .where('user_id', '=', userId)
+      .executeTakeFirstOrThrow();
+    expect(row.completed_at).not.toBeNull();
+    // Capped exactly at started_at + time_limit, not "now".
+    expect(row.completed_at!.getTime()).toBe(pastStart.getTime() + 120 * 1000);
+  });
 });

--- a/server/services/freePlayLifecycle.characterization.test.ts
+++ b/server/services/freePlayLifecycle.characterization.test.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from 'crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { scoreWord } from 'engine/scoring.js';
+import { dockerAvailable, startTestDb, type TestDb } from '../test/pgHarness.js';
+import { boardWithWords } from '../test/fixtures.js';
+import { startFreePlaySession, submitFreePlayWord } from './FreePlayService.js';
+
+const BOARD_SIZE = 5;
+const MIN_WORD_LENGTH = 4;
+
+// Characterizes free-play (solo) submit ahead of / alongside the move onto the
+// shared validateSubmission core. The FOR UPDATE transaction and finalize paths
+// stay in the service; only the validate/derive/score middle is shared.
+describe.runIf(dockerAvailable())('free-play lifecycle (characterization, DB)', () => {
+  let h: TestDb;
+  beforeAll(async () => {
+    h = await startTestDb();
+  }, 180_000);
+  afterAll(async () => {
+    await h?.stop();
+  });
+  beforeEach(async () => {
+    await h.truncateAll();
+  });
+
+  function start(userId: string, board: string[][]) {
+    return startFreePlaySession(h.db, {
+      userId,
+      durationSeconds: 120,
+      boardSize: BOARD_SIZE,
+      minWordLength: MIN_WORD_LENGTH,
+      predefinedBoard: board,
+      challengeId: null,
+    });
+  }
+
+  async function aggregates(userId: string) {
+    return h.db
+      .selectFrom('free_play_sessions')
+      .select(['points', 'word_count', 'longest_word'])
+      .where('user_id', '=', userId)
+      .where('completed_at', 'is', null)
+      .executeTakeFirstOrThrow();
+  }
+
+  it('accepts a valid word and updates points/wordCount/longestWord', async () => {
+    const { board, words } = boardWithWords(BOARD_SIZE, MIN_WORD_LENGTH);
+    const userId = randomUUID();
+    await start(userId, board);
+
+    const short = words[0];
+    const long = words[words.length - 1];
+
+    const r1 = await submitFreePlayWord(h.db, userId, short.path);
+    expect(r1).toMatchObject({ valid: true, word: short.word, score: scoreWord(short.word) });
+    const r2 = await submitFreePlayWord(h.db, userId, long.path);
+    expect(r2).toMatchObject({ valid: true, word: long.word });
+
+    const agg = await aggregates(userId);
+    expect(agg.points).toBe(scoreWord(short.word) + scoreWord(long.word));
+    expect(agg.word_count).toBe(2);
+    expect(agg.longest_word).toBe(long.word);
+  });
+
+  it('rejects a duplicate submission with reason "repeat"', async () => {
+    const { board, words } = boardWithWords(BOARD_SIZE, MIN_WORD_LENGTH);
+    const userId = randomUUID();
+    await start(userId, board);
+
+    await submitFreePlayWord(h.db, userId, words[0].path);
+    const dup = await submitFreePlayWord(h.db, userId, words[0].path);
+    expect(dup).toEqual({ valid: false, reason: 'repeat' });
+  });
+
+  it('rejects a sub-minimum-length path with reason "invalid"', async () => {
+    const { board, words } = boardWithWords(BOARD_SIZE, MIN_WORD_LENGTH);
+    const userId = randomUUID();
+    await start(userId, board);
+
+    const res = await submitFreePlayWord(h.db, userId, [words[0].path[0]]);
+    expect(res).toEqual({ valid: false, reason: 'invalid' });
+  });
+});

--- a/server/services/gauntletRanks.characterization.test.ts
+++ b/server/services/gauntletRanks.characterization.test.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from 'crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { scoreWord } from 'engine/scoring.js';
 import { dockerAvailable, startTestDb, type TestDb } from '../test/pgHarness.js';
-import { getGauntletAggregate, getGauntletRoundRanks } from './DailyGauntletService.js';
+import { boardWithWords } from '../test/fixtures.js';
+import {
+  getGauntletAggregate,
+  getGauntletRoundRanks,
+  submitGauntletWord,
+} from './DailyGauntletService.js';
 
 const DATE = '2026-05-21';
 const DUMMY_BOARD = JSON.stringify(
@@ -32,6 +38,25 @@ async function gauntletRow(
       time_limit: 90,
       ended_at: ts,
       completed_at: ts,
+    })
+    .execute();
+}
+
+// Inserts an in-progress (not-yet-ended) round with a real fixture board so
+// submitGauntletWord can validate genuine paths against it.
+async function startedRound(h: TestDb, userId: string, board: string[][]) {
+  await h.db
+    .insertInto('daily_gauntlet_results')
+    .values({
+      user_id: userId,
+      date: DATE,
+      round_index: 0,
+      round_kind: 'regular',
+      board: JSON.stringify(board),
+      modifier: MODIFIER,
+      board_size: 5,
+      min_word_length: 4,
+      time_limit: 90,
     })
     .execute();
 }
@@ -79,5 +104,41 @@ describe.runIf(dockerAvailable())('gauntlet ranks (characterization, DB)', () =>
     const agg = await getGauntletAggregate(h.db, DATE);
     expect(agg.map((e) => e.aggregateRank)).toEqual([1, 1]);
     expect(agg.every((e) => e.rankSum === 3)).toBe(true);
+  });
+
+  it('submit accepts a valid word and updates aggregates (regular modifier)', async () => {
+    const { board, words } = boardWithWords(5, 4);
+    const userId = randomUUID();
+    await startedRound(h, userId, board);
+
+    const short = words[0];
+    const long = words[words.length - 1];
+
+    const r1 = await submitGauntletWord(h.db, userId, DATE, 0, short.path);
+    expect(r1).toMatchObject({ valid: true, word: short.word, score: scoreWord(short.word) });
+    const r2 = await submitGauntletWord(h.db, userId, DATE, 0, long.path);
+    expect(r2).toMatchObject({ valid: true, word: long.word });
+
+    const row = await h.db
+      .selectFrom('daily_gauntlet_results')
+      .select(['points', 'word_count', 'longest_word'])
+      .where('user_id', '=', userId)
+      .where('date', '=', DATE)
+      .where('round_index', '=', 0)
+      .executeTakeFirstOrThrow();
+    // 'regular' modifier scores identically to the base scorer.
+    expect(row.points).toBe(scoreWord(short.word) + scoreWord(long.word));
+    expect(row.word_count).toBe(2);
+    expect(row.longest_word).toBe(long.word);
+  });
+
+  it('submit rejects a duplicate with reason "repeat"', async () => {
+    const { board, words } = boardWithWords(5, 4);
+    const userId = randomUUID();
+    await startedRound(h, userId, board);
+
+    await submitGauntletWord(h.db, userId, DATE, 0, words[0].path);
+    const dup = await submitGauntletWord(h.db, userId, DATE, 0, words[0].path);
+    expect(dup).toEqual({ valid: false, reason: 'repeat' });
   });
 });

--- a/server/services/gauntletRanks.characterization.test.ts
+++ b/server/services/gauntletRanks.characterization.test.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from 'crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { dockerAvailable, startTestDb, type TestDb } from '../test/pgHarness.js';
+import { getGauntletAggregate, getGauntletRoundRanks } from './DailyGauntletService.js';
+
+const DATE = '2026-05-21';
+const DUMMY_BOARD = JSON.stringify(
+  Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => 'A')),
+);
+const MODIFIER = JSON.stringify({ kind: 'regular' });
+
+async function gauntletRow(
+  h: TestDb,
+  userId: string,
+  roundIndex: number,
+  points: number,
+  completedAt: string,
+) {
+  const ts = new Date(completedAt);
+  await h.db
+    .insertInto('daily_gauntlet_results')
+    .values({
+      user_id: userId,
+      date: DATE,
+      round_index: roundIndex,
+      round_kind: 'regular',
+      board: DUMMY_BOARD,
+      modifier: MODIFIER,
+      points,
+      board_size: 5,
+      min_word_length: 4,
+      time_limit: 90,
+      ended_at: ts,
+      completed_at: ts,
+    })
+    .execute();
+}
+
+// Confirms the gauntlet rank surfaces tie correctly end-to-end through the DB:
+// per-round ranks share a place on equal points, and the aggregate shares a
+// place on equal rank-sum.
+describe.runIf(dockerAvailable())('gauntlet ranks (characterization, DB)', () => {
+  let h: TestDb;
+  beforeAll(async () => {
+    h = await startTestDb();
+  }, 180_000);
+  afterAll(async () => {
+    await h?.stop();
+  });
+  beforeEach(async () => {
+    await h.truncateAll();
+  });
+
+  it('per-round ranks share a place for equal points (1, 1, 3)', async () => {
+    const u1 = randomUUID();
+    const u2 = randomUUID();
+    const u3 = randomUUID();
+    await gauntletRow(h, u1, 0, 10, '2026-05-21T12:00:00Z');
+    await gauntletRow(h, u2, 0, 10, '2026-05-21T12:01:00Z'); // tie with u1
+    await gauntletRow(h, u3, 0, 5, '2026-05-21T12:02:00Z');
+
+    const ranks = await getGauntletRoundRanks(h.db, DATE);
+    const byUser = new Map(ranks.map((r) => [r.user_id, r.rank]));
+    expect(byUser.get(u1)).toBe(1);
+    expect(byUser.get(u2)).toBe(1); // shared place on equal points
+    expect(byUser.get(u3)).toBe(3); // gap skipped
+  });
+
+  it('aggregate shares a place for an equal rank-sum across all rounds', async () => {
+    const u1 = randomUUID();
+    const u2 = randomUUID();
+    // Both finish all three rounds tied on points every round → identical
+    // per-round ranks → identical rank-sum → shared aggregate rank.
+    for (let round = 0; round < 3; round++) {
+      await gauntletRow(h, u1, round, 10, `2026-05-21T12:0${round}:00Z`);
+      await gauntletRow(h, u2, round, 10, `2026-05-21T12:1${round}:00Z`);
+    }
+
+    const agg = await getGauntletAggregate(h.db, DATE);
+    expect(agg.map((e) => e.aggregateRank)).toEqual([1, 1]);
+    expect(agg.every((e) => e.rankSum === 3)).toBe(true);
+  });
+});

--- a/server/services/ranking.test.ts
+++ b/server/services/ranking.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { assignCompetitionRanks } from './ranking.js';
+
+// Characterization: locks the current standard-competition-rank behavior
+// ("1, 1, 3" — equal scores share a rank, the next distinct score skips the
+// gap) before this helper moves to models/. After the move these same
+// assertions must hold against the relocated implementation, byte-for-byte.
+describe('assignCompetitionRanks (characterization)', () => {
+  const ranksOf = (scores: number[]) =>
+    assignCompetitionRanks(
+      scores.map((points) => ({ points })),
+      (p) => p.points,
+    ).map((r) => r.rank);
+
+  it('returns empty for empty input', () => {
+    expect(assignCompetitionRanks([], (x: number) => x)).toEqual([]);
+  });
+
+  it('ranks a strictly-descending field 1,2,3', () => {
+    expect(ranksOf([30, 20, 10])).toEqual([1, 2, 3]);
+  });
+
+  it('shares a rank for a tie and skips the gap (1,1,3)', () => {
+    expect(ranksOf([20, 20, 10])).toEqual([1, 1, 3]);
+  });
+
+  it('gives every player rank 1 when all scores are equal', () => {
+    expect(ranksOf([15, 15, 15])).toEqual([1, 1, 1]);
+  });
+
+  it('handles a trailing tie (1,2,2)', () => {
+    expect(ranksOf([30, 20, 20])).toEqual([1, 2, 2]);
+  });
+
+  it('handles multiple tie groups (1,1,3,3,5)', () => {
+    expect(ranksOf([20, 20, 10, 10, 5])).toEqual([1, 1, 3, 3, 5]);
+  });
+
+  it('ranks a single player first', () => {
+    expect(ranksOf([42])).toEqual([1]);
+  });
+
+  it('preserves the original items alongside their ranks', () => {
+    const items = [{ id: 'a', points: 9 }, { id: 'b', points: 9 }];
+    const out = assignCompetitionRanks(items, (p) => p.points);
+    expect(out).toEqual([
+      { item: { id: 'a', points: 9 }, rank: 1 },
+      { item: { id: 'b', points: 9 }, rank: 1 },
+    ]);
+  });
+});

--- a/server/services/sessionTiming.test.ts
+++ b/server/services/sessionTiming.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
+
+const start = new Date('2026-06-15T12:00:00.000Z');
+const at = (secondsAfterStart: number) =>
+  new Date(start.getTime() + secondsAfterStart * 1000);
+
+describe('isTimedSessionExpired', () => {
+  it('never expires when the limit is non-positive (unlimited game)', () => {
+    expect(isTimedSessionExpired(start, 0, 2, at(10_000))).toBe(false);
+    expect(isTimedSessionExpired(start, -1, 2, at(10_000))).toBe(false);
+  });
+
+  it('is not expired within the limit', () => {
+    expect(isTimedSessionExpired(start, 120, 2, at(100))).toBe(false);
+  });
+
+  it('is not expired during the grace window just past the limit', () => {
+    expect(isTimedSessionExpired(start, 120, 2, at(121))).toBe(false);
+    expect(isTimedSessionExpired(start, 120, 2, at(122))).toBe(false); // limit+grace exactly
+  });
+
+  it('is expired once elapsed exceeds limit + grace', () => {
+    expect(isTimedSessionExpired(start, 120, 2, at(123))).toBe(true);
+  });
+});
+
+describe('timedExpiryInstant', () => {
+  it('caps at started_at + limit (no grace)', () => {
+    expect(timedExpiryInstant(start, 120).toISOString()).toBe('2026-06-15T12:02:00.000Z');
+  });
+});

--- a/server/services/sessionTiming.ts
+++ b/server/services/sessionTiming.ts
@@ -1,0 +1,26 @@
+// Shared expiry math for timed sessions (daily, free-play, gauntlet). One copy
+// instead of three near-identical ones, so the rule can't drift between modes.
+//
+// A non-positive limit never expires — that's free-play's "unlimited" game.
+// Otherwise the session is expired once elapsed time exceeds the limit plus the
+// mode's grace window (the brief buffer that lets a word fairly played at the
+// buzzer still land despite client/server clock skew).
+
+export function isTimedSessionExpired(
+  startedAt: Date,
+  limitSeconds: number,
+  graceSeconds: number,
+  now: Date,
+): boolean {
+  if (limitSeconds <= 0) return false;
+  const elapsed = Math.floor((now.getTime() - startedAt.getTime()) / 1000);
+  return elapsed > limitSeconds + graceSeconds;
+}
+
+// The honest finalize instant: started_at + limit, with no grace. Recording a
+// session as ending here (rather than at "now", which can be well past the
+// buzzer on a late /end or a delayed read) keeps the stored duration from
+// looking longer than the player was actually allowed.
+export function timedExpiryInstant(startedAt: Date, limitSeconds: number): Date {
+  return new Date(startedAt.getTime() + limitSeconds * 1000);
+}

--- a/server/services/zenLifecycle.characterization.test.ts
+++ b/server/services/zenLifecycle.characterization.test.ts
@@ -102,11 +102,10 @@ describe.runIf(dockerAvailable())('zen lifecycle (characterization, DB)', () => 
     expect(row.ended_by_player).toBe(true);
   });
 
-  // BUG DOCUMENTATION: two players with equal points but different word counts
-  // should share rank 1 (competition ranking). Today the zen leaderboard ranks
-  // by array index after a points-then-wordCount sort, so it splits them into
-  // ranks 1 and 2. PR-1 will change the expected ranks below to [1, 1].
-  it('CURRENT (buggy) ranking splits a tie into ranks 1 and 2', async () => {
+  // Two players with equal points but different word counts share rank 1
+  // (competition ranking), matching the daily/free-play leaderboards. The word
+  // count still orders the displayed list, but it does not split the rank.
+  it('shares rank 1 for tied points (competition ranking)', async () => {
     await zenRow(h, ['ABCDEF']); // one 6-letter word  → 5 points, 1 word
     await zenRow(h, ['ABC', 'DEF', 'GHI', 'JKL', 'MNO']); // five 3-letter words → 5 points, 5 words
 
@@ -114,8 +113,8 @@ describe.runIf(dockerAvailable())('zen lifecycle (characterization, DB)', () => 
     const points = lb.rankings.points;
 
     expect(points.map((p) => p.points)).toEqual([5, 5]);
-    expect(points.map((p) => p.rank)).toEqual([1, 2]); // <-- buggy: should become [1, 1]
-    // Current tiebreak sorts the higher word count first.
+    expect(points.map((p) => p.rank)).toEqual([1, 1]); // tie → shared rank
+    // The higher word count still sorts first for display order.
     expect(points[0].wordCount).toBe(5);
     expect(points[1].wordCount).toBe(1);
   });

--- a/server/services/zenLifecycle.characterization.test.ts
+++ b/server/services/zenLifecycle.characterization.test.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { scoreWord } from 'engine/scoring.js';
+import { dockerAvailable, startTestDb, type TestDb } from '../test/pgHarness.js';
+import { boardWithWords } from '../test/fixtures.js';
+import { getDailyZenConfig } from './dailyZenConfig.js';
+import {
+  endSession,
+  getZenLeaderboard,
+  startSession,
+  submitWord,
+} from './DailyZenService.js';
+
+const DATE = '2026-05-01';
+const config = getDailyZenConfig(DATE); // fixed: 5x5, minWordLength 4
+
+const DUMMY_BOARD = JSON.stringify(
+  Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => 'A')),
+);
+
+async function zenRow(h: TestDb, foundWords: string[]) {
+  await h.db
+    .insertInto('daily_zen_results')
+    .values({
+      user_id: randomUUID(),
+      date: DATE,
+      board: DUMMY_BOARD,
+      found_words: JSON.stringify(foundWords),
+      is_competitive: true,
+      ended_at: new Date(),
+    })
+    .execute();
+}
+
+// Characterization of the zen submit + finalize lifecycle and — importantly —
+// the CURRENT (buggy) leaderboard ranking, captured before the fix so PR-1
+// visibly flips the tie assertion from [1,2] to [1,1].
+describe.runIf(dockerAvailable())('zen lifecycle (characterization, DB)', () => {
+  let h: TestDb;
+  beforeAll(async () => {
+    h = await startTestDb();
+  }, 180_000);
+  afterAll(async () => {
+    await h?.stop();
+  });
+  beforeEach(async () => {
+    await h.truncateAll();
+  });
+
+  it('accepts a valid word and accrues gap-capped active time', async () => {
+    const { board, words } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startSession(h.db, userId, DATE, board, true);
+
+    // Backdate last activity by 10s so the gap credit is observable.
+    await h.db
+      .updateTable('daily_zen_results')
+      .set({ last_active_at: new Date(Date.now() - 10_000) })
+      .where('user_id', '=', userId)
+      .where('date', '=', DATE)
+      .execute();
+
+    const res = await submitWord(h.db, userId, DATE, words[0].path);
+    expect(res).toMatchObject({ valid: true, word: words[0].word, score: scoreWord(words[0].word) });
+
+    const row = await h.db
+      .selectFrom('daily_zen_results')
+      .select(['points', 'word_count', 'active_seconds'])
+      .where('user_id', '=', userId)
+      .where('date', '=', DATE)
+      .executeTakeFirstOrThrow();
+    expect(row.points).toBe(scoreWord(words[0].word));
+    expect(row.word_count).toBe(1);
+    expect(Number(row.active_seconds)).toBeGreaterThanOrEqual(9);
+    expect(Number(row.active_seconds)).toBeLessThanOrEqual(60); // ACTIVE_TIME_GAP_CAP_SECONDS
+  });
+
+  it('rejects a duplicate submission with reason "repeat"', async () => {
+    const { board, words } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startSession(h.db, userId, DATE, board, true);
+
+    await submitWord(h.db, userId, DATE, words[0].path);
+    const dup = await submitWord(h.db, userId, DATE, words[0].path);
+    expect(dup).toEqual({ valid: false, reason: 'repeat' });
+  });
+
+  it('endSession marks ended_by_player and stamps ended_at', async () => {
+    const { board } = boardWithWords(config.boardSize, config.minWordLength);
+    const userId = randomUUID();
+    await startSession(h.db, userId, DATE, board, true);
+
+    await endSession(h.db, userId, DATE);
+
+    const row = await h.db
+      .selectFrom('daily_zen_results')
+      .select(['ended_at', 'ended_by_player'])
+      .where('user_id', '=', userId)
+      .where('date', '=', DATE)
+      .executeTakeFirstOrThrow();
+    expect(row.ended_at).not.toBeNull();
+    expect(row.ended_by_player).toBe(true);
+  });
+
+  // BUG DOCUMENTATION: two players with equal points but different word counts
+  // should share rank 1 (competition ranking). Today the zen leaderboard ranks
+  // by array index after a points-then-wordCount sort, so it splits them into
+  // ranks 1 and 2. PR-1 will change the expected ranks below to [1, 1].
+  it('CURRENT (buggy) ranking splits a tie into ranks 1 and 2', async () => {
+    await zenRow(h, ['ABCDEF']); // one 6-letter word  → 5 points, 1 word
+    await zenRow(h, ['ABC', 'DEF', 'GHI', 'JKL', 'MNO']); // five 3-letter words → 5 points, 5 words
+
+    const lb = await getZenLeaderboard(h.db, DATE, undefined);
+    const points = lb.rankings.points;
+
+    expect(points.map((p) => p.points)).toEqual([5, 5]);
+    expect(points.map((p) => p.rank)).toEqual([1, 2]); // <-- buggy: should become [1, 1]
+    // Current tiebreak sorts the higher word count first.
+    expect(points[0].wordCount).toBe(5);
+    expect(points[1].wordCount).toBe(1);
+  });
+});

--- a/server/test/fixtures.ts
+++ b/server/test/fixtures.ts
@@ -1,0 +1,28 @@
+import { generateSeededBoard } from 'engine/board.js';
+import { findAllWords, type FoundWord } from 'engine/solver.js';
+import { dictionary } from '../services/dictionary.js';
+
+export interface BoardFixture {
+  board: string[][];
+  /** Real findable words with their adjacency paths, sorted by length asc. */
+  words: FoundWord[];
+}
+
+// Finds a deterministic seeded board that yields several real dictionary
+// words of at least two distinct lengths, so tests can submit genuine
+// engine-validated paths (and assert longest-word behavior) without
+// hand-crafting adjacency by hand.
+export function boardWithWords(size: number, minWordLength: number): BoardFixture {
+  for (let seed = 1; seed < 10_000; seed++) {
+    const board = generateSeededBoard(size, seed) as string[][];
+    const words = findAllWords(board, dictionary, minWordLength);
+    const distinctLengths = new Set(words.map((w) => w.word.length));
+    if (words.length >= 3 && distinctLengths.size >= 2) {
+      return {
+        board,
+        words: [...words].sort((a, b) => a.word.length - b.word.length),
+      };
+    }
+  }
+  throw new Error('boardWithWords: no suitable seeded board found');
+}

--- a/server/test/pgHarness.ts
+++ b/server/test/pgHarness.ts
@@ -1,0 +1,109 @@
+import { execSync } from 'child_process';
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Kysely, PostgresDialect } from 'kysely';
+import { Pool } from 'pg';
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import { resetDb } from '../db/index.js';
+import type { Database } from '../db/types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.join(__dirname, '../../supabase/migrations');
+
+// Supabase provisions these in prod; our plain-Postgres container does not.
+// The mode tables themselves are vanilla SQL, but service code reaches for
+// auth.users (display-name lookups) and migrations may reference Supabase
+// roles/helpers, so we stub the minimum surface to let the real migration
+// chain apply unchanged.
+const SUPABASE_BOOTSTRAP = `
+  create schema if not exists auth;
+  create table if not exists auth.users (
+    id uuid primary key,
+    raw_user_meta_data jsonb,
+    raw_app_meta_data jsonb
+  );
+  do $$ begin create role anon;          exception when duplicate_object then null; end $$;
+  do $$ begin create role authenticated; exception when duplicate_object then null; end $$;
+  do $$ begin create role service_role;  exception when duplicate_object then null; end $$;
+  create or replace function auth.uid() returns uuid language sql stable as $fn$ select null::uuid $fn$;
+`;
+
+const APP_TABLES = [
+  'daily_results',
+  'daily_zen_results',
+  'daily_gauntlet_results',
+  'free_play_sessions',
+  'feedback',
+] as const;
+
+export interface TestDb {
+  db: Kysely<Database>;
+  pool: Pool;
+  /** Wipe every app table between tests so cases stay independent. */
+  truncateAll: () => Promise<void>;
+  /** Tear down the Kysely pool and stop the container. */
+  stop: () => Promise<void>;
+}
+
+// Cheap synchronous probe so suites can `describe.runIf(dockerAvailable())`
+// and skip (rather than fail) on machines without a running Docker daemon.
+export function dockerAvailable(): boolean {
+  try {
+    execSync('docker info', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Boots a throwaway Postgres, applies the full migration chain in filename
+// order (which also exercises that the migrations still apply cleanly), and
+// binds the app's getDb() singleton to it via DATABASE_URL so service code
+// that uses the global pool hits the same database.
+export async function startTestDb(): Promise<TestDb> {
+  const container: StartedPostgreSqlContainer = await new PostgreSqlContainer(
+    'postgres:16-alpine',
+  ).start();
+
+  const connectionString = container.getConnectionUri();
+  process.env.DATABASE_URL = connectionString;
+
+  const pool = new Pool({ connectionString });
+  await pool.query(SUPABASE_BOOTSTRAP);
+
+  const migrations = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of migrations) {
+    const sqlText = readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8');
+    await pool.query(sqlText);
+  }
+
+  const db = new Kysely<Database>({
+    dialect: new PostgresDialect({ pool }),
+  });
+
+  return {
+    db,
+    pool,
+    async truncateAll() {
+      await pool.query(
+        `truncate ${APP_TABLES.map((t) => `public.${t}`).join(', ')} restart identity cascade;`,
+      );
+      await pool.query('truncate auth.users cascade;');
+    },
+    async stop() {
+      await db.destroy();
+      // Service code under test (e.g. display-name lookups) may have lazily
+      // opened the app-wide getDb() pool against this container. Close it too,
+      // before the container stops, so pg doesn't raise an uncaught
+      // "terminating connection" error that fails the run despite green tests.
+      await resetDb();
+      await container.stop();
+    },
+  };
+}


### PR DESCRIPTION
**What** — Removes the per-mode divergence behind the cross-mode tie bugs: moves the competition-rank helper to `models/` (now shared by daily, free-play, zen, and gauntlet — fixing zen's index-based ties and the gauntlet aggregate's rank-sum ties), extracts one `engine/validateSubmission` core that all five submit paths call, and shares the timed-session expiry math (closing a latent daily zero-guard drift).

**Why** — The four play modes were parallel forks of the same ranking/submit/finalize logic, so features like tie handling applied to some modes and silently not others; centralizing each rule at its proper layer makes those one-place edits that can't drift.

**Follow-ups** — Multiplayer keeps its own in-memory lifecycle and gauntlet keeps its rank-sum metric (both deliberate); finalize writes and the separate mode tables stay per-mode; broader deep-dive items (god files, engine file I/O, duplicate `GameConfig`) are out of scope.

**Testing** — Adds an ephemeral-Postgres characterization net (testcontainers) plus engine unit tests; full suite 122/0, engine+server+client `tsc` clean, and each behavior-preserving refactor is verified to pass against both the original and migrated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)