### PR TITLE
feat(results): capture per-word find times for game timelines

### DIFF
--- a/models/multiplayer.ts
+++ b/models/multiplayer.ts
@@ -40,6 +40,10 @@ export interface MultiplayerPlayer {
    *  starts so the lobby card numbers reflect the latest round, not a
    *  stale aggregate. */
   foundWords: string[];
+  /** Elapsed play time in seconds (from the board's start) at which each
+   *  word in `foundWords` was found — parallel array, index-aligned. Feeds
+   *  the results-page timeline; cleared alongside `foundWords` each board. */
+  foundWordTimes: number[];
   /** Whether the socket is currently connected. Disconnected players
    *  stay in the roster (key-based identity) so reconnects slot back in. */
   connected: boolean;

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -5,6 +5,7 @@ export interface DailyResultsTable {
   user_id: string;
   date: string;
   found_words: Generated<string>; // JSON string
+  word_times: string | null; // JSON string — per-word find offsets (seconds), parallel to found_words
   board: string; // JSON string
   completed_at: Generated<Date>;
   points: Generated<number>;
@@ -22,6 +23,7 @@ export interface DailyZenResultsTable {
   user_id: string;
   date: string;
   found_words: Generated<string>;
+  word_times: string | null; // JSON string — per-word find offsets (seconds), parallel to found_words
   board: string;
   started_at: Generated<Date>;
   last_active_at: Generated<Date>;
@@ -40,6 +42,7 @@ export interface FreePlaySessionsTable {
   user_id: string | null;
   date: string;
   found_words: Generated<string>;
+  word_times: string | null; // JSON string — per-word find offsets (seconds), parallel to found_words
   board: string;
   started_at: Generated<Date>;
   completed_at: Date | null;
@@ -70,6 +73,7 @@ export interface DailyGauntletResultsTable {
   board: string; // JSON string
   modifier: string; // JSON string
   found_words: Generated<string>; // JSON string
+  word_times: string | null; // JSON string — per-word find offsets (seconds), parallel to found_words
   points: Generated<number>;
   word_count: Generated<number>;
   longest_word: Generated<string>;
@@ -89,6 +93,7 @@ export interface ExperimentalResultsTable {
   board: string; // JSON string
   state: Generated<string>; // JSON string — mode-specific bookkeeping
   found_words: Generated<string>; // JSON string
+  word_times: string | null; // JSON string — per-word find offsets (seconds), parallel to found_words
   points: Generated<number>;
   word_count: Generated<number>;
   longest_word: Generated<string>;

--- a/server/multiplayer/store.ts
+++ b/server/multiplayer/store.ts
@@ -23,6 +23,7 @@ import type {
 } from 'models/multiplayer';
 import { dictionary } from '../services/dictionary.js';
 import { scoreResult } from '../services/DailyService.js';
+import { elapsedSeconds } from '../services/wordTiming.js';
 
 const ROOM_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no 0/1/I/O ambiguity
 const ROOM_CODE_LENGTH = 5;
@@ -157,6 +158,7 @@ export interface RoomBoardCompletion {
   participants: Array<{
     userId: string;
     foundWords: string[];
+    foundWordTimes: number[];
     points: number;
     wordCount: number;
     longestWord: string;
@@ -210,6 +212,7 @@ function buildCompletion(entry: RoomEntry, board: MultiplayerBoard): RoomBoardCo
     participants.push({
       userId,
       foundWords: [...player.foundWords],
+      foundWordTimes: [...player.foundWordTimes],
       points: player.points,
       wordCount: player.wordCount,
       longestWord: longestOf(player.foundWords),
@@ -429,6 +432,7 @@ export function joinRoom(
     points: 0,
     wordCount: 0,
     foundWords: [],
+    foundWordTimes: [],
     connected: true,
     left: false,
   };
@@ -626,6 +630,7 @@ export function startBoard(
     player.points = 0;
     player.wordCount = 0;
     player.foundWords = [];
+    player.foundWordTimes = [];
     player.status = player.connected ? 'playing' : 'lobby';
     if (player.status === 'playing') board.participantIds.push(player.id);
   }
@@ -922,6 +927,7 @@ export function submitWord(
   }
 
   player.foundWords.push(result.word);
+  player.foundWordTimes.push(elapsedSeconds(new Date(board.startedAt)));
   player.points = result.aggregate.points;
   player.wordCount = result.aggregate.wordCount;
   touch(entry);

--- a/server/services/DailyExperimentalService.ts
+++ b/server/services/DailyExperimentalService.ts
@@ -19,6 +19,7 @@ import { scoreResult } from './DailyService.js';
 import { getDisplayNames } from './displayNames.js';
 import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
 import { prepareExperimentalBoard } from './experimentalConfig.js';
+import { appendWordTimes, elapsedSeconds, parseWordTimes } from './wordTiming.js';
 
 // Same buzzer-grace window the timed daily uses — a word fairly played as the
 // clock hits zero can reach the server a few hundred ms late.
@@ -30,6 +31,7 @@ export interface ExperimentalSession {
   board: string[][];
   state: ExperimentalModeState;
   found_words: string[];
+  word_times: (number | null)[];
   started_at: Date;
   ended_at: Date | null;
   points: number;
@@ -103,6 +105,7 @@ function parseSession(row: {
   board: unknown;
   state: unknown;
   found_words: unknown;
+  word_times: unknown;
   started_at: Date;
   ended_at: Date | null;
   points: number;
@@ -118,6 +121,7 @@ function parseSession(row: {
     board: parseJson<string[][]>(row.board, []),
     state: parseJson<ExperimentalModeState>(row.state, {}),
     found_words: parseJson<string[]>(row.found_words, []),
+    word_times: parseWordTimes(row.word_times),
     started_at: row.started_at,
     ended_at: row.ended_at,
     points: row.points,
@@ -161,6 +165,7 @@ export async function getExperimentalSession(
       'board',
       'state',
       'found_words',
+      'word_times',
       'started_at',
       'ended_at',
       'points',
@@ -335,10 +340,18 @@ export async function submitExperimentalWord(
 
   if (!branch.valid) return { valid: false, reason: branch.reason };
 
+  const wordTimes = appendWordTimes(
+    session.word_times,
+    session.found_words.length,
+    branch.nextWords.length - session.found_words.length,
+    elapsedSeconds(session.started_at),
+  );
+
   await db
     .updateTable('experimental_results')
     .set({
       found_words: JSON.stringify(branch.nextWords),
+      word_times: JSON.stringify(wordTimes),
       points: branch.aggregates.points,
       word_count: branch.aggregates.wordCount,
       longest_word: branch.aggregates.longestWord,

--- a/server/services/DailyGauntletService.ts
+++ b/server/services/DailyGauntletService.ts
@@ -21,6 +21,7 @@ import {
   getDailyGauntletNumber,
   prepareGauntletRound,
 } from './dailyGauntletConfig.js';
+import { appendWordTimes, elapsedSeconds, parseWordTimes } from './wordTiming.js';
 
 // Same grace window as timed daily — a few hundred ms of client/server
 // clock drift shouldn't reject the last fairly-played word.
@@ -38,6 +39,7 @@ export interface GauntletRoundSession {
     minWordLength: number;
   };
   foundWords: string[];
+  wordTimes: (number | null)[];
   points: number;
   wordCount: number;
   longestWord: string;
@@ -89,6 +91,7 @@ function parseSessionRow(row: {
   board: unknown;
   modifier: unknown;
   found_words: unknown;
+  word_times: unknown;
   points: number;
   word_count: number;
   longest_word: string;
@@ -118,6 +121,7 @@ function parseSessionRow(row: {
       minWordLength: row.min_word_length,
     },
     foundWords,
+    wordTimes: parseWordTimes(row.word_times),
     points: row.points,
     wordCount: row.word_count,
     longestWord: row.longest_word,
@@ -178,6 +182,7 @@ export async function getGauntletRoundSession(
       'board',
       'modifier',
       'found_words',
+      'word_times',
       'points',
       'word_count',
       'longest_word',
@@ -213,6 +218,7 @@ async function getRoundsForUser(
       'board',
       'modifier',
       'found_words',
+      'word_times',
       'points',
       'word_count',
       'longest_word',
@@ -316,10 +322,18 @@ export async function submitGauntletWord(
   });
   if (!result.valid) return { valid: false, reason: result.reason };
 
+  const wordTimes = appendWordTimes(
+    session.wordTimes,
+    session.foundWords.length,
+    result.nextWords.length - session.foundWords.length,
+    elapsedSeconds(session.startedAt),
+  );
+
   await db
     .updateTable('daily_gauntlet_results')
     .set({
       found_words: JSON.stringify(result.nextWords),
+      word_times: JSON.stringify(wordTimes),
       points: result.aggregate.points,
       word_count: result.aggregate.wordCount,
       longest_word: result.aggregate.longestWord,

--- a/server/services/DailyService.ts
+++ b/server/services/DailyService.ts
@@ -6,6 +6,7 @@ import type { Database } from '../db/types.js';
 import { dictionary } from './dictionary.js';
 import { getDailyConfig, type DailyConfig } from './dailyConfig.js';
 import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
+import { appendWordTimes, elapsedSeconds, parseWordTimes } from './wordTiming.js';
 
 export interface ScoredResult {
   points: number;
@@ -459,6 +460,7 @@ export interface TimedDailySession {
   date: string;
   board: string[][];
   found_words: string[];
+  word_times: (number | null)[];
   started_at: Date;
   ended_at: Date | null;
   points: number;
@@ -482,6 +484,7 @@ function parseTimedSession(row: {
   date: string;
   board: unknown;
   found_words: unknown;
+  word_times: unknown;
   started_at: Date;
   ended_at: Date | null;
   points: number;
@@ -497,6 +500,7 @@ function parseTimedSession(row: {
     date: row.date,
     board,
     found_words: foundWords,
+    word_times: parseWordTimes(row.word_times),
     started_at: row.started_at,
     ended_at: row.ended_at,
     points: row.points,
@@ -551,6 +555,7 @@ export async function getTimedDailySession(
       'date',
       'board',
       'found_words',
+      'word_times',
       'started_at',
       'ended_at',
       'points',
@@ -619,10 +624,18 @@ export async function submitTimedDailyWord(
   });
   if (!result.valid) return { valid: false, reason: result.reason };
 
+  const wordTimes = appendWordTimes(
+    session.word_times,
+    session.found_words.length,
+    result.nextWords.length - session.found_words.length,
+    elapsedSeconds(session.started_at),
+  );
+
   await db
     .updateTable('daily_results')
     .set({
       found_words: JSON.stringify(result.nextWords),
+      word_times: JSON.stringify(wordTimes),
       points: result.aggregate.points,
       word_count: result.aggregate.wordCount,
       longest_word: result.aggregate.longestWord,

--- a/server/services/DailyZenService.ts
+++ b/server/services/DailyZenService.ts
@@ -18,11 +18,13 @@ import {
   getDailyZenConfig,
   getDailyZenNumber,
 } from './dailyZenConfig.js';
+import { appendWordTimes, elapsedSeconds, parseWordTimes } from './wordTiming.js';
 
 export interface ZenSession {
   date: string;
   board: string[][];
   found_words: string[];
+  word_times: (number | null)[];
   started_at: Date;
   last_active_at: Date;
   ended_at: Date | null;
@@ -51,6 +53,7 @@ export type SubmitOutcome =
 function parseSession(row: {
   date: string;
   found_words: unknown;
+  word_times: unknown;
   board: unknown;
   started_at: Date;
   last_active_at: Date;
@@ -71,6 +74,7 @@ function parseSession(row: {
     date: row.date,
     board,
     found_words: foundWords,
+    word_times: parseWordTimes(row.word_times),
     started_at: row.started_at,
     last_active_at: row.last_active_at,
     ended_at: row.ended_at,
@@ -173,10 +177,18 @@ export async function submitWord(
   );
   const creditSec = Math.min(gapSec, ACTIVE_TIME_GAP_CAP_SECONDS);
 
+  const wordTimes = appendWordTimes(
+    session.word_times,
+    session.found_words.length,
+    result.nextWords.length - session.found_words.length,
+    elapsedSeconds(session.started_at, now),
+  );
+
   await db
     .updateTable('daily_zen_results')
     .set({
       found_words: JSON.stringify(result.nextWords),
+      word_times: JSON.stringify(wordTimes),
       last_active_at: now,
       points: result.aggregate.points,
       word_count: result.aggregate.wordCount,

--- a/server/services/FreePlayService.roomHistory.test.ts
+++ b/server/services/FreePlayService.roomHistory.test.ts
@@ -48,6 +48,7 @@ function completion(
     participants: userIds.map((userId) => ({
       userId,
       foundWords: ['CAB'],
+      foundWordTimes: [5],
       points: 1,
       wordCount: 1,
       longestWord: 'CAB',
@@ -95,9 +96,9 @@ describe('persistRoomBoardResults', () => {
       endedAt: 61_000,
       hostUserId: 'user-1',
       participants: [
-        { userId: 'user-1', foundWords: ['CA'], points: 2, wordCount: 1, longestWord: 'CA' },
-        { userId: 'user-1', foundWords: ['CAB', 'DAB'], points: 5, wordCount: 2, longestWord: 'CAB' },
-        { userId: 'user-2', foundWords: ['DAB'], points: 3, wordCount: 1, longestWord: 'DAB' },
+        { userId: 'user-1', foundWords: ['CA'], foundWordTimes: [3], points: 2, wordCount: 1, longestWord: 'CA' },
+        { userId: 'user-1', foundWords: ['CAB', 'DAB'], foundWordTimes: [4, 9], points: 5, wordCount: 2, longestWord: 'CAB' },
+        { userId: 'user-2', foundWords: ['DAB'], foundWordTimes: [7], points: 3, wordCount: 1, longestWord: 'DAB' },
       ],
     });
 

--- a/server/services/FreePlayService.ts
+++ b/server/services/FreePlayService.ts
@@ -12,6 +12,7 @@ import { dictionary } from './dictionary.js';
 import { getDailyDatePST } from './dailyConfig.js';
 import { scoreResult } from './DailyService.js';
 import { isTimedSessionExpired, timedExpiryInstant } from './sessionTiming.js';
+import { appendWordTimes, elapsedSeconds, parseWordTimes } from './wordTiming.js';
 
 // Counts challenge participants whose completions are unseen by the
 // originator. A row counts as "unseen" when it isn't the originator's
@@ -69,6 +70,7 @@ export interface FreePlaySession {
   id: string;
   board: string[][];
   found_words: string[];
+  word_times: (number | null)[];
   started_at: Date;
   completed_at: Date | null;
   points: number;
@@ -95,6 +97,7 @@ function parseFreePlaySession(row: {
   id: string;
   board: unknown;
   found_words: unknown;
+  word_times: unknown;
   started_at: Date;
   completed_at: Date | null;
   points: number;
@@ -114,6 +117,7 @@ function parseFreePlaySession(row: {
     id: row.id,
     board,
     found_words: foundWords,
+    word_times: parseWordTimes(row.word_times),
     started_at: row.started_at,
     completed_at: row.completed_at,
     points: row.points,
@@ -148,6 +152,7 @@ const SESSION_COLUMNS = [
   'id',
   'board',
   'found_words',
+  'word_times',
   'started_at',
   'completed_at',
   'points',
@@ -326,10 +331,18 @@ export async function submitFreePlayWord(
     });
     if (!result.valid) return { valid: false, reason: result.reason };
 
+    const wordTimes = appendWordTimes(
+      session.word_times,
+      session.found_words.length,
+      result.nextWords.length - session.found_words.length,
+      elapsedSeconds(session.started_at),
+    );
+
     const updated = await trx
       .updateTable('free_play_sessions')
       .set({
         found_words: JSON.stringify(result.nextWords),
+        word_times: JSON.stringify(wordTimes),
         points: result.aggregate.points,
         word_count: result.aggregate.wordCount,
         longest_word: result.aggregate.longestWord,
@@ -515,6 +528,7 @@ export async function persistRoomBoardResults(
         date,
         board: boardJson,
         found_words: JSON.stringify(p.foundWords),
+        word_times: JSON.stringify(p.foundWordTimes),
         started_at: startedAt,
         completed_at: completedAt,
         points: p.points,

--- a/server/services/wordTiming.test.ts
+++ b/server/services/wordTiming.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { appendWordTimes, elapsedSeconds, parseWordTimes } from './wordTiming.js';
+
+const start = new Date('2026-06-15T12:00:00.000Z');
+const at = (secondsAfterStart: number) =>
+  new Date(start.getTime() + secondsAfterStart * 1000);
+
+describe('elapsedSeconds', () => {
+  it('measures whole seconds from start', () => {
+    expect(elapsedSeconds(start, at(42))).toBe(42);
+  });
+
+  it('rounds to 0.1s', () => {
+    expect(elapsedSeconds(start, new Date(start.getTime() + 12_340))).toBe(12.3);
+  });
+
+  it('floors at zero when the clock reads before start', () => {
+    expect(elapsedSeconds(start, at(-5))).toBe(0);
+  });
+});
+
+describe('parseWordTimes', () => {
+  it('passes a parsed array through (jsonb driver shape)', () => {
+    expect(parseWordTimes([1, 2, null])).toEqual([1, 2, null]);
+  });
+
+  it('parses a JSON string (raw column shape)', () => {
+    expect(parseWordTimes('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  it('reads null / malformed / non-array as empty', () => {
+    expect(parseWordTimes(null)).toEqual([]);
+    expect(parseWordTimes('not json')).toEqual([]);
+    expect(parseWordTimes('{}')).toEqual([]);
+  });
+});
+
+describe('appendWordTimes', () => {
+  it('appends one offset per found word', () => {
+    expect(appendWordTimes([1, 2], 2, 1, 3)).toEqual([1, 2, 3]);
+  });
+
+  it('appends several offsets at once (Golden Ticket multi-word submit)', () => {
+    expect(appendWordTimes([1], 1, 3, 9)).toEqual([1, 9, 9, 9]);
+  });
+
+  it('pads a legacy row (no prior timing) with null so indexes stay aligned', () => {
+    // found_words already had 2 words but word_times was empty (row predates
+    // the column); the new word must land at index 2, not index 0.
+    expect(appendWordTimes([], 2, 1, 7)).toEqual([null, null, 7]);
+  });
+
+  it('trims any overshoot beyond the prior word count before appending', () => {
+    expect(appendWordTimes([1, 2, 3], 2, 1, 5)).toEqual([1, 2, 5]);
+  });
+});

--- a/server/services/wordTiming.ts
+++ b/server/services/wordTiming.ts
@@ -1,0 +1,54 @@
+// Per-word find-time capture for game timelines.
+//
+// Every results table carries a `word_times` JSON array parallel to its
+// `found_words`: word_times[i] is the elapsed play time in seconds (measured
+// from the session's started_at) at which found_words[i] was found. A null
+// entry means the time is unknown — a word recorded before timing capture
+// existed, or one appended to a legacy in-progress row.
+//
+// This lives in one place because every mode's submit path repeats the same
+// read-pad-append shape. Keeping it a single seam is what guarantees the
+// alignment invariant — word_times.length === found_words.length — can't
+// drift independently per mode.
+
+// Elapsed seconds from session start to `now`, floored at zero and rounded to
+// 0.1s: fine enough to cluster finds on a timeline, coarse enough to keep the
+// stored array compact.
+export function elapsedSeconds(startedAt: Date, now: Date = new Date()): number {
+  const raw = (now.getTime() - startedAt.getTime()) / 1000;
+  return Math.max(0, Math.round(raw * 10) / 10);
+}
+
+// jsonb columns come back parsed (an array) from the driver, but the same rows
+// can also surface as a JSON string depending on the query path — mirror how
+// found_words is parsed and accept both. Anything unrecognized reads as empty.
+export function parseWordTimes(raw: unknown): (number | null)[] {
+  if (Array.isArray(raw)) return raw as (number | null)[];
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+// Appends one offset per newly-found word while keeping the array index-aligned
+// with found_words. `priorWordCount` is found_words.length *before* this
+// submission; any shortfall (a row whose word list predates this column) is
+// padded with null so index i always refers to word i. `addedCount` is usually
+// 1, but a single Golden Ticket submission can resolve several words at once,
+// all sharing the same offset.
+export function appendWordTimes(
+  priorTimes: (number | null)[],
+  priorWordCount: number,
+  addedCount: number,
+  offsetSeconds: number,
+): (number | null)[] {
+  const times = priorTimes.slice(0, priorWordCount);
+  while (times.length < priorWordCount) times.push(null);
+  for (let i = 0; i < addedCount; i++) times.push(offsetSeconds);
+  return times;
+}

--- a/supabase/migrations/20260714000000_word_times.sql
+++ b/supabase/migrations/20260714000000_word_times.sql
@@ -1,0 +1,17 @@
+-- Per-word find-time capture for game timelines.
+--
+-- Adds a `word_times` array parallel to each mode's `found_words`:
+-- word_times[i] is the elapsed play time in seconds (from started_at) at which
+-- found_words[i] was found. Nullable with no default, so every row written
+-- before this column — including sessions in progress at migration time — reads
+-- as "no timing". The submit path pads any such gap with nulls as new words
+-- land, keeping the two arrays index-aligned.
+--
+-- These tables already have RLS enabled with their access policies defined at
+-- creation; adding a column inherits those policies and needs no new grant.
+
+alter table public.daily_results add column word_times jsonb;
+alter table public.daily_zen_results add column word_times jsonb;
+alter table public.free_play_sessions add column word_times jsonb;
+alter table public.daily_gauntlet_results add column word_times jsonb;
+alter table public.experimental_results add column word_times jsonb;


### PR DESCRIPTION
## What
Phase 1 of the results-page timeline feature: **server-stamped per-word find times**, persisted but not yet surfaced in any UI. Every mode gains a `word_times` array parallel to `found_words` — `word_times[i]` is the elapsed play seconds (from `started_at`) at which `found_words[i]` was found.

## Why this approach
- **Server-stamped, not client-stamped.** The client already computes a `submittedAt` per word but it's spoofable and subject to clock skew. Each mode's submit path already knows the session's `started_at`, so we stamp `elapsed = now − started_at` on the server — trustworthy, and consistent with the rest of session timing.
- **Parallel array, not a new table.** `word_times` mirrors the existing "rewrite the whole `found_words` array on submit" pattern, is nullable (old rows and in-progress sessions degrade gracefully), and needs no backfill. A normalized per-word table would add write complexity to a hot path for no benefit here.
- **One shared seam.** All five modes repeat the same read-pad-append shape, so `server/services/wordTiming.ts` owns it. That's what guarantees the alignment invariant — `word_times.length === found_words.length` — can't drift per mode. Legacy rows (word list predating the column) are padded with `null` so index `i` always refers to word `i`.
- **Multiplayer.** Room boards persist to `free_play_sessions`, so writing `word_times` there covers multiplayer's history/replay timeline for free. Find times also ride the live room state (`MultiplayerPlayer.foundWordTimes`) to feed the socket-driven post-game results screen in Phase 2.
- **Ships invisibly.** No UI, so it's low-risk and starts accruing real timeline data immediately — by the time the view lands there's history to render.

## Verification
- `tsc` clean across models / server / client.
- Deploy-gating unit suite: 105 passed. New `wordTiming.test.ts` covers offset rounding, jsonb/string parsing, multi-word (Golden Ticket) appends, and legacy-row null-padding.
- Docker-backed integration suite (real migration chain + submit→persist against ephemeral Postgres): 17 passed.

## Follow-ups
- **Phase 2** — the carousel timeline view in the shared `ResultsView` (extend `ScoredWord` with the time, surface it through the results payloads, build the paged panel). All 7 result surfaces light up at once since they share the component.
- **Phase 3** — cross-player timeline comparison and a missed-word board heatmap as additional panels.
- Anonymous multiplayer participants still don't persist (unchanged) — their timelines are live-only.
- Zen/free-play offsets are raw wall-elapsed-from-start; long idle gaps (e.g. a Zen resume hours later) will show as empty stretches. Phase 2 decides how to render/compress those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)